### PR TITLE
fix potentially dangerous programming

### DIFF
--- a/lib/classes/webserver/class.ConfigIO.php
+++ b/lib/classes/webserver/class.ConfigIO.php
@@ -89,8 +89,13 @@ class ConfigIO {
 
 		// get directories
 		$configdirs = array();
-		$configdirs[] = makeCorrectDir($this->_getFile('system', 'apacheconf_vhost'));
-		$configdirs[] = makeCorrectDir($this->_getFile('system', 'apacheconf_diroptions'));
+		$dir = $this->_getFile('system', 'apacheconf_vhost');
+		if ($dir !== false)
+			$configdirs[] = makeCorrectDir($dir);
+
+		$dir = $this->_getFile('system', 'apacheconf_diroptions')
+		if ($dir !== false)
+			$configdirs[] = makeCorrectDir($dir);
 
 		// file pattern
 		$pattern = "/^([0-9]){2}_(froxlor|syscp)_(.+)\.conf$/";

--- a/lib/classes/webserver/class.ConfigIO.php
+++ b/lib/classes/webserver/class.ConfigIO.php
@@ -93,7 +93,7 @@ class ConfigIO {
 		if ($dir !== false)
 			$configdirs[] = makeCorrectDir($dir);
 
-		$dir = $this->_getFile('system', 'apacheconf_diroptions')
+		$dir = $this->_getFile('system', 'apacheconf_diroptions');
 		if ($dir !== false)
 			$configdirs[] = makeCorrectDir($dir);
 

--- a/lib/functions/filedir/function.makeCorrectDir.php
+++ b/lib/functions/filedir/function.makeCorrectDir.php
@@ -26,6 +26,8 @@
  */
 function makeCorrectDir($dir) {
 
+	assert('is_string($dir) && strlen($dir) > 0 /* $dir does not look like an actual folder name */');
+
 	$dir = trim($dir);
 
 	if (substr($dir, -1, 1) != '/') {


### PR DESCRIPTION
Steps to reproduce:

1. set Settings->Webserver->Apache->vhost configuration directory to some nonexistent path
2.  run cronjob with `--force` and watch Froxlor trying to delete all files matching `/^([0-9]){2}_(froxlor|syscp)_(.+)\.conf$/`, starting from `/`

Explanation: `ConfigIO::_getFile()` returns `false` for nonexistent files. And `makeCorrectDir(false)` yields `/`. So Froxlor will try to delete every file on all mounted filesystems, which matches the pattern above.