### PR TITLE
Bug #1220: Added smtpd_relay_restrictions to all postfix configurations

### DIFF
--- a/templates/misc/configfiles/debian_squeeze/postfix_courier/etc_postfix_main.cf
+++ b/templates/misc/configfiles/debian_squeeze/postfix_courier/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/debian_squeeze/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/debian_squeeze/postfix_dovecot/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/debian_wheezy/postfix_courier/etc_postfix_main.cf
+++ b/templates/misc/configfiles/debian_wheezy/postfix_courier/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/debian_wheezy/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/debian_wheezy/postfix_dovecot/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/gentoo/postfix_courier/etc_postfix_main.cf
+++ b/templates/misc/configfiles/gentoo/postfix_courier/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (512MB)
 message_size_limit = 536870912
 

--- a/templates/misc/configfiles/gentoo/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/gentoo/postfix_dovecot/etc_postfix_main.cf
@@ -42,6 +42,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (512MB)
 message_size_limit = 536870912
 

--- a/templates/misc/configfiles/opensuse_11_x/postfix/etc_postfix_main.cf
+++ b/templates/misc/configfiles/opensuse_11_x/postfix/etc_postfix_main.cf
@@ -52,6 +52,7 @@ smtpd_helo_required = no
 smtpd_helo_restrictions =
 strict_rfc821_envelopes = no
 smtpd_recipient_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
+smtpd_relay_restrictions = 
 smtpd_sasl_auth_enable = yes
 smtpd_sasl_local_domain = $myhostname
 smtpd_sasl_security_options = noanonymous

--- a/templates/misc/configfiles/opensuse_11_x/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/opensuse_11_x/postfix_dovecot/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/sle_10/postfix/etc_postfix_main.cf
+++ b/templates/misc/configfiles/sle_10/postfix/etc_postfix_main.cf
@@ -53,6 +53,7 @@ smtpd_helo_required = no
 smtpd_helo_restrictions =
 strict_rfc821_envelopes = no
 smtpd_recipient_restrictions = permit_mynetworks permit_sasl_authenticated reject_unauth_destination
+smtpd_relay_restrictions = 
 smtpd_sasl_auth_enable = yes
 smtpd_sasl_local_domain = $myhostname
 smtpd_sasl_security_options = noanonymous

--- a/templates/misc/configfiles/ubuntu_lucid/postfix_courier/etc_postfix_main.cf
+++ b/templates/misc/configfiles/ubuntu_lucid/postfix_courier/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/ubuntu_lucid/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/ubuntu_lucid/postfix_dovecot/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/ubuntu_precise/postfix_courier/etc_postfix_main.cf
+++ b/templates/misc/configfiles/ubuntu_precise/postfix_courier/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 

--- a/templates/misc/configfiles/ubuntu_precise/postfix_dovecot/etc_postfix_main.cf
+++ b/templates/misc/configfiles/ubuntu_precise/postfix_dovecot/etc_postfix_main.cf
@@ -36,6 +36,11 @@ smtpd_sender_restrictions = permit_mynetworks,
 smtpd_client_restrictions = permit_mynetworks,
 	permit_sasl_authenticated,
 	reject_unknown_client_hostname
+
+# Postfix 2.10 requires this option. Postfix < 2.10 ignores this.
+# The option is intentionally left empty.
+smtpd_relay_restrictions = 
+
 # Maximum size of Message in bytes (50MB)
 message_size_limit = 52428800
 


### PR DESCRIPTION
Hi,

bitte die Änderungen in master pullen. 

Alle Änderungen sind für Bug #1220: Postfix 2.10 requires smtpd_relay_restrictions

LG,

5nafu
