### PR TITLE
Nginx cronjob improvements

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -419,7 +419,7 @@ class nginx {
 				) {
 					$vhost_content.= $this->composeSslSettings($domain);
 				}
-				$vhost_content = $this->mergeVhostCustom($vhost_content, $this->create_pathOptions($domain));
+				$vhost_content = $this->mergeVhostCustom($vhost_content, $this->create_pathOptions($domain)) . "\n";
 				$vhost_content.= $this->composePhpOptions($domain, $ssl_vhost);
 
 				$vhost_content.= isset($this->needed_htpasswds[$domain['id']]) ? $this->needed_htpasswds[$domain['id']] . "\n" : '';


### PR DESCRIPTION
1. Commit adbc4bc:
   Take the corresponding authname instead of the constant string "Restricted area".
2. Commit 8842c02:
   Fixes wrong indentation of location-blocks, when basic auth is used (bug introduced in c6ed0b6).
   To give an example:
   ...
   location /subfolder/ {
   auth_basic "realname";
   auth_basic_user_file /etc/nginx/froxlor-htpasswd/2-a2d3f4g5h6.htpasswd;
   }location ~ .php {
   fastcgi_split_path_info ^(.+.php)(/.+)$;
   ...
