### PR TITLE
fix: undefined variable $logrotatefile when rotating speciallogfile

### DIFF
--- a/scripts/jobs/cron_traffic.php
+++ b/scripts/jobs/cron_traffic.php
@@ -236,6 +236,8 @@ while($row = $db->fetch_array($result))
 			reset($speciallogfile_domainlist[$row['customerid']]);
 			foreach($speciallogfile_domainlist[$row['customerid']] as $domainid => $domain)
 			{
+				
+				$logrotatefile = '/tmp/froxlor_logrotate_tmpfile.conf';
 				$fh = fopen($logrotatefile, 'w');
 
 				$logconf = '# ' . basename($logrotatefile) . "\n" . '# Created ' . date('d.m.Y H:i') . "\n" .


### PR DESCRIPTION
$logrotatefile was used without being initalized (probably copy/paste error)
