### PR TITLE
Update admin_ipsandports.php

### DIFF
--- a/admin_ipsandports.php
+++ b/admin_ipsandports.php
@@ -376,7 +376,7 @@ if ($page == 'ipsandports'
 
 				} else {
 
-					$upd_stmt = Datbase::prepare("
+					$upd_stmt = Database::prepare("
 						UPDATE `" . TABLE_PANEL_IPSANDPORTS . "`
 						SET
 							`ip` = :ip, `port` = :port, `listen_statement` = :ls,


### PR DESCRIPTION
Fix:  Fatal error: Uncaught exception 'Exception' with message 'Could not find class 'Datbase'' in /var/www/froxlor/lib/functions.php:126 Stack trace: #0 [internal function]: Autoloader->doAutoload('Datbase') #1 /var/www/froxlor/admin_ipsandports.php(379): spl_autoload_call('Datbase') #2 {main} thrown in /var/www/froxlor/lib/functions.php on line 126
