### PR TITLE
Fix 'task id 9' issue.

### DIFF
--- a/admin_settings.php
+++ b/admin_settings.php
@@ -83,7 +83,6 @@ if(($page == 'settings' || $page == 'overview')
 			$log->logAction(ADM_ACTION, LOG_INFO, "rebuild configfiles due to changed setting");
 			inserttask('1');
 			inserttask('5');
-			inserttask('9');
 
 			# Using nameserver, insert a task which rebuilds the server config
 			if ($settings['system']['bind_enable'])
@@ -129,7 +128,6 @@ elseif($page == 'rebuildconfigs'
 		$log->logAction(ADM_ACTION, LOG_INFO, "rebuild configfiles");
 		inserttask('1');
 		inserttask('5');
-		inserttask('9');
 		inserttask('10');
 
 		# Using nameserver, insert a task which rebuilds the server config

--- a/lib/functions/froxlor/function.CronjobFunctions.php
+++ b/lib/functions/froxlor/function.CronjobFunctions.php
@@ -216,6 +216,11 @@ function getOutstandingTasks()
 		{
 			$task_desc = $lng['tasks']['diskspace_set_quota'];
 		}
+		else
+		{
+			$task_desc = "ERROR: Unknown task type '".$row['type'].
+			             "'";
+		}
 
 		if($task_desc != '') {
 			$tasks .= '<li>'.$task_desc.'</li>';

--- a/lib/functions/froxlor/function.inserttask.php
+++ b/lib/functions/froxlor/function.inserttask.php
@@ -35,7 +35,6 @@ function inserttask($type, $param1 = '', $param2 = '', $param3 = '', $param4 = '
 	   || $type == '3'
 	   || $type == '4'
 	   || $type == '5'
-	   || $type == '9'
 	   || $type == '10')
 	{
 		$db->query('DELETE FROM `' . TABLE_PANEL_TASKS . '` WHERE `type`="' . $type . '"');


### PR DESCRIPTION
Adds a message on Admin's Overview page if a task is of an unknown type.
Removes task '9' adding on function.inserttask and ignores task id 9 on
CronJobFunctions.
