### PR TITLE
PHPinfo() page breaks if preg match fails

### DIFF
--- a/admin_settings.php
+++ b/admin_settings.php
@@ -143,7 +143,14 @@ if ($page == 'overview' && $userinfo['change_serversettings'] == '1') {
 			eval("\$phpinfohtml .= \"" . getTemplate("settings/phpinfo/phpinfo_table") . "\";");
 		}
 		$phpinfo = $phpinfohtml;
+	} else {
+	    $phpinfo = 'No PHP configuration data available.';
+
+        if (function_exists('phpversion')) {
+            $phpinfo .= ' You are currently running version ' . phpversion();
+        }
 	}
+
 	eval("echo \"" . getTemplate("settings/phpinfo") . "\";");
 
 } elseif($page == 'rebuildconfigs'


### PR DESCRIPTION
If the preg match fails for some reason (with HHVM 4.3.0 for example), the PHPinfo() page breaks and shows an array to string conversion error. Can be easily fixed by adding an else statement and showing a default message.
