### PR TITLE
Minor additions to ssl per vhost settings

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -691,11 +691,21 @@ class apache
 					// this makes it more secure, thx to Marcel (08/2013)
 					$vhost_content .= '  SSLHonorCipherOrder On' . "\n";
 					$vhost_content .= '  SSLCipherSuite ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH' . "\n";
+					$vhost_content .= '  SSLVerifyDepth 10' . "\n";
 					$vhost_content .= '  SSLCertificateFile ' . makeCorrectFile($domain['ssl_cert_file']) . "\n";
 
 					if ($domain['ssl_key_file'] != '') {
 						$vhost_content .= '  SSLCertificateKeyFile ' . makeCorrectFile($domain['ssl_key_file']) . "\n";
 					}
+
+					if ($domain['ssl_ca_file'] != '') {
+						$vhost_content .= '  SSLCACertificateFile ' . makeCorrectFile($domain['ssl_ca_file']) . "\n";
+					}
+
+					if ($domain['ssl_cert_chainfile'] != '') {
+						$vhost_content .= '  SSLCertificateChainFile ' . makeCorrectFile($domain['ssl_cert_chainfile']) . "\n";
+					}
+
 				}
 			}
 


### PR DESCRIPTION
Minor additions to ssl per vhost settings: add ssl CA cert and chainfail to ssl vhost

Besides that it seems to be working in apache. d00p, thanks a lot, great work! I love it!

Also added SSLVerifyDepth 10 wich is sometimes needed. 
The SSL Cipher Suite settings are imho not needed in every vhost and should be placed in the global ssl configuration. But I left them in for so far.

tilman19, tilman@3c7.de
