### PR TITLE
Fix typos found by codespell

### DIFF
--- a/customer_extras.php
+++ b/customer_extras.php
@@ -270,7 +270,7 @@ if ($page == 'overview') {
 			if ($paging->checkDisplay($i)) {
 				if (strpos($row['path'], $userinfo['documentroot']) === 0) {
 					$row['path'] = substr($row['path'], strlen($userinfo['documentroot']));
-					// don't show nothing wehn it's the docroot, show slash
+					// don't show nothing when it's the docroot, show slash
 					if ($row['path'] == '') { $row['path'] = '/'; }
 				}
 
@@ -445,7 +445,7 @@ if ($page == 'overview') {
 			} else {
 				if (strpos($result['path'], $userinfo['documentroot']) === 0) {
 					$result['path'] = substr($result['path'], strlen($userinfo['documentroot']));
-					// don't show nothing wehn it's the docroot, show slash
+					// don't show nothing when it's the docroot, show slash
 					if ($result['path'] == '') { $result['path'] = '/'; }
 				}
 

--- a/install/lib/class.FroxlorInstall.php
+++ b/install/lib/class.FroxlorInstall.php
@@ -1039,7 +1039,7 @@ class FroxlorInstall {
 	private function _getTemplate($template = null) {
 		// build filename
 		$filename = $this->_basepath.'/install/templates/' . $template . '.tpl';
-		// check existance
+		// check existence
 		if(file_exists($filename)
 				&& is_readable($filename)
 		) {
@@ -1222,7 +1222,7 @@ class FroxlorInstall {
 		// we don't actually care about the matches preg gives us.
 		$matches = array();
 
-		// this is faster than calling count($oktens) every time thru the loop.
+		// this is faster than calling count($tokens) every time through the loop.
 		$token_count = count($tokens);
 		for ($i = 0; $i < $token_count; $i++) {
 			// Don't wanna add an empty string as the last thing in the array.

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -1961,7 +1961,7 @@ if (isFroxlorVersion('0.9.28-svn2')) {
 	showUpdateStep("Updating from 0.9.28-svn2 to 0.9.28-svn3");
 	lastStepStatus(0);
 
-	// change lenght of passwd column
+	// change length of passwd column
 	Database::query("ALTER TABLE `" . TABLE_FTP_USERS . "` MODIFY `password` varchar(128) NOT NULL default ''");
 
 	// Add default setting for vmail_maildirname if not already in place

--- a/install/updates/preconfig/0.9/preconfig_0.9.inc.php
+++ b/install/updates/preconfig/0.9/preconfig_0.9.inc.php
@@ -663,7 +663,7 @@ function parseAndOutputPreconfig(&$has_preconfig, &$return, $current_version) {
 		$description  = 'You can enable/disable the display/usage of the custom newsfeed for customers.<br /><br />';
 		$question = '<strong>Do you want to enable the custom newsfeed for customer? (default: no):</strong>&nbsp;';
 		$question.= makeyesno('customer_show_news_feed', '1', '0', '0').'<br />';
-		$question.= '<strong>You have to set the URL for your RSS-feed here, if you have choosen to enable the custom newsfeed on the customer-dashboard:</strong>&nbsp;';
+		$question.= '<strong>You have to set the URL for your RSS-feed here, if you have chosen to enable the custom newsfeed on the customer-dashboard:</strong>&nbsp;';
 		$question.= '<input type="text" class="text" name="customer_news_feed_url" value="" /><br />';
 		eval("\$return.=\"" . getTemplate("update/preconfigitem") . "\";");
 	}

--- a/lib/classes/Smarty-3.1.21/README
+++ b/lib/classes/Smarty-3.1.21/README
@@ -260,7 +260,7 @@ Example: {$object->method1($x)->method2($y)}
 {for} tag added for looping (replacement for {section} tag):
 {for $x=0, $y=count($foo); $x<$y; $x++}  ....  {/for}
 Any number of statements can be used separated by comma as the first
-inital expression at {for}.
+initial expression at {for}.
 
 {for $x = $start to $end step $step} ... {/for}is in the SVN now .
 You can use also

--- a/lib/classes/Smarty-3.1.21/SMARTY_3.1_NOTES.txt
+++ b/lib/classes/Smarty-3.1.21/SMARTY_3.1_NOTES.txt
@@ -50,7 +50,7 @@ The escape modifier now knows the $double_encode option, which will
 prevent entities from being encoded again.
 
 The capitalize modifier now know the $lc_rest option, which makes sure
-all letters following a captial letter are lower-cased.
+all letters following a capital letter are lower-cased.
 
 The count_sentences modifier now accepts (.?!) as
 legitimate endings of a sentence - previously only (.) was

--- a/lib/classes/Smarty-3.1.21/change_log.txt
+++ b/lib/classes/Smarty-3.1.21/change_log.txt
@@ -784,7 +784,7 @@
 - bugfix complete empty inline subtemplates did fail
 
 15/06/2011
-- bugfix template variables where not accessable within inline subtemplates
+- bugfix template variables where not accessible within inline subtemplates
 
 12/06/2011
 - bugfix removed unneeded merging of template variable when fetching includled subtemplates
@@ -1122,7 +1122,7 @@
 17/11/2010
 - bugfix on {call} with variable function name
 - bugfix on {block} if name did contain '-'
-- bugfix in function.fetch.php , referece to undefined $smarty
+- bugfix in function.fetch.php , reference to undefined $smarty
 
 16/11/2010
 - bugfix whitespace in front of "<?php" in smarty_internal_compile_private_block_plugin.php
@@ -1629,7 +1629,7 @@ request_use_auto_globals
 - bugfix for custom delimiter at extends resource and {extends} tag
 
 01/05/2010
-- bugfix sha1() calculations at extends resource and some general improvments on sha1() handling 
+- bugfix sha1() calculations at extends resource and some general improvements on sha1() handling
 
 
 01/03/2010
@@ -1722,7 +1722,7 @@ request_use_auto_globals
 - bugfix for {$foo.$x.$y.$z}
 
 12/01/2009
-- fixed parsing of names of special formated tags like if,elseif,while,for,foreach
+- fixed parsing of names of special formatted tags like if,elseif,while,for,foreach
 - removed direct access to constants in templates because of some syntax problems
 - removed cache resource plugin for mysql from the distribution
 - replaced most hard errors (exceptions) by softerrors(trigger_error) in plugins
@@ -1986,7 +1986,7 @@ NOTICE: existing compiled template and cache files must be deleted
 - added global variable SCRIPT_NAME
 
 08/21/2009
-- fixed problems whitespace in conjuction with custom delimiters
+- fixed problems whitespace in conjunction with custom delimiters
 - Smarty tags can now be used as value anywhere
 
 08/18/2009
@@ -2389,7 +2389,7 @@ NOTICE: existing compiled template and cache files must be deleted
 12/30/2008
 - added compiler support of registered object 
 - added backtick support in doubled quoted strings for backward compatibility
-- some minor bug fixes and improvments
+- some minor bug fixes and improvements
 
 12/23/2008
 - fixed problem of not working "not" operator in if-expressions

--- a/lib/classes/Smarty-3.1.21/change_log.txt
+++ b/lib/classes/Smarty-3.1.21/change_log.txt
@@ -1955,7 +1955,7 @@ NOTICE: existing compiled template and cache files must be deleted
 09/01/2009
 - dropped nl2br as plugin
 - added '<>' as comparission operator in {if} tags
-- cached caching_lifetime property to cache_liftime for backward compatibility with Smarty2.
+- cached caching_lifetime property to cache_lifetime for backward compatibility with Smarty2.
   {include} optional attribute is also now cache_lifetime
 - fixed trigger_error method (moved into Smarty class)
 - version is now  Beta!!!

--- a/lib/classes/Smarty-3.1.21/libs/SmartyBC.class.php
+++ b/lib/classes/Smarty-3.1.21/libs/SmartyBC.class.php
@@ -31,7 +31,7 @@
 require_once(dirname(__FILE__) . '/Smarty.class.php');
 
 /**
- * Smarty Backward Compatability Wrapper Class
+ * Smarty Backward Compatibility Wrapper Class
  *
  * @package Smarty
  */

--- a/lib/classes/Smarty-3.1.21/libs/sysplugins/smarty_internal_template.php
+++ b/lib/classes/Smarty-3.1.21/libs/sysplugins/smarty_internal_template.php
@@ -203,7 +203,7 @@ class Smarty_Internal_Template extends Smarty_Internal_TemplateBase
             }
             throw $e;
         }
-        // compiling succeded
+        // compiling succeeded
         if (!$this->source->recompiled && $this->compiler->write_compiled_code) {
             // write compiled template
             $_filepath = $this->compiled->filepath;

--- a/lib/classes/Smarty-3.1.21/libs/sysplugins/smarty_internal_templatebase.php
+++ b/lib/classes/Smarty-3.1.21/libs/sysplugins/smarty_internal_templatebase.php
@@ -231,7 +231,7 @@ abstract class Smarty_Internal_TemplateBase extends Smarty_Internal_Data
             if ($this->smarty->debugging) {
                 Smarty_Internal_Debug::end_render($_template);
             }
-            // write to cache when nessecary
+            // write to cache when necessary
             if (!$_template->source->recompiled && ($_template->caching == Smarty::CACHING_LIFETIME_SAVED || $_template->caching == Smarty::CACHING_LIFETIME_CURRENT)) {
                 if ($this->smarty->debugging) {
                     Smarty_Internal_Debug::start_cache($_template);

--- a/lib/classes/idna/class.idna_convert.php
+++ b/lib/classes/idna/class.idna_convert.php
@@ -44,7 +44,7 @@
  *
  * Unicode input might be given as either UTF-8 string, UCS-4 string or UCS-4 array.
  * Unicode output is available in the same formats.
- * You can select your preferred format via {@link set_paramter()}.
+ * You can select your preferred format via {@link set_parameter()}.
  *
  * ACE input and output is always expected to be ASCII.
  *
@@ -80,7 +80,7 @@ class idna_convert
 
     protected static $_mb_string_overload = null;
 
-    // See {@link set_paramter()} for details of how to change the following
+    // See {@link set_parameter()} for details of how to change the following
     // settings from within your script / application
     protected $_api_encoding = 'utf8';   // Default input charset is UTF-8
     protected $_allow_overlong = false;  // Overlong UTF-8 encodings are forbidden
@@ -630,7 +630,7 @@ class idna_convert
             } elseif (($this->_idn_version == '2003') && isset(self::$NP['replacemaps'][$v])) {
                 // There's a decomposition mapping for that code point
                 // Decompositions only in version 2003 (original) of IDNA
-                foreach ($this->_apply_cannonical_ordering(self::$NP['replacemaps'][$v]) as $out) {
+                foreach ($this->_apply_canonical_ordering(self::$NP['replacemaps'][$v]) as $out) {
                     $output[] = (int) $out;
                 }
             } else {
@@ -747,7 +747,7 @@ class idna_convert
      * @param    array      Decomposed UCS4 sequence
      * @return   array      Ordered USC4 sequence
      */
-    protected function _apply_cannonical_ordering($input)
+    protected function _apply_canonical_ordering($input)
     {
         $swap = true;
         $size = count($input);

--- a/lib/classes/idna/class.idna_convert.php
+++ b/lib/classes/idna/class.idna_convert.php
@@ -388,9 +388,9 @@ class idna_convert
     }
 
     /**
-     * Use this method to get the last error ocurred
+     * Use this method to get the last error occurred
      * @param    void
-     * @return   string   The last error, that occured
+     * @return   string   The last error, that occurred
      */
     public function get_last_error()
     {
@@ -416,7 +416,7 @@ class idna_convert
             $this->_error('The given encoded string was empty');
             return false;
         }
-        // Find last occurence of the delimiter
+        // Find last occurrence of the delimiter
         $delim_pos = strrpos($encoded, '-');
         if ($delim_pos > self::byteLength($this->_punycode_prefix)) {
             for ($k = self::byteLength($this->_punycode_prefix); $k < $delim_pos; ++$k) {
@@ -606,7 +606,7 @@ class idna_convert
         // Mapping
         // Walking through the input array, performing the required steps on each of
         // the input chars and putting the result into the output array
-        // While mapping required chars we apply the cannonical ordering
+        // While mapping required chars we apply the canonical ordering
         foreach ($input as $v) {
             // Map to nothing == skip that code point
             if (in_array($v, self::$NP['map_nothing'])) continue;
@@ -743,7 +743,7 @@ class idna_convert
     }
 
     /**
-     * Applies the cannonical ordering of a decomposed UCS4 sequence
+     * Applies the canonical ordering of a decomposed UCS4 sequence
      * @param    array      Decomposed UCS4 sequence
      * @return   array      Ordered USC4 sequence
      */

--- a/lib/classes/idna/class.idna_convert_wrapper.php
+++ b/lib/classes/idna/class.idna_convert_wrapper.php
@@ -44,10 +44,10 @@ class idna_convert_wrapper
 	 * Encode a domain name, a email address or a list of one of both.
 	 *
 	 * @param string May be either a single domain name, e single email address or a list of one
-	 * seperated either by ',', ';' or ' '.
+	 * separated either by ',', ';' or ' '.
 	 *
 	 * @return string Returns either a single domain name, a single email address or a list of one of
-	 * both seperated by the same string as the input.
+	 * both separated by the same string as the input.
 	 */
 
 	public function encode($to_encode)
@@ -59,10 +59,10 @@ class idna_convert_wrapper
 	 * Decode a domain name, a email address or a list of one of both.
 	 *
 	 * @param string May be either a single domain name, e single email address or a list of one
-	 * seperated either by ',', ';' or ' '.
+	 * separated either by ',', ';' or ' '.
 	 *
 	 * @return string Returns either a single domain name, a single email address or a list of one of
-	 * both seperated by the same string as the input.
+	 * both separated by the same string as the input.
 	 */
 
 	public function decode($to_decode)
@@ -71,7 +71,7 @@ class idna_convert_wrapper
 	}
 
 	/**
-	 * Do the real de- or encoding. First checks if a list is submitted and seperates it. Afterwards sends
+	 * Do the real de- or encoding. First checks if a list is submitted and separates it. Afterwards sends
 	 * each entry to the idna converter to do the converting.
 	 *
 	 * @param string May be either 'decode' or 'encode'.

--- a/lib/classes/integrity/class.IntegrityCheck.php
+++ b/lib/classes/integrity/class.IntegrityCheck.php
@@ -45,7 +45,7 @@ class IntegrityCheck {
 	}
 
 	/**
-	 * Check all occuring integrity problems at once
+	 * Check all occurring integrity problems at once
 	 */
 	public function checkAll() {
 		$integrityok = true;
@@ -56,7 +56,7 @@ class IntegrityCheck {
 	}
 
 	/**
-	 * Fix all occuring integrity problems at once with default settings
+	 * Fix all occurring integrity problems at once with default settings
 	 */
 	public function fixAll() {
 		$integrityok = true;

--- a/lib/classes/phpinterface/class.phpinterface_fpm.php
+++ b/lib/classes/phpinterface/class.phpinterface_fpm.php
@@ -269,7 +269,7 @@ class phpinterface_fpm {
 				$is = explode("=", $inisection);
 				foreach ($this->_ini as $sec => $possibles) {
 					if (in_array(trim($is[0]), $possibles)) {
-						// check explictly for open_basedir
+						// check explicitly for open_basedir
 						if (trim($is[0]) == 'open_basedir' && $openbasedir == '') {
 							continue;
 						}

--- a/lib/configfiles/wheezy.inc.php
+++ b/lib/configfiles/wheezy.inc.php
@@ -435,7 +435,7 @@ return array(
 					'php-fpm' => array(
 						'label' => 'PHP-FPM',
 						'commands' => array(
-							(Settings::Get('system.webserver') == 'apache2') ? '# add "non-free" after all occurances of "main" in /etc/apt/sources.list' : null,
+							(Settings::Get('system.webserver') == 'apache2') ? '# add "non-free" after all occurrences of "main" in /etc/apt/sources.list' : null,
 							(Settings::Get('system.webserver') == 'apache2') ? '# this is needed for libapache2-mod-fastcgi to install' : null,
 							'apt-get install '.((Settings::Get('system.webserver') == 'apache2') ? 'apache2-suexec libapache2-mod-fastcgi ' : '') . 'php5-fpm',
 							'rm /etc/php5/fpm/pool.d/www.conf',

--- a/lib/cron_init.php
+++ b/lib/cron_init.php
@@ -122,7 +122,7 @@ while ($fName = readdir($lockDirHandle)) {
 		system("kill -CHLD " . (int)$check_pid . " 1> /dev/null 2> /dev/null", $check_pid_return);
 
 		if ($check_pid_return == 1) {
-			// Result:      Existing lockfile/pid isnt running
+			// Result:      Existing lockfile/pid isn't running
 			//              Most likely it has died
 			//
 			// Action:      Remove it and continue
@@ -188,7 +188,7 @@ if (Settings::Get('panel.version') == null
 		 */
 		fclose($debugHandler);
 		unlink($lockfile);
-		$errormessage = "Version of file doesnt match version of database. Exiting...\n\n";
+		$errormessage = "Version of file doesn't match version of database. Exiting...\n\n";
 		$errormessage.= "Possible reason: Froxlor update\n";
 		$errormessage.= "Information: Current version in database: ".Settings::Get('panel.version')." - version of Froxlor files: ".$version."\n";
 		$errormessage.= "Solution: Please visit your Foxlor admin interface for further information.\n";

--- a/lib/functions/filedir/function.findDirs.php
+++ b/lib/functions/filedir/function.findDirs.php
@@ -27,7 +27,7 @@
  * @param  int $uid the uid which must match the found directories
  * @param  int $gid the gid which must match the found direcotries
  *
- * @return array Array of found valid pathes
+ * @return array Array of found valid paths
  */
 function findDirs($path, $uid, $gid) {
 

--- a/lib/functions/filedir/function.makePathfield.php
+++ b/lib/functions/filedir/function.makePathfield.php
@@ -18,14 +18,14 @@
  */
 
 /**
- * Returns a valid html tag for the choosen $fieldType for pathes
+ * Returns a valid html tag for the chosen $fieldType for paths
  *
  * @param string  path      The path to start searching in
  * @param integer uid       The uid which must match the found directories
  * @param integer gid       The gid which must match the found direcotries
  * @param string  value     the value for the input-field
  *
- * @return string   The html tag for the choosen $fieldType
+ * @return string   The html tag for the chosen $fieldType
  *
  * @author Martin Burchert  <martin.burchert@syscp.de>
  * @author Manuel Bernhardt <manuel.bernhardt@syscp.de>

--- a/lib/functions/froxlor/function.moveCustomerToAdmin.php
+++ b/lib/functions/froxlor/function.moveCustomerToAdmin.php
@@ -7,7 +7,7 @@
  * @param int $id customer-id
  * @param int $adminid target-admin-id
  *
- * @return true on sucess, error-message on failure
+ * @return true on success, error-message on failure
  */
 function moveCustomerToAdmin($id = 0, $adminid = 0) {
 	if ($id <= 0 || $adminid <= 0) {

--- a/lib/functions/phphelpers/function.replace_variables.php
+++ b/lib/functions/phphelpers/function.replace_variables.php
@@ -18,7 +18,7 @@
  */
 
 /**
- * Replaces all occurences of variables defined in the second argument
+ * Replaces all occurrences of variables defined in the second argument
  * in the first argument with their values.
  *
  * @param string The string that should be searched for variables

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -215,7 +215,7 @@ $lng['error']['nolanguageselect'] = 'No language selected.';
 $lng['error']['nosubjectcreate'] = 'You must define a topic for this mail template.';
 $lng['error']['nomailbodycreate'] = 'You must define a mail-text for this mail template.';
 $lng['error']['templatenotfound'] = 'Template was not found.';
-$lng['error']['alltemplatesdefined'] = 'You cant define more templates, all languages are supported already.';
+$lng['error']['alltemplatesdefined'] = 'You can\'t define more templates, all languages are supported already.';
 $lng['error']['wwwnotallowed'] = 'www is not allowed for subdomains.';
 $lng['error']['subdomainiswrong'] = 'The subdomain %s contains invalid characters.';
 $lng['error']['domaincantbeempty'] = 'The domain-name can not be empty.';
@@ -376,7 +376,7 @@ $lng['serversettings']['pathedit']['description'] = 'Should a path be selected b
 $lng['serversettings']['nameservers']['title'] = 'Nameservers';
 $lng['serversettings']['nameservers']['description'] = 'A comma separated list containing the hostnames of all nameservers. The first one will be the primary one.';
 $lng['serversettings']['mxservers']['title'] = 'MX servers';
-$lng['serversettings']['mxservers']['description'] = 'A comma seperated list containing a pair of a number and a hostname separated by whitespace (e.g. \'10 mx.example.com\') containing the mx servers.';
+$lng['serversettings']['mxservers']['description'] = 'A comma separated list containing a pair of a number and a hostname separated by whitespace (e.g. \'10 mx.example.com\') containing the mx servers.';
 
 /**
  * CHANGED BETWEEN 1.2.12 and 1.2.13
@@ -1024,7 +1024,7 @@ $lng['serversettings']['ssl']['ssl_ca_file']['description'] = 'Client authentifi
 $lng['error']['usernamealreadyexists'] = 'The username %s already exists.';
 
 $lng['error']['plausibilitychecknotunderstood'] = 'Answer of plausibility check not understood.';
-$lng['error']['errorwhensaving'] = 'An error occured when saving the field %s';
+$lng['error']['errorwhensaving'] = 'An error occurred when saving the field %s';
 
 $lng['success']['success'] = 'Information';
 $lng['success']['clickheretocontinue'] = 'Click here to continue';
@@ -1344,7 +1344,7 @@ $lng['emails']['back_to_overview'] = 'Back to overview';
 // ADDED IN FROXLOR 0.9.20
 $lng['error']['user_banned'] = 'Your account has been locked. Please contact your administrator for further information.';
 $lng['serversettings']['validate_domain'] = 'Validate domain names';
-$lng['login']['combination_not_found'] = 'Combination of user and email adress not found.';
+$lng['login']['combination_not_found'] = 'Combination of user and email address not found.';
 $lng['customer']['generated_pwd'] = 'Password suggestion';
 $lng['customer']['usedmax'] = 'Used / Max';
 $lng['admin']['traffic'] = 'Traffic';

--- a/locales/de/LC_MESSAGES/default.po
+++ b/locales/de/LC_MESSAGES/default.po
@@ -377,7 +377,7 @@ msgstr "Die Datei '%1$s' konnte nicht gespeichert werden!"
 #: webftp.php:747
 #: webftp.php:693
 #, php-format
-msgid "File '%1$s' was saved succesfully!"
+msgid "File '%1$s' was saved successfully!"
 msgstr "Die Datei '%1$s' wurde erfolgreich gespeichert!"
 
 #: webftp.php:754

--- a/locales/en/LC_MESSAGES/default.po
+++ b/locales/en/LC_MESSAGES/default.po
@@ -133,7 +133,7 @@ msgstr ""
 
 #: webftp.php:693
 #, php-format
-msgid "File '%1$s' was saved succesfully!"
+msgid "File '%1$s' was saved successfully!"
 msgstr ""
 
 #: webftp.php:700

--- a/scripts/jobs/cron_mailboxsize.php
+++ b/scripts/jobs/cron_mailboxsize.php
@@ -35,7 +35,7 @@ while ($maildir = $maildirs_stmt->fetch(PDO::FETCH_ASSOC)) {
 	if (file_exists($_maildir)
 		&& is_dir($_maildir)
 	) {
-		// mail-adress allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
+		// mail-address allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
 		$return = false;
 		$back = safe_exec('du -sk ' . escapeshellarg($_maildir), $return, array('|', '&', '`', '$', '~', '?'));
 		foreach ($back as $backrow) {

--- a/scripts/jobs/cron_tasks.inc.dns.10.bind.php
+++ b/scripts/jobs/cron_tasks.inc.dns.10.bind.php
@@ -231,7 +231,7 @@ class bind {
 				$ip_a_records[] = "AAAA\t\t" . $ip['ip'];
 			}
 			else {
-				return ";Error in at least one IP Adress (".$ip['ip']."), could not create zonefile!";
+				return ";Error in at least one IP Address (".$ip['ip']."), could not create zonefile!";
 			}
 		}
 

--- a/scripts/jobs/cron_tasks.php
+++ b/scripts/jobs/cron_tasks.php
@@ -230,7 +230,7 @@ while ($row = $result_tasks_stmt->fetch(PDO::FETCH_ASSOC)) {
 					&& filegroup($maildir) == Settings::Get('system.vmail_gid')
 				) {
 					$cronlog->logAction(CRON_ACTION, LOG_NOTICE, 'Running: rm -rf ' . escapeshellarg($maildir));
-					// mail-adress allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
+					// mail-address allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
 					$return = false;
 					safe_exec('rm -rf '.escapeshellarg($maildir), $return, array('|', '&', '`', '$', '~', '?'));
 				}
@@ -303,7 +303,7 @@ while ($row = $result_tasks_stmt->fetch(PDO::FETCH_ASSOC)) {
 					&& filegroup($maildir) == Settings::Get('system.vmail_gid')
 				) {
 					$cronlog->logAction(CRON_ACTION, LOG_NOTICE, 'Running: rm -rf ' . escapeshellarg($maildir));
-					// mail-adress allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
+					// mail-address allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
 					$return = false;
 					safe_exec('rm -rf '.escapeshellarg($maildir), $return, array('|', '&', '`', '$', '~', '?'));
 
@@ -320,7 +320,7 @@ while ($row = $result_tasks_stmt->fetch(PDO::FETCH_ASSOC)) {
 						&& filegroup($maildir_old) == Settings::Get('system.vmail_gid')
 					) {
 						$cronlog->logAction(CRON_ACTION, LOG_NOTICE, 'Running: rm -rf ' . escapeshellarg($maildir_old));
-						// mail-adress allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
+						// mail-address allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
 						$return = false;
 						safe_exec('rm -rf '.escapeshellarg($maildir_old), $return, array('|', '&', '`', '$', '~', '?'));
 					}

--- a/templates/Sparkle/misc/dberrornice.tpl
+++ b/templates/Sparkle/misc/dberrornice.tpl
@@ -19,7 +19,7 @@
 
 		<section class="errorsec">
 			<div class="errorcontainer bradius">
-				<div class="errortitle">A database error occured</div>
+				<div class="errortitle">A database error occurred</div>
 				<div class="error">
 					<p><TEXT></p>
 					<p>&nbsp;</p>

--- a/templates/misc/configfiles/debian_wheezy/pure-ftpd/etc_pure-ftpd_db_mysql.conf
+++ b/templates/misc/configfiles/debian_wheezy/pure-ftpd/etc_pure-ftpd_db_mysql.conf
@@ -123,7 +123,7 @@ MySQLGetQTASZ  SELECT panel_customers.diskspace/1024 AS QuotaSize FROM panel_cus
 
 # If you're using a transactionnal storage engine, you can enable SQL
 # transactions to avoid races. Leave this commented if you are using the
-# traditionnal MyIsam engine.
+# traditional MyIsam engine.
 
 # MySQLTransactions On
 

--- a/webftp.php
+++ b/webftp.php
@@ -491,7 +491,7 @@ if (isset($_GET['logoff']) || isset($_POST['logoff'])) {
 						$errormessage = sprintf(_('File \'%1$s\' couldn\'t be saved!') . "\n", $file);
 					}
 					else {
-						$successmessage = sprintf(_('File \'%1$s\' was saved succesfully!') . "\n", $file);
+						$successmessage = sprintf(_('File \'%1$s\' was saved successfully!') . "\n", $file);
 					}
 					unlink($downloadDir .  killslashes(html_entity_decode($file))."_".$s);
 				}


### PR DESCRIPTION
Most of them are in comments, strings or documentation.