### PR TITLE
fix idna conversion for UTF-8

### DIFF
--- a/lib/classes/idna/class.idna_convert_wrapper.php
+++ b/lib/classes/idna/class.idna_convert_wrapper.php
@@ -124,7 +124,7 @@ class idna_convert_wrapper
 
 			if(strlen($domain) !== 0)
 			{
-				$domain = utf8_decode($this->idna_converter->$action(utf8_encode($domain . '.none')));
+				$domain = $this->idna_converter->$action($domain . '.none');
 				$domain = substr($domain, 0, strlen($domain) - 5);
 			}
 


### PR DESCRIPTION
Since Froxlor uses UTF-8 encoding IDN domains are converted wrong.
It's just a small change which was forgotten ;-)
