### PR TITLE
fix virtual transport in postfix

### DIFF
--- a/templates/misc/configfiles/ubuntu_precise/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/ubuntu_precise/postfix_dovecot/etc_postfix_main.cf
@@ -45,7 +45,6 @@ smtpd_sasl_local_domain = $myhostname
 broken_sasl_auth_clients = yes
 ## Dovecot Settings for deliver, SASL Auth and virtual transport
 smtpd_sasl_type = dovecot
-virtual_transport = lmtp:unix:private/dovecot-lmtp
 dovecot_destination_recipient_limit = 1
 smtpd_sasl_path = private/dovecot-auth
 


### PR DESCRIPTION
with the former setting, remote mail isn't delivered to local mailboxes. setting virtual transport to "virtual" (which is the default) is better...
