### PR TITLE
Fix Safari checkbox-bug

### DIFF
--- a/templates/Sparkle/assets/css/main.css
+++ b/templates/Sparkle/assets/css/main.css
@@ -651,6 +651,8 @@ input[type="checkbox"] {
 	padding:0;
 	margin:0 5px 0 0;
 	vertical-align:middle;
+	/* Fix Safari-Bug */
+	height: auto;
 }
 
 select {


### PR DESCRIPTION
If checkbox is focused (clicking in the checkbox) checkbox shifts downward. I think: Only in Safari on Yosemite. Other browsers not affected.
