### PR TITLE
Improve user/group name handling on configuration script generation.

### DIFF
--- a/lib/configfiles/gentoo.inc.php
+++ b/lib/configfiles/gentoo.inc.php
@@ -17,6 +17,23 @@
  *
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="mail"; // Gentoo uses 'mail' user/group
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="mail"; // Gentoo uses 'mail' user/group
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'gentoo' => Array(
 		'label' => 'Gentoo',
@@ -126,7 +143,7 @@ return Array(
 							'echo "mail-mta/postfix -dovecot-sasl sasl" >> /etc/portage/package.use',
 							'emerge -av postfix',            
 							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_user['name'].':'.$vmail_group['name'].' ' . $settings['system']['vmail_homedir'],
 							'chmod 0750 ' . $settings['system']['vmail_homedir'],
 							'mv /etc/postfix/main.cf /etc/postfix/main.cf.gentoo',
 							'touch /etc/postfix/main.cf',
@@ -169,7 +186,7 @@ return Array(
 							'echo "mail-mta/postfix dovecot-sasl -sasl" >> /etc/portage/package.use',
               				'emerge -av postfix',
 							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_user['name'].':'.$vmail_group['name'].' ' . $settings['system']['vmail_homedir'],
 							'chmod 0750 ' . $settings['system']['vmail_homedir'],
 							'mv /etc/postfix/main.cf /etc/postfix/main.cf.gentoo',
 							'touch /etc/postfix/main.cf',

--- a/lib/configfiles/hardy.inc.php
+++ b/lib/configfiles/hardy.inc.php
@@ -17,6 +17,23 @@
  *
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'ubuntu_hardy' => Array(
 		'label' => 'Ubuntu 8.04 (Hardy)',
@@ -127,13 +144,13 @@ return Array(
 					'postfix_courier' => Array(
 						'label' => 'Postfix/Courier',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql libsasl2-2 libsasl2-modules libsasl2-modules-sql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',
@@ -188,13 +205,13 @@ return Array(
 					'postfix_dovecot' => Array(
 						'label' => 'Postfix/Dovecot',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',

--- a/lib/configfiles/lenny.inc.php
+++ b/lib/configfiles/lenny.inc.php
@@ -17,6 +17,23 @@
  *
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'debian_lenny' => Array(
 		'label' => 'Debian 5.0 (Lenny)',
@@ -128,13 +145,13 @@ return Array(
 					'postfix_courier' => Array(
 						'label' => 'Postfix/Courier',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql libsasl2-2 libsasl2-modules libsasl2-modules-sql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',
@@ -189,13 +206,13 @@ return Array(
 					'postfix_dovecot' => Array(
 						'label' => 'Postfix/Dovecot',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',

--- a/lib/configfiles/lucid.inc.php
+++ b/lib/configfiles/lucid.inc.php
@@ -17,6 +17,23 @@
  * 
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'ubuntu_lucid' => Array(
 		'label' => 'Ubuntu 10.04 (Lucid)',
@@ -128,13 +145,13 @@ return Array(
 					'postfix_courier' => Array(
 						'label' => 'Postfix/Courier',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql libsasl2-2 libsasl2-modules libsasl2-modules-sql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',
@@ -189,13 +206,13 @@ return Array(
 					'postfix_dovecot' => Array(
 						'label' => 'Postfix/Dovecot',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',

--- a/lib/configfiles/precise.inc.php
+++ b/lib/configfiles/precise.inc.php
@@ -17,6 +17,23 @@
  * 
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'ubuntu_precise' => Array(
 		'label' => 'Ubuntu 12.04 (Precise)',
@@ -128,13 +145,13 @@ return Array(
 					'postfix_courier' => Array(
 						'label' => 'Postfix/Courier',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql libsasl2-2 libsasl2-modules libsasl2-modules-sql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',
@@ -189,13 +206,13 @@ return Array(
 					'postfix_dovecot' => Array(
 						'label' => 'Postfix/Dovecot',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',

--- a/lib/configfiles/sle10.inc.php
+++ b/lib/configfiles/sle10.inc.php
@@ -17,6 +17,23 @@
  *
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'sle_10' => Array(
 		'label' => 'SUSE Linux Enterprise 10',
@@ -71,11 +88,11 @@ return Array(
 							'usr_lib_sasl2_smtpd.conf' => '/usr/lib/sasl2/smtpd.conf'
 						),
 						'commands' => Array(
-							'mkdir -p /var/spool/postfix/etc/pam.d',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
 							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
+							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',

--- a/lib/configfiles/squeeze.inc.php
+++ b/lib/configfiles/squeeze.inc.php
@@ -17,6 +17,23 @@
  *
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'debian_squeeze' => Array(
 		'label' => 'Debian 6.0 (Squeeze)',
@@ -128,13 +145,13 @@ return Array(
 					'postfix_courier' => Array(
 						'label' => 'Postfix/Courier',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' '.$vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql libsasl2-2 libsasl2-modules libsasl2-modules-sql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',
@@ -189,13 +206,13 @@ return Array(
 					'postfix_dovecot' => Array(
 						'label' => 'Postfix/Dovecot',
 						'commands' => Array(
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
+							'mkdir -p ' . $settings['system']['vmail_homedir'],
+							'chown -R ' . $vmail_username . ':' . $vmail_groupname . ' ' . $settings['system']['vmail_homedir'],
 							'apt-get install postfix postfix-mysql',
 							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'mkdir -p /var/spool/postfix/var/run/mysqld',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
-							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',

--- a/lib/configfiles/suse11.inc.php
+++ b/lib/configfiles/suse11.inc.php
@@ -17,6 +17,23 @@
  * 
  */
 
+// Try to guess user/group from settings' email UID/GID
+$vmail_user=posix_getpwuid($settings['system']['vmail_uid']);
+$vmail_group=posix_getgrgid($settings['system']['vmail_gid']);
+
+/* If one of them are not set, call it 'vmail' and suggest creating user/group
+ * in scripts. */
+if ($vmail_user === false) {
+	$vmail_username="vmail";
+} else {
+	$vmail_username=$vmail_user['name'];
+}
+if ($vmail_group === false) {
+	$vmail_groupname="vmail";
+} else {
+	$vmail_groupname=$vmail_group['name'];
+}
+
 return Array(
 	'opensuse_11_x' => Array(
 		'label' => 'openSUSE 11.x',
@@ -68,11 +85,11 @@ return Array(
 							'etc_sasl2_smtpd.conf' => '/etc/sasl2/smtpd.conf'
 						),
 						'commands' => Array(
-							'mkdir -p /var/spool/postfix/etc/pam.d',
-							'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-							'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
+							($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+							($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
 							'mkdir -p ' . $settings['system']['vmail_homedir'],
-							'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
+							'chown -R ' . $vmail_username . ':' . $vmail_groupname . ' ' . $settings['system']['vmail_homedir'],
+							'mkdir -p /var/spool/postfix/etc/pam.d',
 							'touch /etc/postfix/mysql-virtual_alias_maps.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
 							'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',
@@ -106,13 +123,13 @@ return Array(
 					'postfix_dovecot' => Array(
                                                 'label' => 'Postfix/Dovecot',
                                                 'commands' => Array(
+                                                        ($vmail_group === false) ? 'groupadd -g ' . $settings['system']['vmail_gid'] . ' ' . $vmail_groupname : '',
+                                                        ($vmail_user === false) ? 'useradd -u ' . $settings['system']['vmail_uid'] . ' -g ' . $vmail_groupname . ' ' . $vmail_username : '',
                                                         'zypper install postfix postfix-mysql',
                                                         'mkdir -p /var/spool/postfix/etc/pam.d',
                                                         'mkdir -p /var/spool/postfix/var/run/mysqld',
-                                                        'groupadd -g ' . $settings['system']['vmail_gid'] . ' vmail',
-                                                        'useradd -u ' . $settings['system']['vmail_uid'] . ' -g vmail vmail',
                                                         'mkdir -p ' . $settings['system']['vmail_homedir'],
-                                                        'chown -R vmail:vmail ' . $settings['system']['vmail_homedir'],
+                                                        'chown -R '.$vmail_username.':'.$vmail_groupname.' ' . $settings['system']['vmail_homedir'],
                                                         'touch /etc/postfix/mysql-virtual_alias_maps.cf',
                                                         'touch /etc/postfix/mysql-virtual_mailbox_domains.cf',
                                                         'touch /etc/postfix/mysql-virtual_mailbox_maps.cf',


### PR DESCRIPTION
Hello,

  Here's another colaboration to improve Froxlor. I hope it's alright. In general this makes so configuration scripts point to the correct UID/GID if it does exist, or to 'vmail' (or just 'mail' on gentoo) if the email uid/gid is not present on system yet (normally on new installations).

Side note:
  I'm still working on the email paths issue. I've stumbled upon a problem that upon generating the account, PHPMailer fails sending email. I still don't know the cause. It's the only detail to have it done and ready to build up a pull request.

Best regards!
