### PR TITLE
fixing config to work with concrete5

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.35.nginx_phpfpm.php
+++ b/scripts/jobs/cron_tasks.inc.http.35.nginx_phpfpm.php
@@ -27,7 +27,6 @@ class nginx_phpfpm extends nginx
 			$phpconfig = $php->getPhpConfig((int)$domain['phpsettingid']);
 			
 			$php_options_text = "\t".'location ~ \.php$ {'."\n";
-			$php_options_text.= "\t\t".'try_files $uri =404;'."\n";
 			$php_options_text.= "\t\t".'fastcgi_split_path_info ^(.+\.php)(/.+)$;'."\n";
 			$php_options_text.= "\t\t".'fastcgi_pass unix:' . $php->getInterface()->getSocketFile() . ';' . "\n";
 			$php_options_text.= "\t\t".'fastcgi_index index.php;'."\n";


### PR DESCRIPTION
The "try_files $uri =404;" config is not needed for anything but breaks concrete5 functionality. Stuff like WordPress still works just fine.
