### PR TITLE
Fix for duplicate .htpasswd entries (Nginx)

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -1013,6 +1013,8 @@ class nginx {
 				foreach ($this->htpasswds_data as $htpasswd_filename => $htpasswd_file) {
 					$this->known_htpasswdsfilenames[] = basename($htpasswd_filename);
 					$htpasswd_file_handler = fopen($htpasswd_filename, 'w');
+					// Filter duplicate pairs of username and password
+					$htpasswd_file = implode("\n", array_unique(explode("\n", $htpasswd_file)));
 					fwrite($htpasswd_file_handler, $htpasswd_file);
 					fclose($htpasswd_file_handler);
 				}


### PR DESCRIPTION
Problem:
The cronjob for Nginx Vhosts creates an individual .htpasswd file for each protected paths. Since the method getHtpasswds() is called for all (sub-)domains of a specific customer, it occurs that the same pairs of user / pw are inserted multiple times into one .htpasswd file.

For example, assuming a customer has 3 domains, getHtpasswds() is invoked three times and each time adds the same credentials to the very same $htpasswd_filename. The resulting .htpasswd files look as follows:
user1:pass1
user1:pass1
user1:pass1

Solution:
Filter duplicate entries before writing out the .htpasswd file.
