### PR TITLE
Fix bug IMAP/POP3 after reactivating a customer

### DIFF
--- a/admin_customers.php
+++ b/admin_customers.php
@@ -1238,7 +1238,7 @@ if($page == 'customers'
 
 					if($deactivated != $result['deactivated'])
 					{
-						$db->query("UPDATE `" . TABLE_MAIL_USERS . "` SET `postfix`='" . (($deactivated) ? 'N' : 'Y') . "', `pop3`='" . (($deactivated) ? '0' : '1') . "', `imap`='" . (($deactivated) ? '0' : '1') . "' WHERE `customerid`='" . (int)$id . "'");
+						$db->query("UPDATE `" . TABLE_MAIL_USERS . "` SET `postfix`='" . (($deactivated) ? 'N' : 'Y') . "', `pop3`='" . (($deactivated) ? '0' : (int)$result['pop3']) . "', `imap`='" . (($deactivated) ? '0' : (int)$result['imap']) . "' WHERE `customerid`='" . (int)$id . "'");
 						$db->query("UPDATE `" . TABLE_FTP_USERS . "` SET `login_enabled`='" . (($deactivated) ? 'N' : 'Y') . "' WHERE `customerid`='" . (int)$id . "'");
 						$db->query("UPDATE `" . TABLE_PANEL_DOMAINS . "` SET `deactivated`='" . (int)$deactivated . "' WHERE `customerid`='" . (int)$id . "'");
 


### PR DESCRIPTION
Values for IMAP/POP3 were always set to 1. Instead the predefined values of this customer should be recovered
