### PR TITLE
Renamed exceute() to execute() in class.FroxlorInstall.php

### DIFF
--- a/install/lib/class.FroxlorInstall.php
+++ b/install/lib/class.FroxlorInstall.php
@@ -403,7 +403,7 @@ class FroxlorInstall {
 	 * @param string $value
 	 */
 	private function _updateSetting(&$stmt = null, $value = null, $group = null, $varname = null) {
-		$stmt->exceute(array(
+		$stmt->execute(array(
 				'group' => $group,
 				'varname' => $varname,
 				'value' => $value


### PR DESCRIPTION
Just a small fix for a typo but enough to prevent installation.
