### PR TITLE
White text on light background

### DIFF
--- a/templates/Froxlor/assets/css/main.css
+++ b/templates/Froxlor/assets/css/main.css
@@ -539,6 +539,7 @@ table tfoot td {
 
 /* input elements */
 input {
+	color: black;
 	background: #dae7ee url('../img/icons/text_align_left.png') no-repeat 5px 4px;
 	padding: 2px 4px 2px 22px;
 	border: 1px solid #666666;
@@ -550,6 +551,7 @@ input {
 }
 
 textarea {
+	color: black;
 	background: #dae7ee url('../img/icons/text_align_left.png') no-repeat 5px 4px;
 	padding: 4px 4px 2px 22px;
 	border: 1px solid #666666;
@@ -600,6 +602,7 @@ input[type="checkbox"] {
 }
 
 select {
+	color: black;
 	background: #dae7ee;
 	padding: 4px;
 	border: 1px solid #666666;


### PR DESCRIPTION
I'm using a variant of the GTK theme Xfce-dusk, so that my system colors are mainly dark background and white text. The main.css overrides my dark background with #dae7ee, but the foreground color remains the system color white with the result that text areas etc. are quite unreadable.
