### PR TITLE
override fg color to obtain readability

### DIFF
--- a/install/templates/assets/css/install.css
+++ b/install/templates/assets/css/install.css
@@ -415,7 +415,7 @@ table tfoot td {
 /* input elements */
 input {
 	background: #fff url(../img/text_align_left.png) no-repeat 5px 4px;
-	color: black;
+	color: #333;
 	padding:2px 4px 2px 24px;
 	height:22px;
 	border: 1px solid #d9d9d9;
@@ -425,7 +425,7 @@ input {
 
 textarea {
 	background:#fff url(../img/text_align_left.png) no-repeat 5px 4px;
-	color: black;
+	color: #333;
 	padding:4px 4px 2px 24px;
 	border:1px solid #d9d9d9;
 	margin-bottom: 5px;
@@ -503,7 +503,7 @@ input[type="radio"] {
 select {
 	background:#fff;
 	padding:4px;
-	color: black;
+	color: #333;
 	border:1px solid #d9d9d9;
 	margin-bottom: 5px;
 	min-width: 100px;

--- a/templates/Sparkle/assets/css/main.css
+++ b/templates/Sparkle/assets/css/main.css
@@ -662,7 +662,7 @@ table tfoot td {
 /* input elements */
 input {
 	background:#fff url(../img/icons/text_align_left.png) no-repeat 5px 4px;
-	color: black;
+	color: #333;
 	padding:1px 4px 2px 24px;
 	height:23px;
 	border:1px solid #d9d9d9;
@@ -672,7 +672,7 @@ input {
 
 textarea {
 	background:#fff url(../img/icons/text_align_left.png) no-repeat 5px 4px;
-	color: black;
+	color: #333;
 	padding:4px 4px 2px 24px;
 	border:1px solid #d9d9d9;
 	margin-bottom:5px;
@@ -756,7 +756,7 @@ input[type="checkbox"] {
 
 select {
 	padding:2px 4px 2px 24px;
-	color: black;
+	color: #333;
 	height:28px;
 	border:1px solid #d9d9d9;
 	margin:0 5px 5px 0!important;


### PR DESCRIPTION
Setting a css bg color without setting a fg color will use the system default as fg and thus can result in unreadable text.
