### PR TITLE
Fixes bug #1097 reported by and with suggestion from d00p

### DIFF
--- a/lib/functions/database/function.correctMysqlUsers.php
+++ b/lib/functions/database/function.correctMysqlUsers.php
@@ -24,7 +24,7 @@ function correctMysqlUsers($mysql_access_host_array)
 	foreach($sql_root as $mysql_server => $mysql_server_details)
 	{
 		$db_root = new db($mysql_server_details['host'], $mysql_server_details['user'], $mysql_server_details['password'], '');
-		unset($db_root->password);
+		unset($mysql_server_details['password']);
 
 		$users = array();
 		$users_result = $db_root->query('SELECT * FROM `mysql`.`user`');


### PR DESCRIPTION
Fixes the following error:
Fatal error: Cannot access private property db::$password in
/var/www/froxlor/lib/functions/database/function.correctMysqlUsers.php
on line 27

Bug ID on Redmine: #1097 2012-05-30
