### PR TITLE
Changed executable dir for Postfix on Gentoo

### DIFF
--- a/templates/misc/configfiles/gentoo/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/gentoo/postfix_dovecot/etc_postfix_main.cf
@@ -1,7 +1,7 @@
 # Postfix programs paths settings
 command_directory = /usr/sbin
-daemon_directory = /usr/lib/postfix
-program_directory = /usr/lib/postfix
+daemon_directory = /usr/libexec/postfix
+program_directory = /usr/libexec/postfix
 sendmail_path = /usr/sbin/sendmail
 
 ## General Postfix configuration


### PR DESCRIPTION
See: http://redmine.froxlor.org/issues/1152
