### PR TITLE
Update german.lng.php

### DIFF
--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1419,7 +1419,7 @@ $lng['admin']['domain_editable']['desc'] = 'Wenn ja, darf der Kunde verschiedene
 // Added in Froxlor 0.9.29-dev
 $lng['serversettings']['panel_phpconfigs_hidestdsubdomain']['title'] = 'Verstecke Standard-Subdomains in PHP-Konfigurations-Übersicht';
 $lng['serversettings']['panel_phpconfigs_hidestdsubdomain']['description'] = 'Wenn aktiviert, werden die Standard-Subdomains der Kunden nicht mehr in der PHP-Konfigurations-Übersicht angezeigt.<br /><br />Hinweis: Nur relevant, wenn FCGID oder PHP-FPM aktiviert ist.';
-$lng['serversettings']['passwordcryptfunc']['title'] = 'Wähle zu verwendende Passwort-Verschlüsselungsmethode';
+$lng['serversettings']['passwordcryptfunc']['title'] = 'Wähle zu verwendende Passwort-Speichermethode';
 $lng['serversettings']['systemdefault'] = 'Systemstandard';
 $lng['serversettings']['panel_allow_theme_change_admin'] = 'Erlaube Admins das Theme zu wechseln';
 $lng['serversettings']['panel_allow_theme_change_customer'] = 'Erlaube Kunden das Theme zu wechseln';


### PR DESCRIPTION
Hashs sind __keine__ Verschlüsselung, daher Umbenennung.