### PR TITLE
Fix for cron_tasks.inc.http.10.apache.php on 1315

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -1312,17 +1312,21 @@ class apache
 			$configdir = $this->settings['phpfpm']['configdir'];
 			$phpfpm_file_dirhandle = opendir($this->settings['phpfpm']['configdir']);
 
-			while(false !== ($phpfpm_filename = readdir($phpfpm_file_dirhandle)))
-			{
-				if($phpfpm_filename != '.'
-					&& $phpfpm_filename != '..'
-					&& !in_array($phpfpm_filename, $known_phpfpm_files)
-					&& file_exists(makeCorrectFile($this->settings['phpfpm']['configdir'] . '/' . $phpfpm_filename)))
-					{
-						fwrite($this->debugHandler, '  apache::wipeOutOldVhostConfigs: unlinking PHP5-FPM ' . $phpfpm_filename . "\n");
-						$this->logger->logAction(CRON_ACTION, LOG_NOTICE, 'unlinking ' . $phpfpm_filename);
-						unlink(makeCorrectFile($this->settings['phpfpm']['configdir'] . '/' . $phpfpm_filename));
-					}
+			if ($phpfpm_file_dirhandle !== false) {
+				while(false !== ($phpfpm_filename = readdir($phpfpm_file_dirhandle)))
+				{
+					if($phpfpm_filename != '.'
+						&& $phpfpm_filename != '..'
+						&& !in_array($phpfpm_filename, $known_phpfpm_files)
+						&& file_exists(makeCorrectFile($this->settings['phpfpm']['configdir'] . '/' . $phpfpm_filename)))
+						{
+							fwrite($this->debugHandler, '  apache::wipeOutOldVhostConfigs: unlinking PHP5-FPM ' . $phpfpm_filename . "\n");
+							$this->logger->logAction(CRON_ACTION, LOG_NOTICE, 'unlinking ' . $phpfpm_filename);
+							unlink(makeCorrectFile($this->settings['phpfpm']['configdir'] . '/' . $phpfpm_filename));
+						}
+				}
+			} else {
+				$this->logger->logAction(CRON_ACTION, LOG_WARNING, "WARNING!! PHP-FPM configuration path could not be read (".$this->settings['phpfpm']['configdir'].")");
 			}
 		}
 	}


### PR DESCRIPTION
Error should have been fixed in #24 but the following error still occured if $this->settings['phpfpm']['configdir'] is not available:

```
PHP Warning:  readdir() expects parameter 1 to be resource, boolean given in /var/www/froxlor/scripts/jobs/cron_tasks.inc.http.10.apache.php on line 1315
```

Structure of the fix is the same as in f5bc81faca86ca7eeb81ed2de2b08a492079321b but copied to the other section.
