### PR TITLE
Correcting a minor type in Feature #545

### DIFF
--- a/scripts/jobs/cron_traffic.inc.functions.php
+++ b/scripts/jobs/cron_traffic.inc.functions.php
@@ -55,7 +55,7 @@ function awstatsDoSingleDomain($domain, $outputdir) {
 		safe_exec('ln -fTs ' . escapeshellarg($staticOutputdir) . ' ' . escapeshellarg($new_current));
 
 		//statistics file looks like: 'awstats[month][year].[domain].txt'
-		$file = makeCorrectFile($staticOutputdir.'/awstats'.date('mY', time()).'.'.$domain.'.txt');
+		$file = makeCorrectFile($outputdir.'/awstats'.date('mY', time()).'.'.$domain.'.txt');
 		$cronlog->logAction(CRON_ACTION, LOG_INFO, "Gathering traffic information from '".$file."'");
 
 		if (file_exists($file)) {


### PR DESCRIPTION
I might have made a minor typo there. It does not error out when the awstats file is non-existent.