### PR TITLE
Inserting new feature: plan templates

### DIFF
--- a/admin_admins.php
+++ b/admin_admins.php
@@ -468,6 +468,14 @@ if($page == 'admins'
 					$ips[] = $row['ip'];
 				}
 			}
+			
+			$plan_options = makeoption('', '');
+			$planlist = $db->query("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `adminid` = '" . (int)$userinfo['adminid'] . "' AND `plan_type` = '0' ORDER BY `plan_name`");
+			$plannum = $db->num_rows($planlist);
+			while($plan = $db->fetch_array($planlist))
+			{
+				$plan_options.= makeoption($plan['plan_name'], $plan['planid']);
+			}
 
 			$customers_ul = makecheckbox('customers_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
 			$diskspace_ul = makecheckbox('diskspace_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
@@ -880,6 +888,14 @@ if($page == 'admins'
 						$ipaddress.= makeoption($row['ip'], $row['id'], $result['ip']);
 						$ips[] = $row['ip'];
 					}
+				}
+				
+				$plan_options = makeoption('', '');
+				$planlist = $db->query("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `adminid` = '" . (int)$userinfo['adminid'] . "' AND `plan_type` = '0' ORDER BY `plan_name`");
+				$plannum = $db->num_rows($planlist);
+				while($plan = $db->fetch_array($planlist))
+				{
+					$plan_options.= makeoption($plan['plan_name'], $plan['planid']);
 				}
 
 				/*

--- a/admin_customers.php
+++ b/admin_customers.php
@@ -887,6 +887,14 @@ if($page == 'customers'
 				{
 					$language_options.= makeoption($language_name, $language_file, $settings['panel']['standardlanguage'], true);
 				}
+				
+				$plan_options = makeoption('', '');
+				$planlist = $db->query("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `adminid` = '" . (int)$userinfo['adminid'] . "' AND `plan_type` = '1' ORDER BY `plan_name`");
+				$plannum = $db->num_rows($planlist);
+				while($plan = $db->fetch_array($planlist))
+				{
+					$plan_options.= makeoption($plan['plan_name'], $plan['planid']);
+				}
 
 				$diskspace_ul = makecheckbox('diskspace_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
 				$traffic_ul = makecheckbox('traffic_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
@@ -1478,6 +1486,14 @@ if($page == 'customers'
 				while(list($language_file, $language_name) = each($languages))
 				{
 					$language_options.= makeoption($language_name, $language_file, $result['def_language'], true);
+				}
+				
+				$plan_options = makeoption('', '');
+				$planlist = $db->query("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `adminid` = '" . (int)$userinfo['adminid'] . "' AND `plan_type` = '1' ORDER BY `plan_name`");
+				$plannum = $db->num_rows($planlist);
+				while($plan = $db->fetch_array($planlist))
+				{
+					$plan_options.= makeoption($plan['plan_name'], $plan['planid']);
 				}
 
 				$result['traffic'] = round($result['traffic'] / (1024 * 1024), $settings['panel']['decimal_places']);

--- a/admin_plans.php
+++ b/admin_plans.php
@@ -1,0 +1,893 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2003-2009 the SysCP Team (see authors).
+ * Copyright (c) 2012 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Florian Lippert <flo@syscp.org> (2003-2009)
+ * @author     Froxlor team <team@froxlor.org> (2012-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Panel
+ *
+ */
+
+define('AREA', 'admin');
+
+/**
+ * Include our init.php, which manages Sessions, Language etc.
+ */
+
+require ("./lib/init.php");
+
+if(isset($_POST['id']))
+{
+	$id = intval($_POST['id']);
+}
+elseif(isset($_GET['id']))
+{
+	$id = intval($_GET['id']);
+}
+
+if($page == 'show')
+{
+	$result = $db->query_first("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `planid`='" . (int)$id . "' AND `adminid` = '" . (int)$userinfo['adminid'] . "' ");
+
+	if($result['planid'] != '')
+	{
+		$result['traffic'] = round($result['traffic'] / (1024 * 1024), $settings['panel']['decimal_places']);
+		$result['diskspace'] = round($result['diskspace'] / 1024, $settings['panel']['decimal_places']);
+
+		$result['diskspace_ul'] = $result['traffic_ul'] = $result['subdomains_ul'] = $result['emails_ul'] = $result['email_accounts_ul'] =
+		$result['email_forwarders_ul'] = $result['email_autoresponder_ul'] = $result['ftps_ul'] = $result['mysqls_ul'] = $result['customers_ul'] =
+		$result['email_quota_ul'] = $result['tickets_ul'] = $result['number_of_aps_packages_ul'] = $result['domains_ul'] = false;
+	
+		$result['customers_see_all'] = ($result['customers_see_all']=='1') ? true : false;
+		$result['domains_see_all'] = ($result['domains_see_all']=='1') ? true : false;
+		$result['caneditphpsettings'] = ($result['caneditphpsettings']=='1') ? true : false;
+		$result['change_serversettings'] = ($result['change_serversettings']=='1') ? true : false;
+		$result['can_manage_aps_packages'] = ($result['can_manage_aps_packages']=='1') ? true : false;
+		$result['phpenabled'] = ($result['phpenabled']=='1') ? true : false;
+		$result['perlenabled'] = ($result['perlenabled']=='1') ? true : false;
+		$result['email_imap'] = ($result['imap']=='1') ? true : false;
+		$result['email_pop3'] = ($result['pop3']=='1') ? true : false;
+		$result['number_of_aps_packages'] = $result['aps_packages'];
+		
+		if($result['domains'] == '-1')
+		{
+			$result['domains'] = '';
+			$result['domains_ul'] = true;
+		}
+		
+		if($result['customers'] == '-1')
+		{
+			$result['customers'] = '';
+			$result['customers_ul'] = true;
+		}
+
+		if($result['diskspace'] == '-1')
+		{
+			$result['diskspace'] = '';
+			$result['diskspace_ul'] = true;
+		}
+
+		if($result['traffic'] == '-1')
+		{
+			$result['traffic'] = '';
+			$result['traffic_ul'] = true;
+		}
+
+		if($result['subdomains'] == '-1')
+		{
+			$result['subdomains'] = '';
+			$result['subdomains_ul'] = true;
+		}
+
+		if($result['emails'] == '-1')
+		{
+			$result['emails'] = '';
+			$result['emails_ul'] = true;
+		}
+
+		if($result['email_accounts'] == '-1')
+		{
+			$result['email_accounts'] = '';
+			$result['email_accounts_ul'] = true;
+		}
+
+		if($result['email_forwarders'] == '-1')
+		{
+			$result['email_forwarders'] = '';
+			$result['email_forwarders_ul'] = true;
+		}
+
+		if($result['email_quota'] == '-1')
+		{
+			$result['email_quota'] = '';
+			$result['email_quota_ul'] = true;
+		}
+
+		if($result['email_autoresponder'] == '-1')
+		{
+			$result['email_autoresponder'] = '';
+			$result['email_autoresponder_ul'] = true;
+		}
+
+		if($result['ftps'] == '-1')
+		{
+			$result['ftps'] = '';
+			$result['ftps_ul'] = true;
+		}
+
+		if($result['tickets'] == '-1')
+		{
+			$result['tickets'] = '';
+			$result['tickets_ul'] = true;
+		}
+
+		if($result['mysqls'] == '-1')
+		{
+			$result['mysqls'] = '';
+			$result['mysqls_ul'] = true;
+		}
+
+		if($result['aps_packages'] == '-1')
+		{
+			$result['number_of_aps_packages'] = '';
+			$result['number_of_aps_packages_ul'] = true; 
+		}
+		
+		unset($result['plan_name']);
+		unset($result['adminid']);
+		unset($result['planid']);
+		echo json_encode($result);
+	}
+}
+
+if($page == 'plan')
+{
+	if($action == '')
+	{
+		// clear request data
+		unset($_SESSION['requestData']);
+
+		$log->logAction(ADM_ACTION, LOG_NOTICE, "viewed admin_plans");
+		$fields = array(
+			'plan_name' => $lng['customer']['name'],
+			'plan_type' => $lng['admin']['plans']['plan_group'],
+			'diskspace' => $lng['customer']['diskspace'],
+			'traffic' => $lng['customer']['traffic']
+		);
+
+		if($_REQUEST['searchfield']=='diskspace' || $_REQUEST['searchfield']=='traffic')
+		{
+			$_REQUEST['searchtext'] *= 1024;
+		}
+		
+		if($_REQUEST['searchfield']=='plan_type' && strtolower($_REQUEST['searchtext'])==strtolower($lng['admin']['admins']))
+		{
+			$_REQUEST['searchtext'] = '0';
+		}
+		elseif($_REQUEST['searchfield']=='plan_type' && strtolower($_REQUEST['searchtext'])==strtolower($lng['admin']['customers']))
+		{
+			$_REQUEST['searchtext'] = '1';
+		}
+
+		$paging = new paging($userinfo, $db, TABLE_PANEL_PLANS, $fields, $settings['panel']['paging'], $settings['panel']['natsorting']);
+		$plan = '';
+		$result = $db->query("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `adminid` = '" . (int)$userinfo['adminid'] . "' " . $paging->getSqlWhere(true) . " " . $paging->getSqlOrderBy($settings['panel']['natsorting']) . " " . $paging->getSqlLimit());
+		$paging->setEntries($db->num_rows($result));
+		$sortcode = $paging->getHtmlSortCode($lng, true);
+		$arrowcode = $paging->getHtmlArrowCode($filename . '?page=' . $page . '&s=' . $s);
+		$searchcode = $paging->getHtmlSearchCode($lng);
+		$pagingcode = $paging->getHtmlPagingCode($filename . '?page=' . $page . '&s=' . $s);
+		$i = 0;
+		$count = 0;
+
+		while($row = $db->fetch_array($result))
+		{
+			if($paging->checkDisplay($i))
+			{
+				$row['traffic'] = round($row['traffic'] / (1024 * 1024), $settings['panel']['decimal_places']);
+				$row['diskspace'] = round($row['diskspace'] / 1024, $settings['panel']['decimal_places']);
+				$column_style = '';
+				$plan_types = array($lng['admin']['admins'], $lng['admin']['customers']);
+				$row['plan_type'] = $plan_types[$row['plan_type']];
+				$row = htmlentities_array($row);
+				eval("\$plan.=\"" . getTemplate("plans/plans_plan") . "\";");
+				$count++;
+			}
+			$i++;
+		}
+
+		$plancount = $db->num_rows($result);
+		eval("echo \"" . getTemplate("plans/plans") . "\";");
+	}
+	elseif($action == 'delete'
+	       && $id != 0)
+	{
+		$result = $db->query_first("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `planid`='" . (int)$id . "' AND `adminid` = '" . (int)$userinfo['adminid'] . "' ");
+
+		if($result['planid'] != '')
+		{
+			if(isset($_POST['send'])
+			   && $_POST['send'] == 'send')
+			{
+				$db->query("DELETE FROM `" . TABLE_PANEL_PLANS . "` WHERE `planid`='" . (int)$id . "'");
+				$log->logAction(ADM_ACTION, LOG_INFO, "deleted plan '" . $result['plan_name'] . "'");
+				redirectTo($filename, Array('page' => $page, 's' => $s));
+			}
+			else
+			{
+				ask_yesno('admin_template_reallydelete', $filename, array('id' => $id, 'page' => $page, 'action' => $action), $result['plan_name']);
+			}
+		}
+	}
+	elseif($action == 'add')
+	{
+		if($userinfo['customers_used'] < $userinfo['customers']
+		   || $userinfo['customers'] == '-1')
+		{
+			if(isset($_POST['prepare'])
+			   && $_POST['prepare'] == 'prepare')
+			{
+				$plan_type = intval($_POST['plan_type']);
+				if($plan_type!=1)
+				{
+					$customers_ul = makecheckbox('customers_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+					$domains_ul = makecheckbox('domains_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				}
+				
+				$diskspace_ul = makecheckbox('diskspace_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$traffic_ul = makecheckbox('traffic_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$subdomains_ul = makecheckbox('subdomains_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$emails_ul = makecheckbox('emails_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$email_accounts_ul = makecheckbox('email_accounts_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$email_forwarders_ul = makecheckbox('email_forwarders_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$email_quota_ul = makecheckbox('email_quota_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$email_autoresponder_ul = makecheckbox('email_autoresponder_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$ftps_ul = makecheckbox('ftps_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$tickets_ul = makecheckbox('tickets_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$mysqls_ul = makecheckbox('mysqls_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$number_of_aps_packages_ul = makecheckbox('number_of_aps_packages_ul', $lng['customer']['unlimited'], '-1', false, '0', true, true);
+				$backup_allowed = makeyesno('backup_allowed', '1', '0', '0');
+
+				$plan_add_data = include_once dirname(__FILE__).'/lib/formfields/admin/plans/formfield.plan_add.php';
+				$plan_add_form = htmlform::genHTMLForm($plan_add_data);
+
+				$title = $plan_add_data['plan_add']['title'];
+				$image = $plan_add_data['plan_add']['image'];
+
+				eval("echo \"" . getTemplate("plans/plans_add_2") . "\";");
+			}
+			elseif(isset($_POST['send'])
+			   && $_POST['send'] == 'send')
+			{
+				$plan_name = validate($_POST['plan_name'], 'plan_name');
+				$plan_type = intval($_POST['plan_type']);
+				$customers = intval_ressource($_POST['customers']);
+				
+				if(isset($_POST['customers_ul']))
+				{
+					$customers = - 1;
+				}
+				
+				$domains = intval_ressource($_POST['domains']);
+				
+				if(isset($_POST['domains_ul']))
+				{
+					$domains = - 1;
+				}
+				
+				$diskspace = intval_ressource($_POST['diskspace']);
+
+				if(isset($_POST['diskspace_ul']))
+				{
+					$diskspace = - 1;
+				}
+
+				$traffic = doubleval_ressource($_POST['traffic']);
+
+				if(isset($_POST['traffic_ul']))
+				{
+					$traffic = - 1;
+				}
+
+				$subdomains = intval_ressource($_POST['subdomains']);
+
+				if(isset($_POST['subdomains_ul']))
+				{
+					$subdomains = - 1;
+				}
+
+				$emails = intval_ressource($_POST['emails']);
+
+				if(isset($_POST['emails_ul']))
+				{
+					$emails = - 1;
+				}
+
+				$email_accounts = intval_ressource($_POST['email_accounts']);
+
+				if(isset($_POST['email_accounts_ul']))
+				{
+					$email_accounts = - 1;
+				}
+
+				$email_forwarders = intval_ressource($_POST['email_forwarders']);
+
+				if(isset($_POST['email_forwarders_ul']))
+				{
+					$email_forwarders = - 1;
+				}
+
+				if($settings['system']['mail_quota_enabled'] == '1')
+				{
+					$email_quota = validate($_POST['email_quota'], 'email_quota', '/^\d+$/', 'vmailquotawrong', array('0', ''));
+
+					if(isset($_POST['email_quota_ul']))
+					{
+						$email_quota = - 1;
+					}
+				}
+				else
+				{
+					$email_quota = - 1;
+				}
+
+				if($settings['autoresponder']['autoresponder_active'] == '1')
+				{
+					$email_autoresponder = intval_ressource($_POST['email_autoresponder']);
+
+					if(isset($_POST['email_autoresponder_ul']))
+					{
+						$email_autoresponder = - 1;
+					}
+				}
+				else
+				{
+					$email_autoresponder = 0;
+				}
+
+				$email_imap = 0;
+				if(isset($_POST['email_imap']))
+					$email_imap = intval_ressource($_POST['email_imap']);
+
+				$email_pop3 = 0;
+				if(isset($_POST['email_pop3']))
+					$email_pop3 = intval_ressource($_POST['email_pop3']);
+
+				$ftps = 0;
+				if(isset($_POST['ftps']))
+					$ftps = intval_ressource($_POST['ftps']);
+
+				if(isset($_POST['ftps_ul']))
+				{
+					$ftps = - 1;
+				}
+
+				$tickets = ($settings['ticket']['enabled'] == 1 ? intval_ressource($_POST['tickets']) : 0);
+
+				if(isset($_POST['tickets_ul'])
+				   && $settings['ticket']['enabled'] == '1')
+				{
+					$tickets = - 1;
+				}
+
+				$mysqls = intval_ressource($_POST['mysqls']);
+
+				if(isset($_POST['mysqls_ul']))
+				{
+					$mysqls = - 1;
+				}
+
+				if($settings['aps']['aps_active'] == '1')
+				{
+					$can_manage_aps_packages = (isset($_POST['can_manage_aps_packages'])) ? true : false;
+					$number_of_aps_packages = intval_ressource($_POST['number_of_aps_packages']);
+
+					if(isset($_POST['number_of_aps_packages_ul']))
+					{
+						$number_of_aps_packages = - 1;
+					}
+				}
+				else
+				{
+					$can_manage_aps_packages = 0;
+					$number_of_aps_packages = 0;
+				}
+
+				$backup_allowed = 0;
+				if(isset($_POST['backup_allowed']))
+					$backup_allowed = intval($_POST['backup_allowed']);
+
+				if ($backup_allowed != 0)
+				{
+					$backup_allowed = 1;
+				}
+				
+				$customers_see_all = (isset($_POST['customers_see_all'])) ? true : false;
+				$domains_see_all = (isset($_POST['domains_see_all'])) ? true : false;
+				$caneditphpsettings = (isset($_POST['caneditphpsettings'])) ? true : false;
+				$change_serversettings = (isset($_POST['change_serversettings'])) ? true : false;
+
+				$phpenabled = 0;
+				if(isset($_POST['phpenabled']))
+					$phpenabled = intval($_POST['phpenabled']);
+
+				$perlenabled = 0;
+				if(isset($_POST['perlenabled']))
+					$perlenabled = intval($_POST['perlenabled']);
+
+				$diskspace = $diskspace * 1024;
+				$traffic = $traffic * 1024 * 1024;
+
+				if((($diskspace > $userinfo['diskspace']) && ($userinfo['diskspace'] / 1024) != '-1')
+				   || (($mysqls > $userinfo['mysqls']) && $userinfo['mysqls'] != '-1')
+				   || (($emails > $userinfo['emails']) && $userinfo['emails'] != '-1')
+				   || (($email_accounts > $userinfo['email_accounts']) && $userinfo['email_accounts'] != '-1')
+				   || (($email_forwarders > $userinfo['email_forwarders']) && $userinfo['email_forwarders'] != '-1')
+				   || (($email_quota > $userinfo['email_quota']) && $userinfo['email_quota'] != '-1' && $settings['system']['mail_quota_enabled'] == '1')
+				   || (($email_autoresponder > $userinfo['email_autoresponder']) && $userinfo['email_autoresponder'] != '-1' && $settings['autoresponder']['autoresponder_active'] == '1')
+				   || (($ftps > $userinfo['ftps']) && $userinfo['ftps'] != '-1')
+				   || (($tickets > $userinfo['tickets']) && $userinfo['tickets'] != '-1')
+				   || (($subdomains > $userinfo['subdomains']) && $userinfo['subdomains'] != '-1')
+				   || (($number_of_aps_packages > $userinfo['aps_packages']) && $userinfo['aps_packages'] != '-1' && $settings['aps']['aps_active'] == '1')
+				   || (($diskspace / 1024) == '-1' && ($userinfo['diskspace'] / 1024) != '-1')
+				   || (($customers > $userinfo['customers']) && $userinfo['customers'] != '-1')
+				   || (($domains > $userinfo['domains']) && $userinfo['domains'] != '-1')
+				   || ($mysqls == '-1' && $userinfo['mysqls'] != '-1')
+				   || ($emails == '-1' && $userinfo['emails'] != '-1')
+				   || ($email_accounts == '-1' && $userinfo['email_accounts'] != '-1')
+				   || ($email_forwarders == '-1' && $userinfo['email_forwarders'] != '-1')
+				   || ($email_quota == '-1' && $userinfo['email_quota'] != '-1' && $settings['system']['mail_quota_enabled'] == '1')
+				   || ($email_autoresponder == '-1' && $userinfo['email_autoresponder'] != '-1' && $settings['autoresponder']['autoresponder_active'] == '1')
+				   || ($ftps == '-1' && $userinfo['ftps'] != '-1')
+				   || ($tickets == '-1' && $userinfo['tickets'] != '-1')
+				   || ($subdomains == '-1' && $userinfo['subdomains'] != '-1')
+				   || ($customers == '-1' && $userinfo['customers'] != '-1')
+				   || ($domains == '-1' && $userinfo['domains'] != '-1')
+				   || ($number_of_aps_packages == '-1' && $userinfo['aps_packages'] != '-1'))
+				{
+					standard_error('youcantallocatemorethanyouhave');
+					exit;
+				}
+				else
+				{
+					// Check if the plan already exists
+					$name_check = $db->query_first("SELECT `plan_name` FROM `" . TABLE_PANEL_PLANS . "` WHERE `plan_name` = '" . $db->escape($name) . "' AND `adminid` = '" . (int)$userinfo['adminid'] . "'");
+
+					if(strtolower($name_check['plan_name']) == strtolower($plan_name))
+					{
+						standard_error('nameexists', $plan_name);
+					}
+
+					if($phpenabled != '0')
+					{
+						$phpenabled = '1';
+					}
+
+					if($perlenabled != '0')
+					{
+						$perlenabled = '1';
+					}
+
+					$result = $db->query(
+						"INSERT INTO `" . TABLE_PANEL_PLANS . "` SET
+							`adminid` = '" . (int)$userinfo['adminid'] . "',
+							`plan_name` = '" . $db->escape($plan_name) . "',
+							`plan_type` = '" . $db->escape($plan_type) . "',
+							`customers` = '" . $db->escape($customers) . "',
+							`customers_see_all` = '" . $db->escape($customers_see_all) . "',
+							`domains` = '" . $db->escape($domains) . "',
+							`domains_see_all` = '" . $db->escape($domains_see_all) . "',
+							`caneditphpsettings` = '" . $db->escape($caneditphpsettings) . "',
+							`change_serversettings` = '" . $db->escape($change_serversettings) . "',
+							`diskspace` = '" . $db->escape($diskspace) . "',
+							`traffic` = '" . $db->escape($traffic) . "',
+							`subdomains` = '" . $db->escape($subdomains) . "',
+							`emails` = '" . $db->escape($emails) . "',
+							`email_accounts` = '" . $db->escape($email_accounts) . "',
+							`email_forwarders` = '" . $db->escape($email_forwarders) . "',
+							`email_quota` = '" . $db->escape($email_quota) . "',
+							`ftps` = '" . $db->escape($ftps) . "',
+							`tickets` = '" . $db->escape($tickets) . "',
+							`mysqls` = '" . $db->escape($mysqls) . "',
+							`phpenabled` = '" . $db->escape($phpenabled) . "',
+							`imap` = '" . $db->escape($email_imap) . "',
+							`pop3` = '" . $db->escape($email_pop3) . "',
+							`can_manage_aps_packages` = '" . $db->escape($can_manage_aps_packages) . "',
+							`aps_packages` = '" . (int)$number_of_aps_packages . "',
+							`perlenabled` = '" . $db->escape($perlenabled) . "',
+							`email_autoresponder` = '" . $db->escape($email_autoresponder) . "',
+							`backup_allowed` = '" . $db->escape($backup_allowed) . "'"
+					);
+					$planid = $db->insert_id();
+					$log->logAction(ADM_ACTION, LOG_INFO, "added plan '" . $plan_name . "'");
+					redirectTo($filename, Array('page' => $page, 's' => $s));
+				}
+			}
+			else
+			{
+				$plan_options = makeoption($lng['admin']['customers'], '1', NULL, true);
+				if($userinfo['change_serversettings'] == '1')
+				{
+					$plan_options.= makeoption($lng['admin']['admins'], '0', NULL, true);
+				}
+
+				eval("echo \"" . getTemplate("plans/plans_add_1") . "\";");
+			}
+		}
+	}
+	elseif($action == 'edit'
+	       && $id != 0)
+	{
+		$result = $db->query_first("SELECT * FROM `" . TABLE_PANEL_PLANS . "` WHERE `planid`='" . (int)$id . "' AND `adminid` = '" . (int)$userinfo['adminid'] . "' ");
+
+		if($result['planid'] != '')
+		{
+			if(isset($_POST['send'])
+			   && $_POST['send'] == 'send')
+			{
+				$plan_name = validate($_POST['plan_name'], 'plan_name');
+				$customers = intval_ressource($_POST['customers']);
+				
+				if(isset($_POST['customers_ul']))
+				{
+					$customers = - 1;
+				}
+				
+				$domains = intval_ressource($_POST['domains']);
+				
+				if(isset($_POST['domains_ul']))
+				{
+					$domains = - 1;
+				}
+				
+				$diskspace = intval_ressource($_POST['diskspace']);
+
+				if(isset($_POST['diskspace_ul']))
+				{
+					$diskspace = - 1;
+				}
+
+				$traffic = doubleval_ressource($_POST['traffic']);
+
+				if(isset($_POST['traffic_ul']))
+				{
+					$traffic = - 1;
+				}
+
+				$subdomains = intval_ressource($_POST['subdomains']);
+
+				if(isset($_POST['subdomains_ul']))
+				{
+					$subdomains = - 1;
+				}
+
+				$emails = intval_ressource($_POST['emails']);
+
+				if(isset($_POST['emails_ul']))
+				{
+					$emails = - 1;
+				}
+
+				$email_accounts = intval_ressource($_POST['email_accounts']);
+
+				if(isset($_POST['email_accounts_ul']))
+				{
+					$email_accounts = - 1;
+				}
+
+				$email_forwarders = intval_ressource($_POST['email_forwarders']);
+
+				if(isset($_POST['email_forwarders_ul']))
+				{
+					$email_forwarders = - 1;
+				}
+
+				if($settings['system']['mail_quota_enabled'] == '1')
+				{
+					$email_quota = validate($_POST['email_quota'], 'email_quota', '/^\d+$/', 'vmailquotawrong', array('0', ''));
+
+					if(isset($_POST['email_quota_ul']))
+					{
+						$email_quota = - 1;
+					}
+				}
+				else
+				{
+					$email_quota = - 1;
+				}
+
+				if($settings['autoresponder']['autoresponder_active'] == '1')
+				{
+					$email_autoresponder = intval_ressource($_POST['email_autoresponder']);
+
+					if(isset($_POST['email_autoresponder_ul']))
+					{
+						$email_autoresponder = - 1;
+					}
+				}
+				else
+				{
+					$email_autoresponder = 0;
+				}
+
+				$email_imap = 0;
+				if(isset($_POST['email_imap']))
+					$email_imap = intval_ressource($_POST['email_imap']);
+
+				$email_pop3 = 0;
+				if(isset($_POST['email_pop3']))
+					$email_pop3 = intval_ressource($_POST['email_pop3']);
+
+				$ftps = 0;
+				if(isset($_POST['ftps']))
+					$ftps = intval_ressource($_POST['ftps']);
+
+				if(isset($_POST['ftps_ul']))
+				{
+					$ftps = - 1;
+				}
+
+				$tickets = ($settings['ticket']['enabled'] == 1 ? intval_ressource($_POST['tickets']) : 0);
+
+				if(isset($_POST['tickets_ul'])
+				   && $settings['ticket']['enabled'] == '1')
+				{
+					$tickets = - 1;
+				}
+
+				$backup_allowed = 0;
+				if (isset($_POST['backup_allowed']))
+					$backup_allowed = intval($_POST['backup_allowed']);
+
+				if($backup_allowed != '0'){
+					$backup_allowed = 1;
+				}
+				
+				$customers_see_all = (isset($_POST['customers_see_all'])) ? true : false;
+				$domains_see_all = (isset($_POST['domains_see_all'])) ? true : false;
+				$caneditphpsettings = (isset($_POST['caneditphpsettings'])) ? true : false;
+				$change_serversettings = (isset($_POST['change_serversettings'])) ? true : false;
+
+				$mysqls = 0;
+				if(isset($_POST['mysqls']))
+					$mysqls = intval_ressource($_POST['mysqls']);
+
+				if(isset($_POST['mysqls_ul']))
+				{
+					$mysqls = - 1;
+				}
+
+				if($settings['aps']['aps_active'] == '1')
+				{
+					$number_of_aps_packages = intval_ressource($_POST['number_of_aps_packages']);
+					$can_manage_aps_packages = (isset($_POST['can_manage_aps_packages'])) ? true : false;
+
+					if(isset($_POST['number_of_aps_packages_ul']))
+					{
+						$number_of_aps_packages = - 1;
+					}
+				}
+				else
+				{
+					$number_of_aps_packages = 0;
+					$can_manage_aps_packages = 0;
+				}
+
+				$phpenabled = 0;
+				if(isset($_POST['phpenabled']))
+					$phpenabled = intval($_POST['phpenabled']);
+
+				$perlenabled = 0;
+				if(isset($_POST['perlenabled']))
+					$perlenabled = intval($_POST['perlenabled']);
+				$diskspace = $diskspace * 1024;
+				$traffic = $traffic * 1024 * 1024;
+
+				if((($diskspace > $userinfo['diskspace']) && ($userinfo['diskspace'] / 1024) != '-1')
+				   || (($mysqls > $userinfo['mysqls']) && $userinfo['mysqls'] != '-1')
+				   || (($emails > $userinfo['emails']) && $userinfo['emails'] != '-1')
+				   || (($email_accounts > $userinfo['email_accounts']) && $userinfo['email_accounts'] != '-1')
+				   || (($email_forwarders > $userinfo['email_forwarders']) && $userinfo['email_forwarders'] != '-1')
+				   || (($email_quota > $userinfo['email_quota']) && $userinfo['email_quota'] != '-1' && $settings['system']['mail_quota_enabled'] == '1')
+				   || (($email_autoresponder > $userinfo['email_autoresponder']) && $userinfo['email_autoresponder'] != '-1' && $settings['autoresponder']['autoresponder_active'] == '1')
+				   || (($ftps > $userinfo['ftps']) && $userinfo['ftps'] != '-1')
+				   || (($tickets > $userinfo['tickets']) && $userinfo['tickets'] != '-1')
+				   || (($subdomains > $userinfo['subdomains']) && $userinfo['subdomains'] != '-1')
+				   || (($diskspace / 1024) == '-1' && ($userinfo['diskspace'] / 1024) != '-1')
+				   || (($number_of_aps_packages > $userinfo['aps_packages']) && $userinfo['aps_packages'] != '-1' && $settings['aps']['aps_active'] == '1')
+				   || (($customers > $userinfo['customers']) && $userinfo['customers'] != '-1')
+				   || (($domains > $userinfo['domains']) && $userinfo['domains'] != '-1')
+				   || ($mysqls == '-1' && $userinfo['mysqls'] != '-1')
+				   || ($emails == '-1' && $userinfo['emails'] != '-1')
+				   || ($email_accounts == '-1' && $userinfo['email_accounts'] != '-1')
+				   || ($email_forwarders == '-1' && $userinfo['email_forwarders'] != '-1')
+				   || ($email_quota == '-1' && $userinfo['email_quota'] != '-1' && $settings['system']['mail_quota_enabled'] == '1')
+				   || ($email_autoresponder == '-1' && $userinfo['email_autoresponder'] != '-1' && $settings['autoresponder']['autoresponder_active'] == '1')
+				   || ($ftps == '-1' && $userinfo['ftps'] != '-1')
+				   || ($tickets == '-1' && $userinfo['tickets'] != '-1')
+				   || ($subdomains == '-1' && $userinfo['subdomains'] != '-1')
+				   || ($customers == '-1' && $userinfo['customers'] != '-1')
+				   || ($domains == '-1' && $userinfo['domains'] != '-1')
+				   || ($number_of_aps_packages == '-1' && $userinfo['aps_packages'] != '-1'))
+				{
+					standard_error('youcantallocatemorethanyouhave');
+					exit;
+				}
+				else
+				{
+					if($phpenabled != '0')
+					{
+						$phpenabled = '1';
+					}
+
+					if($perlenabled != '0')
+					{
+						$perlenabled = '1';
+					}
+
+					$db->query(
+						"UPDATE `" . TABLE_PANEL_PLANS . "` SET 
+							`plan_name` = '" . $db->escape($plan_name) . "', 
+							`customers` = '" . $db->escape($customers) . "',
+							`customers_see_all` = '" . $db->escape($customers_see_all) . "',
+							`domains` = '" . $db->escape($domains) . "',
+							`domains_see_all` = '" . $db->escape($domains_see_all) . "',
+							`caneditphpsettings` = '" . $db->escape($caneditphpsettings) . "',
+							`change_serversettings` = '" . $db->escape($change_serversettings) . "',
+							`diskspace` = '" . $db->escape($diskspace) . "', 
+							`traffic` = '" . $db->escape($traffic) . "', 
+							`subdomains` = '" . $db->escape($subdomains) . "', 
+							`emails` = '" . $db->escape($emails) . "', 
+							`email_accounts` = '" . $db->escape($email_accounts) . "', 
+							`email_forwarders` = '" . $db->escape($email_forwarders) . "', 
+							`ftps` = '" . $db->escape($ftps) . "', 
+							`tickets` = '" . $db->escape($tickets) . "', 
+							`mysqls` = '" . $db->escape($mysqls) . "', 
+							`phpenabled` = '" . $db->escape($phpenabled) . "', 
+							`email_quota` = '" . $db->escape($email_quota) . "', 
+							`imap` = '" . $db->escape($email_imap) . "', 
+							`pop3` = '" . $db->escape($email_pop3) . "', 
+							`can_manage_aps_packages` = '" . $db->escape($can_manage_aps_packages) . "',
+							`aps_packages` = '" . (int)$number_of_aps_packages . "', 
+							`perlenabled` = '" . $db->escape($perlenabled) . "', 
+							`email_autoresponder` = '" . $db->escape($email_autoresponder) . "', 
+							`backup_allowed` = '" . $db->escape($backup_allowed) . "' 
+						WHERE `planid` = '" . (int)$id . "'");
+
+					$log->logAction(ADM_ACTION, LOG_INFO, "edited plan '" . $result['plan_name'] . "'");
+					$redirect_props = Array(
+						'page' => $page,
+						's' => $s
+					);
+
+					redirectTo($filename, $redirect_props);
+				}
+			}
+			else
+			{
+				$plan_type = $result['plan_type'];
+				$result['traffic'] = round($result['traffic'] / (1024 * 1024), $settings['panel']['decimal_places']);
+				$result['diskspace'] = round($result['diskspace'] / 1024, $settings['panel']['decimal_places']);
+				$customers_ul = makecheckbox('customers_ul', $lng['customer']['unlimited'], '-1', false, $result['customers'], true, true);
+
+				if($result['customers'] == '-1')
+				{
+					$result['customers'] = '';
+				}
+				
+				$domains_ul = makecheckbox('domains_ul', $lng['customer']['unlimited'], '-1', false, $result['domains'], true, true);
+
+				if($result['domains'] == '-1')
+				{
+					$result['domains'] = '';
+				}
+				
+				$diskspace_ul = makecheckbox('diskspace_ul', $lng['customer']['unlimited'], '-1', false, $result['diskspace'], true, true);
+
+				if($result['diskspace'] == '-1')
+				{
+					$result['diskspace'] = '';
+				}
+
+				$traffic_ul = makecheckbox('traffic_ul', $lng['customer']['unlimited'], '-1', false, $result['traffic'], true, true);
+
+				if($result['traffic'] == '-1')
+				{
+					$result['traffic'] = '';
+				}
+
+				$subdomains_ul = makecheckbox('subdomains_ul', $lng['customer']['unlimited'], '-1', false, $result['subdomains'], true, true);
+
+				if($result['subdomains'] == '-1')
+				{
+					$result['subdomains'] = '';
+				}
+
+				$emails_ul = makecheckbox('emails_ul', $lng['customer']['unlimited'], '-1', false, $result['emails'], true, true);
+
+				if($result['emails'] == '-1')
+				{
+					$result['emails'] = '';
+				}
+
+				$email_accounts_ul = makecheckbox('email_accounts_ul', $lng['customer']['unlimited'], '-1', false, $result['email_accounts'], true, true);
+
+				if($result['email_accounts'] == '-1')
+				{
+					$result['email_accounts'] = '';
+				}
+
+				$email_forwarders_ul = makecheckbox('email_forwarders_ul', $lng['customer']['unlimited'], '-1', false, $result['email_forwarders'], true, true);
+
+				if($result['email_forwarders'] == '-1')
+				{
+					$result['email_forwarders'] = '';
+				}
+
+				$email_quota_ul = makecheckbox('email_quota_ul', $lng['customer']['unlimited'], '-1', false, $result['email_quota'], true, true);
+
+				if($result['email_quota'] == '-1')
+				{
+					$result['email_quota'] = '';
+				}
+
+				$email_autoresponder_ul = makecheckbox('email_autoresponder_ul', $lng['customer']['unlimited'], '-1', false, $result['email_autoresponder'], true, true);
+
+				if($result['email_autoresponder'] == '-1')
+				{
+					$result['email_autoresponder'] = '';
+				}
+
+				$ftps_ul = makecheckbox('ftps_ul', $lng['customer']['unlimited'], '-1', false, $result['ftps'], true, true);
+
+				if($result['ftps'] == '-1')
+				{
+					$result['ftps'] = '';
+				}
+
+				$tickets_ul = makecheckbox('tickets_ul', $lng['customer']['unlimited'], '-1', false, $result['tickets'], true, true);
+
+				if($result['tickets'] == '-1')
+				{
+					$result['tickets'] = '';
+				}
+
+				$mysqls_ul = makecheckbox('mysqls_ul', $lng['customer']['unlimited'], '-1', false, $result['mysqls'], true, true);
+
+				if($result['mysqls'] == '-1')
+				{
+					$result['mysqls'] = '';
+				}
+
+				$number_of_aps_packages_ul = makecheckbox('number_of_aps_packages_ul', $lng['customer']['unlimited'], '-1', false, $result['aps_packages'], true, true);
+
+				if($result['aps_packages'] == '-1')
+				{
+					$result['aps_packages'] = '';
+				}
+
+				$backup_allowed = makeyesno('backup_allowed', '1', '0', $result['backup_allowed']);
+				$result = htmlentities_array($result);
+
+				$plan_edit_data = include_once dirname(__FILE__).'/lib/formfields/admin/plans/formfield.plan_edit.php';
+				$plan_edit_form = htmlform::genHTMLForm($plan_edit_data);
+
+				$title = $plan_edit_data['plan_edit']['title'];
+				$image = $plan_edit_data['plan_edit']['image'];
+
+				eval("echo \"" . getTemplate("plans/plans_edit") . "\";");
+			}
+		}
+	}
+}
+
+?>

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -913,3 +913,39 @@ CREATE TABLE IF NOT EXISTS `domain_docrootsettings` (
   PRIMARY KEY  (`id`)
 ) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
 
+
+
+DROP TABLE IF EXISTS `panel_plans`;
+CREATE TABLE IF NOT EXISTS `panel_plans` (
+  `planid` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `adminid` int(11) NOT NULL,
+  `plan_name` varchar(255) NOT NULL DEFAULT '',
+  `plan_type` tinyint(1) NOT NULL DEFAULT '0',
+  `customers` int(15) NOT NULL DEFAULT '0',
+  `customers_see_all` tinyint(1) NOT NULL DEFAULT '0',
+  `domains` int(15) NOT NULL DEFAULT '0',
+  `domains_see_all` tinyint(1) NOT NULL DEFAULT '0',
+  `caneditphpsettings` tinyint(1) NOT NULL DEFAULT '0',
+  `change_serversettings` tinyint(1) NOT NULL DEFAULT '0',
+  `diskspace` bigint(30) NOT NULL DEFAULT '0',
+  `mysqls` int(15) NOT NULL DEFAULT '0',
+  `emails` int(15) NOT NULL DEFAULT '0',
+  `email_accounts` int(15) NOT NULL DEFAULT '0',
+  `email_forwarders` int(15) NOT NULL DEFAULT '0',
+  `email_quota` bigint(13) NOT NULL DEFAULT '0',
+  `ftps` int(15) NOT NULL DEFAULT '0',
+  `tickets` int(15) NOT NULL DEFAULT '0',
+  `subdomains` int(15) NOT NULL DEFAULT '0',
+  `traffic` bigint(30) NOT NULL DEFAULT '0',
+  `phpenabled` tinyint(1) NOT NULL DEFAULT '0',
+  `pop3` tinyint(1) NOT NULL DEFAULT '0',
+  `imap` tinyint(1) NOT NULL DEFAULT '0',
+  `can_manage_aps_packages` tinyint(1) NOT NULL DEFAULT '0',
+  `aps_packages` int(5) NOT NULL DEFAULT '0',
+  `perlenabled` tinyint(1) NOT NULL DEFAULT '0',
+  `email_autoresponder` int(5) NOT NULL DEFAULT '0',
+  `backup_allowed` tinyint(1) NOT NULL DEFAULT '0',
+  `backup_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`planid`)
+) ENGINE=MyISAM  DEFAULT CHARSET=utf8 ;
+

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -2018,3 +2018,45 @@ if(isFroxlorVersion('0.9.28-svn5')) {
 
 	updateToVersion('0.9.28-svn6');
 }
+
+if(isFroxlorVersion('0.9.28-svn6')) {
+        showUpdateStep("Updating from 0.9.28-svn6 to 0.9.28-svn7", true);
+        lastStepStatus(0);
+
+        showUpdateStep("Inserting new feature: plan templates", true);
+        $db->query("CREATE TABLE IF NOT EXISTS `panel_plans` (
+		  `planid` int(11) unsigned NOT NULL AUTO_INCREMENT,
+		  `adminid` int(11) NOT NULL,
+		  `plan_name` varchar(255) NOT NULL DEFAULT '',
+		  `plan_type` tinyint(1) NOT NULL DEFAULT '0',
+		  `customers` int(15) NOT NULL DEFAULT '0',
+		  `customers_see_all` tinyint(1) NOT NULL DEFAULT '0',
+		  `domains` int(15) NOT NULL DEFAULT '0',
+		  `domains_see_all` tinyint(1) NOT NULL DEFAULT '0',
+		  `caneditphpsettings` tinyint(1) NOT NULL DEFAULT '0',
+		  `change_serversettings` tinyint(1) NOT NULL DEFAULT '0',
+		  `diskspace` bigint(30) NOT NULL DEFAULT '0',
+		  `mysqls` int(15) NOT NULL DEFAULT '0',
+		  `emails` int(15) NOT NULL DEFAULT '0',
+		  `email_accounts` int(15) NOT NULL DEFAULT '0',
+		  `email_forwarders` int(15) NOT NULL DEFAULT '0',
+		  `email_quota` bigint(13) NOT NULL DEFAULT '0',
+		  `ftps` int(15) NOT NULL DEFAULT '0',
+		  `tickets` int(15) NOT NULL DEFAULT '0',
+		  `subdomains` int(15) NOT NULL DEFAULT '0',
+		  `traffic` bigint(30) NOT NULL DEFAULT '0',
+		  `phpenabled` tinyint(1) NOT NULL DEFAULT '0',
+		  `pop3` tinyint(1) NOT NULL DEFAULT '0',
+		  `imap` tinyint(1) NOT NULL DEFAULT '0',
+		  `can_manage_aps_packages` tinyint(1) NOT NULL DEFAULT '0',
+		  `aps_packages` int(5) NOT NULL DEFAULT '0',
+		  `perlenabled` tinyint(1) NOT NULL DEFAULT '0',
+		  `email_autoresponder` int(5) NOT NULL DEFAULT '0',
+		  `backup_allowed` tinyint(1) NOT NULL DEFAULT '0',
+		  `backup_enabled` tinyint(1) NOT NULL DEFAULT '0',
+		  PRIMARY KEY (`planid`)
+		) ENGINE=MyISAM  DEFAULT CHARSET=utf8 ;");
+        lastStepStatus(0);
+
+        updateToVersion('0.9.28-svn7');
+}

--- a/lib/formfields/admin/admin/formfield.admin_add.php
+++ b/lib/formfields/admin/admin/formfield.admin_add.php
@@ -72,6 +72,12 @@ return array(
 						'type' => 'select',
 						'select_var' => $ipaddress
 					),
+					'plan' => array(
+						'visible' => ($plannum > 0 ? true : false),
+						'label' => $lng['admin']['plans']['usetemplate'],
+						'type' => 'select',
+						'select_var' => $plan_options
+					),
 					'change_serversettings' => array(
 						'label' => $lng['admin']['change_serversettings'],
 						'type' => 'checkbox',

--- a/lib/formfields/admin/admin/formfield.admin_edit.php
+++ b/lib/formfields/admin/admin/formfield.admin_edit.php
@@ -86,6 +86,12 @@ return array(
 						'type' => 'select',
 						'select_var' => $ipaddress
 					),
+					'plan' => array(
+						'visible' => ($plannum > 0 ? true : false),
+						'label' => $lng['admin']['plans']['usetemplate'],
+						'type' => 'select',
+						'select_var' => $plan_options
+					),
 					'change_serversettings' => array(
 						'label' => $lng['admin']['change_serversettings'],
 						'type' => 'checkbox',

--- a/lib/formfields/admin/customer/formfield.customer_add.php
+++ b/lib/formfields/admin/customer/formfield.customer_add.php
@@ -128,6 +128,12 @@ return array(
 				'title' => $lng['admin']['servicedata'],
 				'image' => 'icons/user_add.png',
 				'fields' => array(
+					'plan' => array(
+						'visible' => ($plannum > 0 ? true : false),
+						'label' => $lng['admin']['plans']['usetemplate'],
+						'type' => 'select',
+						'select_var' => $plan_options
+					),
 					'diskspace' => array(
 						'label' => $lng['customer']['diskspace'],
 						'type' => 'textul',

--- a/lib/formfields/admin/customer/formfield.customer_edit.php
+++ b/lib/formfields/admin/customer/formfield.customer_edit.php
@@ -136,6 +136,12 @@ return array(
 				'title' => $lng['admin']['servicedata'],
 				'image' => 'icons/user_edit.png',
 				'fields' => array(
+					'plan' => array(
+						'visible' => ($plannum>0 ? true : false),
+						'label' => $lng['admin']['plans']['usetemplate'],
+						'type' => 'select',
+						'select_var' => $plan_options
+					),
 					'diskspace' => array(
 						'label' => $lng['customer']['diskspace'],
 						'type' => 'textul',

--- a/lib/formfields/admin/plans/formfield.plan_add.php
+++ b/lib/formfields/admin/plans/formfield.plan_add.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Froxlor team <team@froxlor.org> (2010-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Formfields
+ *
+ */
+
+return array(
+	'plan_add' => array(
+		'title' => $lng['admin']['plans']['plan_add'],
+		'image' => 'icons/domain_add.png',
+		'sections' => array(
+			'section_a' => array(
+				'title' => $lng['admin']['servicedata'],
+				'image' => 'icons/user_add.png',
+				'fields' => array(
+					'plan_name' => array(
+						'label' => $lng['admin']['plans']['plan_name'],
+						'type' => 'text',
+						'mandatory' => true
+					),
+					'change_serversettings' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['change_serversettings'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array()
+					),
+					'customers' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['customers'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $customers_ul
+					),
+					'customers_see_all' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['customers_see_all'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array()
+					),
+					'domains' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['domains'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $domains_ul
+					),
+					'domains_see_all' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['domains_see_all'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array()
+					),
+					'caneditphpsettings' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['caneditphpsettings'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array()
+					),
+					'diskspace' => array(
+						'label' => $lng['customer']['diskspace'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 6,
+						'mandatory' => true,
+						'ul_field' => $diskspace_ul
+					),
+					'traffic' => array(
+						'label' => $lng['customer']['traffic'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 4,
+						'mandatory' => true,
+						'ul_field' => $traffic_ul
+					),
+					'subdomains' => array(
+						'label' => $lng['customer']['subdomains'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $subdomains_ul
+					),
+					'emails' => array(
+						'label' => $lng['customer']['emails'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $emails_ul
+					),
+					'email_accounts' => array(
+						'label' => $lng['customer']['accounts'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $email_accounts_ul
+					),
+					'email_forwarders' => array(
+						'label' => $lng['customer']['forwarders'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $email_forwarders_ul
+					),
+					'email_quota' => array(
+						'label' => $lng['customer']['email_quota'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'visible' => ($settings['system']['mail_quota_enabled'] == '1' ? true : false),
+						'mandatory' => true,
+						'ul_field' => $email_quota_ul
+					),
+					'email_autoresponder' => array(
+						'label' => $lng['customer']['autoresponder'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'visible' => ($settings['autoresponder']['autoresponder_active'] == '1' ? true : false),
+						'ul_field' => $email_autoresponder_ul
+					),
+					'email_imap' => array(
+						'label' => $lng['customer']['email_imap'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array('1'),
+						'mandatory' => true
+					),
+					'email_pop3' => array(
+						'label' => $lng['customer']['email_pop3'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array('1'),
+						'mandatory' => true
+					),
+					'ftps' => array(
+						'label' => $lng['customer']['ftps'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'ul_field' => $ftps_ul
+					),
+					'tickets' => array(
+						'label' => $lng['customer']['tickets'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'visible' => ($settings['ticket']['enabled'] == '1' ? true : false),
+						'ul_field' => $tickets_ul
+					),
+					'mysqls' => array(
+						'label' => $lng['customer']['mysqls'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $mysqls_ul
+					),
+					'phpenabled' => array(
+						'label' => $lng['admin']['phpenabled'].'?',
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array('1')
+					),
+					'perlenabled' => array(
+						'label' => $lng['admin']['perlenabled'].'?',
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									)
+					),
+					'backup_allowed' => array(
+						'label' => $lng['backup_allowed'].'?',
+						'type' => 'yesno',
+						'value' => 0,
+						'yesno_var' => $backup_allowed,
+						'visible' => (($settings['system']['backup_enabled'] == '1' && $plan_type == 1) ? true : false)
+					),
+					'can_manage_aps_packages' => array(
+						'label' => $lng['aps']['canmanagepackages'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array(),
+						'visible' => (($settings['aps']['aps_active'] == '1' && $plan_type == 0) ? true : false)
+					),
+					'number_of_aps_packages' => array(
+						'label' => $lng['aps']['numberofapspackages'],
+						'type' => 'textul',
+						'value' => 0,
+						'maxlength' => 9,
+						'visible' => ($settings['aps']['aps_active'] == '1' ? true : false),
+						'ul_field' => $number_of_aps_packages_ul
+					)
+				)
+			)
+		)
+	)
+);

--- a/lib/formfields/admin/plans/formfield.plan_edit.php
+++ b/lib/formfields/admin/plans/formfield.plan_edit.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Froxlor team <team@froxlor.org> (2010-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Formfields
+ *
+ */
+
+return array(
+	'plan_edit' => array(
+		'title' => $lng['admin']['plans']['plan_edit'],
+		'image' => 'icons/domain_edit.png',
+		'sections' => array(
+			'section_a' => array(
+				'title' => $lng['admin']['servicedata'],
+				'image' => 'icons/user_edit.png',
+				'fields' => array(
+					'plan_name' => array(
+						'label' => $lng['admin']['plans']['plan_name'],
+						'type' => 'text',
+						'value' => $result['plan_name'],
+						'mandatory' => true
+					),
+					'change_serversettings' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['change_serversettings'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['change_serversettings'])
+					),
+					'customers' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['customers'],
+						'type' => 'textul',
+						'value' => $result['customers'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $customers_ul
+					),
+					'customers_see_all' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['customers_see_all'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['customers_see_all'])
+					),
+					'domains' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['domains'],
+						'type' => 'textul',
+						'value' => $result['domains'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $domains_ul
+					),
+					'domains_see_all' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['domains_see_all'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['domains_see_all'])
+					),
+					'caneditphpsettings' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['admin']['caneditphpsettings'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['caneditphpsettings'])
+					),
+					'diskspace' => array(
+						'label' => $lng['customer']['diskspace'],
+						'type' => 'textul',
+						'value' => $result['diskspace'],
+						'maxlength' => 6,
+						'mandatory' => true,
+						'ul_field' => $diskspace_ul
+					),
+					'traffic' => array(
+						'label' => $lng['customer']['traffic'],
+						'type' => 'textul',
+						'value' => $result['traffic'],
+						'maxlength' => 4,
+						'mandatory' => true,
+						'ul_field' => $traffic_ul
+					),
+					'subdomains' => array(
+						'label' => $lng['customer']['subdomains'],
+						'type' => 'textul',
+						'value' => $result['subdomains'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $subdomains_ul
+					),
+					'emails' => array(
+						'label' => $lng['customer']['emails'],
+						'type' => 'textul',
+						'value' => $result['emails'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $emails_ul
+					),
+					'email_accounts' => array(
+						'label' => $lng['customer']['accounts'],
+						'type' => 'textul',
+						'value' => $result['email_accounts'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $email_accounts_ul
+					),
+					'email_forwarders' => array(
+						'label' => $lng['customer']['forwarders'],
+						'type' => 'textul',
+						'value' => $result['email_forwarders'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $email_forwarders_ul
+					),
+					'email_quota' => array(
+						'label' => $lng['customer']['email_quota'],
+						'type' => 'textul',
+						'value' => $result['email_quota'],
+						'maxlength' => 9,
+						'visible' => ($settings['system']['mail_quota_enabled'] == '1' ? true : false),
+						'mandatory' => true,
+						'ul_field' => $email_quota_ul
+					),
+					'email_autoresponder' => array(
+						'label' => $lng['customer']['autoresponder'],
+						'type' => 'textul',
+						'value' => $result['email_autoresponder'],
+						'maxlength' => 9,
+						'visible' => ($settings['autoresponder']['autoresponder_active'] == '1' ? true : false),
+						'ul_field' => $email_autoresponder_ul
+					),
+					'email_imap' => array(
+						'label' => $lng['customer']['email_imap'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['imap']),
+						'mandatory' => true
+					),
+					'email_pop3' => array(
+						'label' => $lng['customer']['email_pop3'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['pop3']),
+						'mandatory' => true
+					),
+					'ftps' => array(
+						'label' => $lng['customer']['ftps'],
+						'type' => 'textul',
+						'value' => $result['ftps'],
+						'maxlength' => 9,
+						'ul_field' => $ftps_ul
+					),
+					'tickets' => array(
+						'label' => $lng['customer']['tickets'],
+						'type' => 'textul',
+						'value' => $result['tickets'],
+						'maxlength' => 9,
+						'visible' => ($settings['ticket']['enabled'] == '1' ? true : false),
+						'ul_field' => $tickets_ul
+					),
+					'mysqls' => array(
+						'label' => $lng['customer']['mysqls'],
+						'type' => 'textul',
+						'value' => $result['mysqls'],
+						'maxlength' => 9,
+						'mandatory' => true,
+						'ul_field' => $mysqls_ul
+					),
+					'phpenabled' => array(
+						'label' => $lng['admin']['phpenabled'].'?',
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['phpenabled'])
+					),
+					'perlenabled' => array(
+						'label' => $lng['admin']['perlenabled'].'?',
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['perlenabled'])
+					),
+					'backup_allowed' => array(
+						'label' => $lng['backup_allowed'].'?',
+						'type' => 'yesno',
+						'value' => 0,
+						'yesno_var' => $backup_allowed,
+						'visible' => (($settings['system']['backup_enabled'] == '1' && $plan_type == 1) ? true : false)
+					),
+					'can_manage_aps_packages' => array(
+						'visible' => ($plan_type == 0 ? true : false),
+						'label' => $lng['aps']['canmanagepackages'],
+						'type' => 'checkbox',
+						'values' => array(
+										array ('label' => $lng['panel']['yes'], 'value' => '1')
+									),
+						'value' => array($result['can_manage_aps_packages']),
+						'visible' => ($settings['aps']['aps_active'] == '1' ? true : false)
+					),
+					'number_of_aps_packages' => array(
+						'label' => $lng['aps']['numberofapspackages'],
+						'type' => 'textul',
+						'value' => $result['aps_packages'],
+						'maxlength' => 9,
+						'visible' => ($settings['aps']['aps_active'] == '1' ? true : false),
+						'ul_field' => $number_of_aps_packages_ul
+					)
+				)
+			)
+		)
+	)
+);

--- a/lib/navigation/00.froxlor.main.php
+++ b/lib/navigation/00.froxlor.main.php
@@ -270,6 +270,10 @@ return array (
 					'url' => 'admin_message.php?page=message',
 					'label' => $lng['admin']['message'],
 				),
+				array (
+					'url' => 'admin_plans.php?page=plan',
+					'label' => $lng['admin']['plans']['plan'],
+				),
 			),
 		),
 	),

--- a/lib/tables.inc.php
+++ b/lib/tables.inc.php
@@ -54,6 +54,7 @@ define('TABLE_PANEL_REDIRECTCODES', 'redirect_codes');
 define('TABLE_PANEL_DOMAINREDIRECTS', 'domain_redirect_codes');
 define('TABLE_PANEL_IPDOCROOTSETTINGS', 'ipsandports_docrootsettings');
 define('TABLE_PANEL_DOMDOCROOTSETTINGS', 'domain_docrootsettings');
+define('TABLE_PANEL_PLANS', 'panel_plans');
 
 // APS constants
 

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1936,3 +1936,13 @@ $lng['serversettings']['enablewebfonts']['title'] = 'Enable usage of a google we
 $lng['serversettings']['enablewebfonts']['description'] = 'If enabled, the defined webfont is being used for the font-display';
 $lng['serversettings']['definewebfont']['title'] = 'Define a <a href="http://www.google.com/webfonts" rel="external">google-webfont</a> for the panel';
 $lng['serversettings']['definewebfont']['description'] = 'If enabled, this wefont will be used for the font-display.<br />Note: replace spaces with the "+" sign, e.g. "Open+Sans"';
+
+// ADDED IN 0.9.28-svn7
+$lng['admin']['plans']['plan'] = 'Hosting plans';
+$lng['admin']['plans']['usetemplate'] = 'Use predefined plan';
+$lng['admin']['plans']['plan_name'] = 'Plan name';
+$lng['admin']['plans']['plan_add'] = 'Create plan';
+$lng['admin']['plans']['plan_edit'] = 'Edit plan';
+$lng['admin']['plans']['plan_group'] = 'Plan for';
+$lng['question']['admin_plan_reallydelete'] = 'Do you really want to delete %s?';
+$lng['error']['nameexists'] = 'Plan name %s already exists or is not correct.';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1661,3 +1661,13 @@ $lng['serversettings']['enablewebfonts']['title'] = 'Verwende Google Webfonts im
 $lng['serversettings']['enablewebfonts']['description'] = 'Wenn aktiviert, wird die angegebene Google-Schriftart eingebunden und verwendet';
 $lng['serversettings']['definewebfont']['title'] = '<a href="http://www.google.com/webfonts" rel="external">Google Webfont</a> festlegen';
 $lng['serversettings']['definewebfont']['description'] = 'Wenn aktiviert, wird diese Schriftart im Panel verwendet.<br />Hinweis: Leerzeichen bitte mit einem "+" ersetzen, z.B. "Open+Sans"';
+
+// ADDED IN 0.9.28-svn7
+$lng['admin']['plans']['plan'] = 'Ressourcenvorlagen';
+$lng['admin']['plans']['usetemplate'] = 'Vordefinierte Vorlage nutzen';
+$lng['admin']['plans']['plan_name'] = 'Vorlagenname';
+$lng['admin']['plans']['plan_add'] = 'Neue Vorlage anlegen';
+$lng['admin']['plans']['plan_edit'] = 'Vorlage bearbeiten';
+$lng['admin']['plans']['plan_group'] = 'Vorlage f&uuml;r';
+$lng['question']['admin_plan_reallydelete'] = 'Wollen Sie die Ressourcenvorlage %s wirklich l&ouml;schen?';
+$lng['error']['nameexists'] = 'Der Vorlagenname %s ist nicht korrekt oder existiert bereits.';

--- a/templates/Froxlor/admin/plans/plans.tpl
+++ b/templates/Froxlor/admin/plans/plans.tpl
@@ -1,0 +1,65 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="templates/{$theme}/assets/img/icons/domains.png" alt="" />&nbsp;
+				{$lng['admin']['plans']['plan']}
+			</h2>
+		</header>
+
+		<section>
+
+			<form action="{$linker->getLink(array('section' => 'plans'))}" method="post" enctype="application/x-www-form-urlencoded">
+
+			<div class="overviewsearch">
+				{$searchcode}
+			</div>
+
+			<table class="bradiusodd table-striped">
+			<thead>
+				<tr>
+					<th>
+                        {$lng['customer']['name']}{$arrowcode['plan_name']}
+					</th>
+					<th>
+						{$lng['admin']['plans']['plan_group']}{$arrowcode['plan_type']}
+					</th>
+					<th>
+						{$lng['customer']['diskspace']}&nbsp;{$arrowcode['diskspace']}
+					</th>
+					<th>
+						{$lng['customer']['traffic']}&nbsp;{$arrowcode['traffic']}
+					</th>
+					<th>
+						{$lng['panel']['options']}
+					</th>
+				</tr>
+			</thead>
+			<if $pagingcode != ''>
+				<tfoot>
+					<tr>
+						<td>{$pagingcode}</td>
+					</tr>
+				</tfoot>
+			</if>
+			<tbody>
+				$plan
+			</tbody>
+			</table>
+
+			<p style="display:none;">
+				<input type="hidden" name="s" value="$s" />
+				<input type="hidden" name="page" value="$page" />
+			</p>
+
+			</form>
+
+			<div class="overviewadd">
+				<img src="templates/{$theme}/assets/img/icons/domain_add.png" alt="" />&nbsp;
+				<a class="btn" href="{$linker->getLink(array('section' => 'plans', 'page' => $page, 'action' => 'add'))}"><i class="icon-plus"></i> {$lng['admin']['plans']['plan_add']}</a>
+			</div>
+
+		</section>
+
+	</article>
+$footer

--- a/templates/Froxlor/admin/plans/plans_add_1.tpl
+++ b/templates/Froxlor/admin/plans/plans_add_1.tpl
@@ -1,0 +1,30 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="templates/{$theme}/assets/img/icons/domain_add.png" alt="" />&nbsp;
+				{$lng['admin']['plans']['plan_add']}
+			</h2>
+		</header>
+
+		<section class="tinyform bradiusodd">
+			<form method="post" action="{$linker->getLink(array('section' => 'plans'))}" enctype="application/x-www-form-urlencoded">
+				<fieldset>
+				<legend>Froxlor&nbsp;-&nbsp;{$lng['admin']['plans']['plan']}</legend>
+				<p>
+					<label for="plan_type">{$lng['admin']['plans']['plan_group']}:</label>&nbsp;
+					<select id="plan_type" name="plan_type">$plan_options</select>
+				</p>
+				<p class="submit">
+					<input type="hidden" name="s" value="$s" />
+					<input type="hidden" name="page" value="$page" />
+					<input type="hidden" name="action" value="$action" />
+					<input type="hidden" name="prepare" value="prepare" />
+					<input type="submit" value="{$lng['panel']['next']}" />
+				</p>
+				</fieldset>
+			</form>
+		</section>
+	</article>
+$footer
+

--- a/templates/Froxlor/admin/plans/plans_add_2.tpl
+++ b/templates/Froxlor/admin/plans/plans_add_2.tpl
@@ -1,0 +1,41 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="/templates/{$theme}/assets/img/{$image}" alt="{$title}" />&nbsp;
+				{$title}
+			</h2>
+		</header>
+
+		<section class="fullform bradiusodd">
+
+			<form action="{$linker->getLink(array('section' => 'plans'))}" method="post" enctype="application/x-www-form-urlencoded">
+				<fieldset>
+					<legend>Froxlor&nbsp;-&nbsp;{$title}</legend>
+
+					<table class="formtable">
+						{$plan_add_form}
+					</table>
+
+					<p style="display: none;">
+						<input type="hidden" name="plan_type" value="$plan_type" />
+						<input type="hidden" name="s" value="$s" />
+						<input type="hidden" name="page" value="$page" />
+						<input type="hidden" name="action" value="$action" />
+						<input type="hidden" name="send" value="send" />
+					</p>
+				</fieldset>
+			</form>
+
+		</section>
+
+	</article>
+	<br />
+	<article>
+		<section class="fullform bradiusodd">
+			<p style="margin-left:15px;">
+				<span style="color:#ff0000;">*</span>: {$lng['admin']['valuemandatory']}<br />
+			</p>
+		</section>
+	</article>
+$footer

--- a/templates/Froxlor/admin/plans/plans_edit.tpl
+++ b/templates/Froxlor/admin/plans/plans_edit.tpl
@@ -1,0 +1,41 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="/templates/{$theme}/assets/{$image}" alt="{$title}" />&nbsp;
+				{$title}
+			</h2>
+		</header>
+
+		<section class="fullform bradiusodd">
+
+			<form action="{$linker->getLink(array('section' => 'plans'))}" method="post" enctype="application/x-www-form-urlencoded">
+				<fieldset>
+					<legend>Froxlor&nbsp;-&nbsp;{$title}</legend>
+
+					<table class="formtable">
+						{$plan_edit_form}
+					</table>
+
+					<p style="display: none;">
+						<input type="hidden" name="s" value="$s" />
+						<input type="hidden" name="page" value="$page" />
+						<input type="hidden" name="action" value="$action" />
+						<input type="hidden" name="id" value="$id" />
+						<input type="hidden" name="send" value="send" />
+					</p>
+				</fieldset>
+			</form>
+
+		</section>
+
+	</article>
+	<br />
+	<article>
+		<section class="fullform bradiusodd">
+			<p style="margin-left:15px;">
+				<span style="color:#ff0000;">*</span>: {$lng['admin']['valuemandatory']}<br />
+			</p>
+		</section>
+	</article>
+$footer

--- a/templates/Froxlor/admin/plans/plans_plan.tpl
+++ b/templates/Froxlor/admin/plans/plans_plan.tpl
@@ -1,0 +1,26 @@
+<tr>
+	<td>{$row['plan_name']}</td>
+	<td>{$row['plan_type']}</td>
+	<td>
+		<if $row['diskspace'] != '-1'>
+			{$row['diskspace']}
+		<else>
+			{$lng['customer']['unlimited']}
+		</if>
+	</td>
+	<td>
+		<if $row['traffic'] != '-1'>
+			{$row['traffic']}
+		<else>
+			{$lng['customer']['unlimited']}
+		</if>
+	</td>
+	<td>
+		<a href="{$linker->getLink(array('section' => 'plans', 'page' => $page, 'action' => 'edit', 'id' => $row['planid']))}" style="text-decoration:none;">
+			<img src="/templates/{$theme}/assets/img/icons/edit.png" alt="{$lng['panel']['edit']}" />
+		</a>&nbsp;
+		<a href="{$linker->getLink(array('section' => 'plans', 'page' => $page, 'action' => 'delete', 'id' => $row['planid']))}" style="text-decoration:none;">
+			<img src="/templates/{$theme}/assets/img/icons/delete.png" alt="{$lng['panel']['delete']}" />
+		</a>
+	</td>
+</tr>

--- a/templates/Froxlor/assets/js/main.js
+++ b/templates/Froxlor/assets/js/main.js
@@ -74,6 +74,26 @@ $(document).ready(function() {
 		history.back();
 	});
 
+	function checkPlans(index, Element)
+	{
+		var $thisname = $(this).attr('name').substring(0, $(this).attr('name').length-3);
+		var $thisval = $(this).prop('checked');
+		$("table input[type=text][name="+$thisname+"]").prop('disabled', $thisval);
+	}
+	
+	$("#plan").change( function() {
+		$.get("admin_plans.php", { page: "show", s: $.getQueryVariable("s"), id: $(this).val() }, function(data){
+				$.each(data, function(key, value){
+					$("#"+key).val(value);
+					$("input[type=checkbox][name='"+key+"']").prop('checked', value);
+				});
+				$("table input[type=checkbox][name$=_ul]").each(checkPlans);
+		}, "json");
+	});
+
+	$("table input[type=checkbox][name$=_ul]").each(checkPlans);
+	$("table input[type=checkbox][name$=_ul]").change(checkPlans);
+
     $('input[name=speciallogfile]').click(function () {
             if($.getQueryVariable("page") == "domains" && $.getQueryVariable("action") == "edit") {
                     $speciallogdialog.dialog("open");


### PR DESCRIPTION
Adds new feature to Froxlor: solves tickets #673, #943, #139 and #79

This patch provides possibility to create predefined package templates.
When adding customers (or admins) you can optionally simply select a predefined template which fills out the form for you.

I don't know if this is interesting for you in one of the next versions?
