### PR TITLE
Fix Bug #1488

### DIFF
--- a/templates/Sparkle/admin/settings/settings_group.tpl
+++ b/templates/Sparkle/admin/settings/settings_group.tpl
@@ -2,7 +2,7 @@
 	<th>
 		{$groupdetails['title']}
 	</th>
-	<th class="right">
+	<th class="right nolbr">
 		<input type="reset" value="{$lng['panel']['reset']}" /><input type="submit" value="{$lng['panel']['save']}" />
 	</th>
 </tr>


### PR DESCRIPTION
 "discard changes" and "save" on top of each other in security options; there was missing this additional template to fix the bug definitely.