### PR TITLE
Bugfix when deleting customer, fix #1058

### DIFF
--- a/admin_customers.php
+++ b/admin_customers.php
@@ -279,7 +279,7 @@ if($page == 'customers'
 
 				if($result['email_autoresponder'] != '-1')
 				{
-					$admin_update_query.= ", `email_autoresponder` = `email_autoresponder` - 0" . (int)$result['email_autoresponder'];
+					$admin_update_query.= ", `email_autoresponder_used` = `email_autoresponder_used` - 0" . (int)$result['email_autoresponder'];
 				}
 
 				if($result['subdomains'] != '-1')
@@ -299,7 +299,7 @@ if($page == 'customers'
 
 				if($result['aps_packages'] != '-1')
 				{
-					$admin_update_query.= ", `aps_packages` = `aps_packages` - 0" . (int)$result['aps_packages'];
+					$admin_update_query.= ", `aps_packages_used` = `aps_packages_used` - 0" . (int)$result['aps_packages'];
 				}
 
 				if(($result['diskspace'] / 1024) != '-1')


### PR DESCRIPTION
When deleting a customer, the correct *_used values of the admin should be decreased afterwards (also for autoresponder and aps_packages).
Instead of that, the limit itself was decreased falsely.
