### PR TITLE
allow 'login' mech (to support Outlook < 2007, and Outlook Express)

### DIFF
--- a/templates/misc/configfiles/ubuntu_precise/dovecot/etc_dovecot_conf.d_10_auth.conf
+++ b/templates/misc/configfiles/ubuntu_precise/dovecot/etc_dovecot_conf.d_10_auth.conf
@@ -96,7 +96,7 @@
 #   plain login digest-md5 cram-md5 ntlm rpa apop anonymous gssapi otp skey
 #   gss-spnego
 # NOTE: See also disable_plaintext_auth setting.
-auth_mechanisms = plain
+auth_mechanisms = plain login
 
 ##
 ## Password and user databases


### PR DESCRIPTION
without this, users of Outlook 2003 and older, and Outlook Express, won't be able to authenticate. This setting is already contained in the respective config in Gentoo.
