### PR TITLE
Add foreign key constrains to database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ install/update.log
 .buildpath
 .project
 .settings/
+.idea
 *.diff
 *~

--- a/admin_customers.php
+++ b/admin_customers.php
@@ -77,7 +77,7 @@ if ($page == 'customers'
 					SELECT COUNT(`id`) AS `domains`
 					FROM `" . TABLE_PANEL_DOMAINS . "`
 					WHERE `customerid` = :cid
-					AND `parentdomainid` = '0'
+					AND `parentdomainid` IS NULL
 					AND `id`<> :stdd"
 				);
 				Database::pexecute($domains_stmt, array('cid' => $row['customerid'], 'stdd' => $row['standardsubdomain']));
@@ -892,7 +892,7 @@ if ($page == 'customers'
 							`domain` = :domain,
 							`customerid` = :customerid,
 							`adminid` = :adminid,
-							`parentdomainid` = '0',
+							`parentdomainid` = NULL,
 							`documentroot` = :docroot,
 							`zonefile` = '',
 							`isemaildomain` = '0',
@@ -1230,7 +1230,7 @@ if ($page == 'customers'
 							`domain` = :domain,
 							`customerid` = :customerid,
 							`adminid` = :adminid,
-							`parentdomainid` = '0',
+							`parentdomainid` = NULL,
 							`documentroot` = :docroot,
 							`zonefile` = '',
 							`isemaildomain` = '0',

--- a/admin_domains.php
+++ b/admin_domains.php
@@ -58,7 +58,7 @@ if ($page == 'domains'
 			FROM `" . TABLE_PANEL_DOMAINS . "` `d`
 			LEFT JOIN `" . TABLE_PANEL_CUSTOMERS . "` `c` USING(`customerid`)
 			LEFT JOIN `" . TABLE_PANEL_DOMAINS . "` `ad` ON `d`.`aliasdomain`=`ad`.`id`
-			WHERE `d`.`parentdomainid`='0' " .
+			WHERE `d`.`parentdomainid` IS NULL " .
 			($userinfo['customers_see_all'] ? '' : " AND `d`.`adminid` = :adminid ") .
 			" " . $paging->getSqlWhere(true) . " " . $paging->getSqlOrderBy() . " " . $paging->getSqlLimit()
 		);
@@ -921,7 +921,7 @@ if ($page == 'domains'
 				$domains = makeoption($lng['domains']['noaliasdomain'], 0, NULL, true);
 				$result_domains_stmt = Database::prepare("
 					SELECT `d`.`id`, `d`.`domain`, `c`.`loginname` FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_CUSTOMERS . "` `c`
-					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` = 0" . $standardsubdomains .
+					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` IS NULL" . $standardsubdomains .
 					($userinfo['customers_see_all'] ? '' : " AND `d`.`adminid` = :adminid") . "
 					AND `d`.`customerid`=`c`.`customerid` ORDER BY `loginname`, `domain` ASC
 				");
@@ -938,7 +938,7 @@ if ($page == 'domains'
 				$subtodomains = makeoption($lng['domains']['nosubtomaindomain'], 0, NULL, true);
 				$result_domains_stmt = Database::prepare("
 					SELECT `d`.`id`, `d`.`domain`, `c`.`loginname` FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_CUSTOMERS . "` `c`
-					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` = 0 AND `d`.`ismainbutsubto` = 0 " . $standardsubdomains .
+					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` IS NULL AND `d`.`ismainbutsubto` = 0 " . $standardsubdomains .
 					($userinfo['customers_see_all'] ? '' : " AND `d`.`adminid` = :adminid") . "
 					AND `d`.`customerid`=`c`.`customerid` ORDER BY `loginname`, `domain` ASC
 				");
@@ -989,7 +989,7 @@ if ($page == 'domains'
 
 		$result_stmt = Database::prepare("
 			SELECT `d`.*, `c`.`customerid` FROM `" . TABLE_PANEL_DOMAINS . "` `d` LEFT JOIN `" . TABLE_PANEL_CUSTOMERS . "` `c` USING(`customerid`)
-			WHERE `d`.`parentdomainid` = '0' AND `d`.`id` = :id" .
+			WHERE `d`.`parentdomainid` IS NULL AND `d`.`id` = :id" .
 			($userinfo['customers_see_all'] ? '' : " AND `d`.`adminid` = :adminid")
 		);
 		$params = array('id' => $id);
@@ -1794,7 +1794,7 @@ if ($page == 'domains'
 
 				$result_domains_stmt = Database::prepare("
 					SELECT `d`.`id`, `d`.`domain`  FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_CUSTOMERS . "` `c`
-					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` = '0' AND `d`.`id` <> :id
+					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` IS NULL AND `d`.`id` <> :id
 					AND `c`.`standardsubdomain`<>`d`.`id` AND `d`.`customerid` = :customerid AND `c`.`customerid`=`d`.`customerid`
 					ORDER BY `d`.`domain` ASC
 				");
@@ -1807,7 +1807,7 @@ if ($page == 'domains'
 				$subtodomains = makeoption($lng['domains']['nosubtomaindomain'], 0, null, true);
 				$result_domains_stmt = Database::prepare("
 					SELECT `d`.`id`, `d`.`domain` FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_CUSTOMERS . "` `c`
-					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` = '0' AND `d`.`id` <> :id
+					WHERE `d`.`aliasdomain` IS NULL AND `d`.`parentdomainid` IS NULL AND `d`.`id` <> :id
 					AND `c`.`standardsubdomain`<>`d`.`id` AND `c`.`customerid`=`d`.`customerid`".
 					($userinfo['customers_see_all'] ? '' : " AND `d`.`adminid` = :adminid") . "
 					ORDER BY `d`.`domain` ASC

--- a/admin_index.php
+++ b/admin_index.php
@@ -73,7 +73,7 @@ if ($page == 'overview') {
 
 	$number_domains_stmt = Database::prepare("
 		SELECT COUNT(*) AS `number_domains` FROM `" . TABLE_PANEL_DOMAINS . "`
-		WHERE `parentdomainid`='0'" . ($userinfo['customers_see_all'] ? '' : " AND `adminid` = :adminid")
+		WHERE `parentdomainid` IS NULL " . ($userinfo['customers_see_all'] ? '' : " AND `adminid` = :adminid")
 	);
 	$number_domains = Database::pexecute_first($number_domains_stmt, array('adminid' => $userinfo['adminid']));
 

--- a/admin_phpsettings.php
+++ b/admin_phpsettings.php
@@ -41,7 +41,7 @@ if ($page == 'overview') {
 
 			$query = "SELECT * FROM `".TABLE_PANEL_DOMAINS."`
 					WHERE `phpsettingid` = :id
-					AND `parentdomainid` = '0'";
+					AND `parentdomainid` IS NULL";
 
 			if ((int)$userinfo['domains_see_all'] == 0) {
 				$query .= " AND `adminid` = :adminid";

--- a/customer_domains.php
+++ b/customer_domains.php
@@ -460,7 +460,7 @@ if ($page == 'overview') {
 			FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_DOMAINS . "` `pd`
 			WHERE `d`.`customerid` = :customerid
 			AND `d`.`id` = :id
-			AND ((`d`.`parentdomainid` NOT NULL
+			AND ((`d`.`parentdomainid` IS NOT NULL
 					AND `pd`.`id` = `d`.`parentdomainid`)
 				OR (`d`.`parentdomainid` IS NULL
 					AND `pd`.`id` = `d`.`id`))

--- a/customer_domains.php
+++ b/customer_domains.php
@@ -59,7 +59,7 @@ if ($page == 'overview') {
 			$row['aliasdomain'] = $idna_convert->decode($row['aliasdomain']);
 			$row['domainalias'] = $idna_convert->decode($row['domainalias']);
 
-			if ($row['parentdomainid'] == '0' && $row['caneditdomain'] == '1') {
+			if ($row['parentdomainid'] != null && $row['caneditdomain'] == '1') {
 				$parentdomains_count++;
 			}
 
@@ -76,7 +76,7 @@ if ($page == 'overview') {
 				$row['domain_hascert'] = 1;
 			} else {
 				// check if it's parent has one set (shared)
-				if ($row['parentdomainid'] != 0) {
+				if ($row['parentdomainid'] != null) {
 					$ssl_stmt = Database::prepare("SELECT * FROM `".TABLE_PANEL_DOMAIN_SSL_SETTINGS."` WHERE `domainid` = :domainid");
 					Database::pexecute($ssl_stmt, array("domainid" => $row['parentdomainid']));
 					$ssl_result = $ssl_stmt->fetch(PDO::FETCH_ASSOC);
@@ -99,7 +99,7 @@ if ($page == 'overview') {
 
 		$domain_sort_array = array();
 		foreach ($domain_array as $sortkey => $row) {
-			if ($row['parentdomainid'] == 0) {
+			if ($row['parentdomainid'] == null) {
 				$domain_sort_array[$sortkey][$sortkey] = $row;
 			} else {
 				$domain_sort_array[$domain_id_array[$row['parentdomainid']]][$sortkey] = $row;
@@ -223,7 +223,7 @@ if ($page == 'overview') {
 				$domain_stmt = Database::prepare("SELECT * FROM `" . TABLE_PANEL_DOMAINS . "`
 					WHERE `domain` = :domain
 					AND `customerid` = :customerid
-					AND `parentdomainid` = '0'
+					AND `parentdomainid` IS NULL
 					AND `email_only` = '0'
 					AND `caneditdomain` = '1'"
 				);
@@ -396,7 +396,7 @@ if ($page == 'overview') {
 			} else {
 				$stmt = Database::prepare("SELECT `id`, `domain`, `documentroot`, `ssl_redirect`,`isemaildomain` FROM `" . TABLE_PANEL_DOMAINS . "`
 					WHERE `customerid` = :customerid
-					AND `parentdomainid` = '0'
+					AND `parentdomainid` IS NULL
 					AND `email_only` = '0'
 					AND `caneditdomain` = '1'
 					ORDER BY `domain` ASC"
@@ -412,7 +412,7 @@ if ($page == 'overview') {
 				$domains_stmt = Database::prepare("SELECT `d`.`id`, `d`.`domain` FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_CUSTOMERS . "` `c`
 					WHERE `d`.`aliasdomain` IS NULL
 					AND `d`.`id` <> `c`.`standardsubdomain`
-					AND `d`.`parentdomainid` = '0'
+					AND `d`.`parentdomainid` IS NULL
 					AND `d`.`customerid`=`c`.`customerid`
 					AND `d`.`email_only`='0'
 					AND `d`.`customerid`= :customerid
@@ -460,9 +460,9 @@ if ($page == 'overview') {
 			FROM `" . TABLE_PANEL_DOMAINS . "` `d`, `" . TABLE_PANEL_DOMAINS . "` `pd`
 			WHERE `d`.`customerid` = :customerid
 			AND `d`.`id` = :id
-			AND ((`d`.`parentdomainid`!='0'
+			AND ((`d`.`parentdomainid` NOT NULL
 					AND `pd`.`id` = `d`.`parentdomainid`)
-				OR (`d`.`parentdomainid`='0'
+				OR (`d`.`parentdomainid` IS NULL
 					AND `pd`.`id` = `d`.`id`))
 			AND `d`.`caneditdomain`='1'");
 		$result = Database::pexecute_first($stmt, array("customerid" => $userinfo['customerid'], "id" => $id));
@@ -498,7 +498,7 @@ if ($page == 'overview') {
 
 				$aliasdomain = intval($_POST['alias']);
 
-				if (isset($_POST['selectserveralias']) && $result['parentdomainid'] == '0' ) {
+				if (isset($_POST['selectserveralias']) && $result['parentdomainid'] == null ) {
 					$iswildcarddomain = ($_POST['selectserveralias'] == '0') ? '1' : '0';
 					$wwwserveralias = ($_POST['selectserveralias'] == '1') ? '1' : '0';
 				} else {
@@ -614,7 +614,7 @@ if ($page == 'overview') {
 					WHERE `d`.`aliasdomain` IS NULL
 					AND `d`.`id` <> :id
 					AND `c`.`standardsubdomain` <> `d`.`id`
-					AND `d`.`parentdomainid` = '0'
+					AND `d`.`parentdomainid` IS NULL
 					AND `d`.`customerid` = :customerid
 					AND `c`.`customerid` = `d`.`customerid`
 					AND `d`.`id` = `dip`.`id_domain`

--- a/customer_email.php
+++ b/customer_email.php
@@ -420,7 +420,7 @@ if ($page == 'overview') {
 			);
 			$result = Database::pexecute_first($stmt, array("cid" => $userinfo['customerid'], "id" => $id));
 
-			if (isset($result['email']) && $result['email'] != '' && $result['popaccountid'] == '0') {
+			if (isset($result['email']) && $result['email'] != '' && $result['popaccountid'] == null) {
 				if (isset($_POST['send']) && $_POST['send'] == 'send') {
 					$email_full = $result['email_full'];
 					$username = $idna_convert->decode($email_full);

--- a/customer_email.php
+++ b/customer_email.php
@@ -141,7 +141,7 @@ if ($page == 'overview') {
 					$result['destination'] = explode(' ', $result['destination']);
 					$number_forwarders = count($result['destination']);
 
-					if ($result['popaccountid'] != 0) {
+					if ($result['popaccountid'] != null) {
 						// Free the Quota used by the email account
 						if (Settings::Get('system.mail_quota_enabled') == 1) {
 							$stmt = Database::prepare("SELECT `quota` FROM `" . TABLE_MAIL_USERS . "`
@@ -627,7 +627,7 @@ if ($page == 'overview') {
 		);
 		$result = Database::pexecute_first($stmt, array("cid" => $userinfo['customerid'], "id" => $id));
 
-		if (isset($result['popaccountid']) && $result['popaccountid'] != '') {
+		if (isset($result['popaccountid']) && $result['popaccountid'] != null) {
 			if (isset($_POST['send']) && $_POST['send'] == 'send') {
 				$password = validate($_POST['email_password'], 'password');
 
@@ -682,7 +682,7 @@ if ($page == 'overview') {
 		);
 		$result = Database::pexecute_first($stmt, array("cid" => $userinfo['customerid'], "id" => $id));
 
-		if (isset($result['popaccountid']) && $result['popaccountid'] != '') {
+		if (isset($result['popaccountid']) && $result['popaccountid'] != null) {
 			if (isset($_POST['send']) && $_POST['send'] == 'send') {
 				$quota = (int)validate($_POST['email_quota'], 'email_quota', '/^\d+$/', 'vmailquotawrong');
 
@@ -747,7 +747,7 @@ if ($page == 'overview') {
 
 				$stmt = Database::prepare("UPDATE `" . TABLE_MAIL_VIRTUAL . "`
 					SET `destination` = :dest,
-						`popaccountid` = '0'
+						`popaccountid` = NULL
 					WHERE `customerid`= :cid
 					AND `id`= :id"
 				);

--- a/customer_index.php
+++ b/customer_index.php
@@ -48,7 +48,7 @@ if ($page == 'overview') {
 
 	$domain_stmt = Database::prepare("SELECT `domain` FROM `" . TABLE_PANEL_DOMAINS . "`
 		WHERE `customerid` = :customerid
-		AND `parentdomainid` = '0'
+		AND `parentdomainid` IS NULL
 		AND `id` <> :standardsubdomain
 	");
 	Database::pexecute($domain_stmt, array("customerid" => $userinfo['customerid'], "standardsubdomain" => $userinfo['standardsubdomain']));

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -1,92 +1,3 @@
-DROP TABLE IF EXISTS `ftp_groups`;
-CREATE TABLE `ftp_groups` (
-  `id` int(20) NOT NULL auto_increment,
-  `groupname` varchar(60) NOT NULL default '',
-  `gid` int(5) NOT NULL default '0',
-  `members` longtext NOT NULL,
-  `customerid` int(11) NOT NULL default '0',
-  PRIMARY KEY  (`id`),
-  UNIQUE KEY `groupname` (`groupname`),
-  KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
-
-
-
-DROP TABLE IF EXISTS `ftp_users`;
-CREATE TABLE `ftp_users` (
-  `id` int(20) NOT NULL auto_increment,
-  `username` varchar(255) NOT NULL default '',
-  `uid` int(5) NOT NULL default '0',
-  `gid` int(5) NOT NULL default '0',
-  `password` varchar(128) NOT NULL default '',
-  `homedir` varchar(255) NOT NULL default '',
-  `shell` varchar(255) NOT NULL default '/bin/false',
-  `login_enabled` enum('N','Y') NOT NULL default 'N',
-  `login_count` int(15) NOT NULL default '0',
-  `last_login` datetime NOT NULL default '0000-00-00 00:00:00',
-  `up_count` int(15) NOT NULL default '0',
-  `up_bytes` bigint(30) NOT NULL default '0',
-  `down_count` int(15) NOT NULL default '0',
-  `down_bytes` bigint(30) NOT NULL default '0',
-  `customerid` int(11) NOT NULL default '0',
-  `description` varchar(255) NOT NULL DEFAULT '',
-  PRIMARY KEY  (`id`),
-  UNIQUE KEY `username` (`username`),
-  KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
-
-
-
-DROP TABLE IF EXISTS `mail_users`;
-CREATE TABLE `mail_users` (
-  `id` int(11) NOT NULL auto_increment,
-  `email` varchar(255) NOT NULL default '',
-  `username` varchar(255) NOT NULL default '',
-  `password` varchar(128) NOT NULL default '',
-  `password_enc` varchar(128) NOT NULL default '',
-  `uid` int(11) NOT NULL default '0',
-  `gid` int(11) NOT NULL default '0',
-  `homedir` varchar(255) NOT NULL default '',
-  `maildir` varchar(255) NOT NULL default '',
-  `postfix` enum('Y','N') NOT NULL default 'Y',
-  `domainid` int(11) NOT NULL default '0',
-  `customerid` int(11) NOT NULL default '0',
-  `quota` bigint(13) NOT NULL default '0',
-  `pop3` tinyint(1) NOT NULL default '1',
-  `imap` tinyint(1) NOT NULL default '1',
-  `mboxsize` bigint(30) NOT NULL default '0',
-  PRIMARY KEY  (`id`),
-  UNIQUE KEY `email` (`email`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
-
-
-
-DROP TABLE IF EXISTS `mail_virtual`;
-CREATE TABLE `mail_virtual` (
-  `id` int(11) NOT NULL auto_increment,
-  `email` varchar(255) NOT NULL default '',
-  `email_full` varchar(255) NOT NULL default '',
-  `destination` text NOT NULL,
-  `domainid` int(11) NOT NULL default '0',
-  `customerid` int(11) NOT NULL default '0',
-  `popaccountid` int(11) NOT NULL default '0',
-  `iscatchall` tinyint(1) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`id`),
-  KEY `email` (`email`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
-
-
-DROP TABLE IF EXISTS `panel_activation`;
-CREATE TABLE `panel_activation` (
-  `id` int(11) unsigned NOT NULL auto_increment,
-  `userid` int(11) unsigned NOT NULL default '0',
-  `admin` tinyint(1) unsigned NOT NULL default '0',
-  `creation` int(11) unsigned NOT NULL default '0',
-  `activationcode` varchar(50) default NULL,
-  PRIMARY KEY (id)
-) ENGINE=MyISAM  CHARSET=utf8 COLLATE=utf8_general_ci;
-
-
 DROP TABLE IF EXISTS `panel_admins`;
 CREATE TABLE `panel_admins` (
   `adminid` int(11) unsigned NOT NULL auto_increment,
@@ -135,7 +46,7 @@ CREATE TABLE `panel_admins` (
   `custom_notes_show` tinyint(1) NOT NULL default '0',
    PRIMARY KEY  (`adminid`),
    UNIQUE KEY `loginname` (`loginname`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -195,21 +106,99 @@ CREATE TABLE `panel_customers` (
   `custom_notes` text,
   `custom_notes_show` tinyint(1) NOT NULL default '0',
    PRIMARY KEY  (`customerid`),
-   UNIQUE KEY `loginname` (`loginname`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+   UNIQUE KEY `loginname` (`loginname`),
+   FOREIGN KEY `fk_admin` (adminid)
+      REFERENCES panel_admins(adminid)
+      ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
-DROP TABLE IF EXISTS `panel_databases`;
-CREATE TABLE `panel_databases` (
-  `id` int(11) unsigned NOT NULL auto_increment,
-  `customerid` int(11) NOT NULL default '0',
-  `databasename` varchar(255) NOT NULL default '',
-  `description` varchar(255) NOT NULL default '',
-  `dbserver` int(11) unsigned NOT NULL default '0',
+DROP TABLE IF EXISTS `ftp_groups`;
+CREATE TABLE `ftp_groups` (
+  `id` int(20) NOT NULL auto_increment,
+  `groupname` varchar(60) NOT NULL default '',
+  `gid` int(5) NOT NULL default '0',
+  `members` longtext NOT NULL,
+  `customerid` int(11) unsigned NOT NULL default '0',
   PRIMARY KEY  (`id`),
-  KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  UNIQUE KEY `groupname` (`groupname`),
+  FOREIGN KEY `fk_customer` (`customerid`) 
+    REFERENCES panel_customers(customerid) 
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+
+
+
+DROP TABLE IF EXISTS `ftp_users`;
+CREATE TABLE `ftp_users` (
+  `id` int(20) NOT NULL auto_increment,
+  `username` varchar(255) NOT NULL default '',
+  `uid` int(5) NOT NULL default '0',
+  `gid` int(5) NOT NULL default '0',
+  `password` varchar(128) NOT NULL default '',
+  `homedir` varchar(255) NOT NULL default '',
+  `shell` varchar(255) NOT NULL default '/bin/false',
+  `login_enabled` enum('N','Y') NOT NULL default 'N',
+  `login_count` int(15) NOT NULL default '0',
+  `last_login` datetime NOT NULL default '0000-00-00 00:00:00',
+  `up_count` int(15) NOT NULL default '0',
+  `up_bytes` bigint(30) NOT NULL default '0',
+  `down_count` int(15) NOT NULL default '0',
+  `down_bytes` bigint(30) NOT NULL default '0',
+  `customerid` int(11) unsigned NOT NULL default '0',
+  `description` varchar(255) NOT NULL DEFAULT '',
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `username` (`username`),
+  FOREIGN KEY `fk_customer` (`customerid`)
+    REFERENCES panel_customers(customerid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+
+
+
+DROP TABLE IF EXISTS `panel_phpconfigs`;
+CREATE TABLE `panel_phpconfigs` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `description` varchar(50) NOT NULL,
+  `binary` varchar(255) NOT NULL,
+  `file_extensions` varchar(255) NOT NULL,
+  `mod_fcgid_starter` int(4) NOT NULL DEFAULT '-1',
+  `mod_fcgid_maxrequests` int(4) NOT NULL DEFAULT '-1',
+  `fpm_slowlog` tinyint(1) NOT NULL default '0',
+  `fpm_reqterm` varchar(15) NOT NULL default '60s',
+  `fpm_reqslow` varchar(15) NOT NULL default '5s',
+  `phpsettings` text NOT NULL,
+  PRIMARY KEY  (`id`)
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+
+
+
+INSERT INTO `panel_phpconfigs` (`id`, `description`, `binary`, `file_extensions`, `mod_fcgid_starter`, `mod_fcgid_maxrequests`, `phpsettings`) VALUES
+(1, 'Default Config', '/usr/bin/php-cgi', 'php', '-1', '-1', 'allow_call_time_pass_reference = Off\r\nallow_url_fopen = Off\r\nasp_tags = Off\r\ndisable_classes =\r\ndisable_functions = curl_exec,curl_multi_exec,exec,parse_ini_file,passthru,popen,proc_close,proc_get_status,proc_nice,proc_open,proc_terminate,shell_exec,show_source,system\r\ndisplay_errors = Off\r\ndisplay_startup_errors = Off\r\nenable_dl = Off\r\nerror_reporting = E_ALL & ~E_NOTICE\r\nexpose_php = Off\r\nfile_uploads = On\r\ncgi.force_redirect = 1\r\ngpc_order = "GPC"\r\nhtml_errors = Off\r\nignore_repeated_errors = Off\r\nignore_repeated_source = Off\r\ninclude_path = ".:{PEAR_DIR}"\r\nlog_errors = On\r\nlog_errors_max_len = 1024\r\nmagic_quotes_gpc = Off\r\nmagic_quotes_runtime = Off\r\nmagic_quotes_sybase = Off\r\nmax_execution_time = 30\r\nmax_input_time = 60\r\nmemory_limit = 128\r\n{OPEN_BASEDIR_C}open_basedir = "{OPEN_BASEDIR}"\r\noutput_buffering = 4096\r\npost_max_size = 16M\r\nprecision = 14\r\nregister_argc_argv = Off\r\nregister_globals = Off\r\nreport_memleaks = On\r\nsendmail_path = "/usr/sbin/sendmail -t -i -f {CUSTOMER_EMAIL}"\r\nsession.auto_start = 0\r\nsession.bug_compat_42 = 0\r\nsession.bug_compat_warn = 1\r\nsession.cache_expire = 180\r\nsession.cache_limiter = nocache\r\nsession.cookie_domain =\r\nsession.cookie_lifetime = 0\r\nsession.cookie_path = /\r\nsession.entropy_file = /dev/urandom\r\nsession.entropy_length = 16\r\nsession.gc_divisor = 1000\r\nsession.gc_maxlifetime = 1440\r\nsession.gc_probability = 1\r\nsession.name = PHPSESSID\r\nsession.referer_check =\r\nsession.save_handler = files\r\nsession.save_path = "{TMP_DIR}"\r\nsession.serialize_handler = php\r\nsession.use_cookies = 1\r\nsession.use_trans_sid = 0\r\nshort_open_tag = On\r\nsuhosin.mail.protect = 1\r\nsuhosin.simulation = Off\r\ntrack_errors = Off\r\nupload_max_filesize = 32M\r\nupload_tmp_dir = "{TMP_DIR}"\r\nvariables_order = "GPCS"\r\n;mail.add_x_header = On\r\n;mail.log = "/var/log/phpmail.log"\r\n'),
+(2, 'Froxlor Vhost Config', '/usr/bin/php-cgi', 'php', '-1', '-1', 'allow_call_time_pass_reference = Off\r\nallow_url_fopen = On\r\nasp_tags = Off\r\ndisable_classes =\r\ndisable_functions = curl_multi_exec,exec,parse_ini_file,passthru,popen,proc_close,proc_get_status,proc_nice,proc_open,proc_terminate,shell_exec,show_source,system\r\ndisplay_errors = Off\r\ndisplay_startup_errors = Off\r\nenable_dl = Off\r\nerror_reporting = E_ALL & ~E_NOTICE\r\nexpose_php = Off\r\nfile_uploads = On\r\ncgi.force_redirect = 1\r\ngpc_order = "GPC"\r\nhtml_errors = Off\r\nignore_repeated_errors = Off\r\nignore_repeated_source = Off\r\ninclude_path = ".:{PEAR_DIR}"\r\nlog_errors = On\r\nlog_errors_max_len = 1024\r\nmagic_quotes_gpc = Off\r\nmagic_quotes_runtime = Off\r\nmagic_quotes_sybase = Off\r\nmax_execution_time = 60\r\nmax_input_time = 60\r\nmemory_limit = 128M\r\nnoutput_buffering = 4096\r\npost_max_size = 16M\r\nprecision = 14\r\nregister_argc_argv = Off\r\nregister_globals = Off\r\nreport_memleaks = On\r\nsendmail_path = "/usr/sbin/sendmail -t -i -f {CUSTOMER_EMAIL}"\r\nsession.auto_start = 0\r\nsession.bug_compat_42 = 0\r\nsession.bug_compat_warn = 1\r\nsession.cache_expire = 180\r\nsession.cache_limiter = nocache\r\nsession.cookie_domain =\r\nsession.cookie_lifetime = 0\r\nsession.cookie_path = /\r\nsession.entropy_file = /dev/urandom\r\nsession.entropy_length = 16\r\nsession.gc_divisor = 1000\r\nsession.gc_maxlifetime = 1440\r\nsession.gc_probability = 1\r\nsession.name = PHPSESSID\r\nsession.referer_check =\r\nsession.save_handler = files\r\nsession.save_path = "{TMP_DIR}"\r\nsession.serialize_handler = php\r\nsession.use_cookies = 1\r\nsession.use_trans_sid = 0\r\nshort_open_tag = On\r\nsuhosin.mail.protect = 1\r\nsuhosin.simulation = Off\r\ntrack_errors = Off\r\nupload_max_filesize = 32M\r\nupload_tmp_dir = "{TMP_DIR}"\r\nvariables_order = "GPCS"\r\n;mail.add_x_header = On\r\n;mail.log = "/var/log/phpmail.log"\r\n');
+
+
+
+DROP TABLE IF EXISTS `panel_ipsandports`;
+CREATE TABLE `panel_ipsandports` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `ip` varchar(39) NOT NULL default '',
+  `port` int(5) NOT NULL default '80',
+  `listen_statement` tinyint(1) NOT NULL default '0',
+  `namevirtualhost_statement` tinyint(1) NOT NULL default '0',
+  `vhostcontainer` tinyint(1) NOT NULL default '0',
+  `vhostcontainer_servername_statement` tinyint(1) NOT NULL default '0',
+  `specialsettings` text,
+  `ssl` tinyint(4) NOT NULL default '0',
+  `ssl_cert_file` varchar(255) NOT NULL,
+  `ssl_key_file` varchar(255) NOT NULL,
+  `ssl_ca_file` varchar(255) NOT NULL,
+  `default_vhostconf_domain` text,
+  `ssl_cert_chainfile` varchar(255) NOT NULL,
+  `docroot` varchar(255) NOT NULL default '',
+  PRIMARY KEY  (`id`)
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -233,7 +222,7 @@ CREATE TABLE `panel_domains` (
   `dkim_privkey` text,
   `dkim_pubkey` text,
   `wwwserveralias` tinyint(1) NOT NULL default '1',
-  `parentdomainid` int(11) NOT NULL default '0',
+  `parentdomainid` int(11) unsigned NULL,
   `openbasedir` tinyint(1) NOT NULL default '0',
   `openbasedir_path` tinyint(1) NOT NULL default '0',
   `speciallogfile` tinyint(1) NOT NULL default '0',
@@ -248,32 +237,103 @@ CREATE TABLE `panel_domains` (
   `mod_fcgid_maxrequests` int(4) default '-1',
   `ismainbutsubto` int(11) unsigned NOT NULL default '0',
   PRIMARY KEY  (`id`),
-  KEY `customerid` (`customerid`),
-  KEY `parentdomain` (`parentdomainid`),
-  KEY `domain` (`domain`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  KEY `domain` (`domain`),
+  FOREIGN KEY `fk_admin` (adminid) 
+    REFERENCES panel_admins(adminid)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_customer` (customerid)
+    REFERENCES panel_customers(customerid)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_parent` (parentdomainid)
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_alias` (aliasdomain)
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE SET NULL,
+  FOREIGN KEY `fk_phpsetting` (phpsettingid)
+    REFERENCES panel_phpconfigs(id)
+    ON UPDATE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
-DROP TABLE IF EXISTS `panel_ipsandports`;
-CREATE TABLE `panel_ipsandports` (
+DROP TABLE IF EXISTS `mail_users`;
+CREATE TABLE `mail_users` (
+  `id` int(11) NOT NULL auto_increment,
+  `email` varchar(255) NOT NULL default '',
+  `username` varchar(255) NOT NULL default '',
+  `password` varchar(128) NOT NULL default '',
+  `password_enc` varchar(128) NOT NULL default '',
+  `uid` int(11) NOT NULL default '0',
+  `gid` int(11) NOT NULL default '0',
+  `homedir` varchar(255) NOT NULL default '',
+  `maildir` varchar(255) NOT NULL default '',
+  `postfix` enum('Y','N') NOT NULL default 'Y',
+  `domainid` int(11) unsigned NOT NULL default '0',
+  `customerid` int(11) unsigned NOT NULL default '0',
+  `quota` bigint(13) NOT NULL default '0',
+  `pop3` tinyint(1) NOT NULL default '1',
+  `imap` tinyint(1) NOT NULL default '1',
+  `mboxsize` bigint(30) NOT NULL default '0',
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `email` (`email`),
+  FOREIGN KEY `fk_domain` (`domainid`) 
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_customer` (`customerid`) 
+    REFERENCES panel_customers(customerid) 
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+
+
+
+DROP TABLE IF EXISTS `mail_virtual`;
+CREATE TABLE `mail_virtual` (
+  `id` int(11) NOT NULL auto_increment,
+  `email` varchar(255) NOT NULL default '',
+  `email_full` varchar(255) NOT NULL default '',
+  `destination` text NOT NULL,
+  `domainid` int(11) unsigned NOT NULL default '0',
+  `customerid` int(11) unsigned NOT NULL default '0',
+  `popaccountid` int(11) NULL,
+  `iscatchall` tinyint(1) unsigned NOT NULL default '0',
+  PRIMARY KEY  (`id`),
+  KEY `email` (`email`),
+  FOREIGN KEY `fk_customer` (customerid) 
+    REFERENCES panel_customers(customerid) 
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_domain` (domainid)
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_account` (popaccountid)
+    REFERENCES mail_users(id) 
+    ON UPDATE CASCADE ON DELETE SET NULL
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
+
+
+
+DROP TABLE IF EXISTS `panel_activation`;
+CREATE TABLE `panel_activation` (
   `id` int(11) unsigned NOT NULL auto_increment,
-  `ip` varchar(39) NOT NULL default '',
-  `port` int(5) NOT NULL default '80',
-  `listen_statement` tinyint(1) NOT NULL default '0',
-  `namevirtualhost_statement` tinyint(1) NOT NULL default '0',
-  `vhostcontainer` tinyint(1) NOT NULL default '0',
-  `vhostcontainer_servername_statement` tinyint(1) NOT NULL default '0',
-  `specialsettings` text,
-  `ssl` tinyint(4) NOT NULL default '0',
-  `ssl_cert_file` varchar(255) NOT NULL,
-  `ssl_key_file` varchar(255) NOT NULL,
-  `ssl_ca_file` varchar(255) NOT NULL,
-  `default_vhostconf_domain` text,
-  `ssl_cert_chainfile` varchar(255) NOT NULL,
-  `docroot` varchar(255) NOT NULL default '',
-  PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  `userid` int(11) unsigned NOT NULL default '0',
+  `admin` tinyint(1) unsigned NOT NULL default '0',
+  `creation` int(11) unsigned NOT NULL default '0',
+  `activationcode` varchar(50) default NULL,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB  CHARSET=utf8 COLLATE=utf8_general_ci;
+
+
+
+DROP TABLE IF EXISTS `panel_databases`;
+CREATE TABLE `panel_databases` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `customerid` int(11) NOT NULL default '0',
+  `databasename` varchar(255) NOT NULL default '',
+  `description` varchar(255) NOT NULL default '',
+  `dbserver` int(11) unsigned NOT NULL default '0',
+  PRIMARY KEY  (`id`),
+  KEY `customerid` (`customerid`)
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -288,8 +348,11 @@ CREATE TABLE `panel_htaccess` (
   `error500path` varchar(255) NOT NULL default '',
   `error401path` varchar(255) NOT NULL default '',
   `options_cgi` tinyint(1) NOT NULL default '0',
-  PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  PRIMARY KEY  (`id`),
+  FOREIGN KEY `fk_customer` (customerid)
+    REFERENCES panel_customers(customerid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -302,8 +365,10 @@ CREATE TABLE `panel_htpasswds` (
   `password` varchar(255) NOT NULL default '',
   `authname` varchar(255) NOT NULL default 'Restricted Area',
   PRIMARY KEY  (`id`),
-  KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  FOREIGN KEY `fk_customerid` (customerid)
+    REFERENCES panel_customers(customerid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -332,7 +397,7 @@ CREATE TABLE `panel_settings` (
   `varname` varchar(255) NOT NULL default '',
   `value` text NOT NULL,
   PRIMARY KEY  (`settingid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('catchall', 'catchall_enabled', '1'),
@@ -548,7 +613,7 @@ CREATE TABLE `panel_tasks` (
   `type` int(11) NOT NULL default '0',
   `data` text NOT NULL,
   PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 INSERT INTO `panel_tasks` (`type`) VALUES ('99');
 
@@ -556,14 +621,16 @@ INSERT INTO `panel_tasks` (`type`) VALUES ('99');
 DROP TABLE IF EXISTS `panel_templates`;
 CREATE TABLE `panel_templates` (
   `id` int(11) NOT NULL auto_increment,
-  `adminid` int(11) NOT NULL default '0',
+  `adminid` int(11) unsigned NOT NULL default '0',
   `language` varchar(255) NOT NULL default '',
   `templategroup` varchar(255) NOT NULL default '',
   `varname` varchar(255) NOT NULL default '',
   `value` longtext NOT NULL,
-  PRIMARY KEY  (id),
-  KEY adminid (adminid)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  PRIMARY KEY (id),
+  FOREIGN KEY `fk_admin` (adminid)
+    REFERENCES panel_admins(adminid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -580,8 +647,10 @@ CREATE TABLE `panel_traffic` (
   `ftp_down` bigint(30) unsigned NOT NULL default '0',
   `mail` bigint(30) unsigned NOT NULL default '0',
   PRIMARY KEY  (`id`),
-  KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  FOREIGN KEY `fk_customer` (customerid)
+    REFERENCES panel_customers(customerid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -598,8 +667,10 @@ CREATE TABLE `panel_traffic_admins` (
   `ftp_down` bigint(30) unsigned NOT NULL default '0',
   `mail` bigint(30) unsigned NOT NULL default '0',
   PRIMARY KEY  (`id`),
-  KEY `adminid` (`adminid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  FOREIGN KEY `fk_admin` (adminid)
+    REFERENCES panel_admins(adminid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -614,9 +685,11 @@ CREATE TABLE `panel_diskspace` (
   `webspace` bigint(30) unsigned NOT NULL default '0',
   `mail` bigint(30) unsigned NOT NULL default '0',
   `mysql` bigint(30) unsigned NOT NULL default '0',
-  PRIMARY KEY  (`id`),
-  KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  PRIMARY KEY (`id`),
+  FOREIGN KEY `fk_customer` (customerid)
+    REFERENCES panel_customers(customerid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -633,7 +706,7 @@ CREATE TABLE `panel_diskspace_admins` (
   `mysql` bigint(30) unsigned NOT NULL default '0',
   PRIMARY KEY  (`id`),
   KEY `adminid` (`adminid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -644,7 +717,7 @@ CREATE TABLE `panel_languages` (
   `iso` char(3) NOT NULL DEFAULT 'foo',
   `file` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -662,8 +735,8 @@ INSERT INTO `panel_languages` (`id`, `language`, `iso`, `file`) VALUES
 DROP TABLE IF EXISTS `panel_tickets`;
 CREATE TABLE `panel_tickets` (
   `id` int(11) unsigned NOT NULL auto_increment,
-  `customerid` int(11) NOT NULL,
-  `adminid` int(11) NOT NULL,
+  `customerid` int(11) unsigned NOT NULL,
+  `adminid` int(11) unsigned NOT NULL,
   `category` smallint(5) unsigned NOT NULL default '1',
   `priority` enum('1','2','3') NOT NULL default '3',
   `subject` varchar(70) NOT NULL,
@@ -678,7 +751,7 @@ CREATE TABLE `panel_tickets` (
   `archived` enum('0','1') NOT NULL default '0',
   PRIMARY KEY  (`id`),
   KEY `customerid` (`customerid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -686,10 +759,13 @@ DROP TABLE IF EXISTS `panel_ticket_categories`;
 CREATE TABLE `panel_ticket_categories` (
   `id` smallint(5) unsigned NOT NULL auto_increment,
   `name` varchar(60) NOT NULL,
-  `adminid` int(11) NOT NULL,
+  `adminid` int(11) unsigned NOT NULL,
   `logicalorder` int(3) NOT NULL default '1',
-  PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  PRIMARY KEY (`id`),
+  FOREIGN KEY `fk_admin` (adminid) 
+    REFERENCES panel_admins(adminid)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -702,29 +778,8 @@ CREATE TABLE IF NOT EXISTS `panel_syslog` (
   `user` varchar(50) NOT NULL,
   `text` text NOT NULL,
   PRIMARY KEY  (`logid`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
-
-DROP TABLE IF EXISTS `panel_phpconfigs`;
-CREATE TABLE `panel_phpconfigs` (
-  `id` int(11) unsigned NOT NULL auto_increment,
-  `description` varchar(50) NOT NULL,
-  `binary` varchar(255) NOT NULL,
-  `file_extensions` varchar(255) NOT NULL,
-  `mod_fcgid_starter` int(4) NOT NULL DEFAULT '-1',
-  `mod_fcgid_maxrequests` int(4) NOT NULL DEFAULT '-1',
-  `fpm_slowlog` tinyint(1) NOT NULL default '0',
-  `fpm_reqterm` varchar(15) NOT NULL default '60s',
-  `fpm_reqslow` varchar(15) NOT NULL default '5s',
-  `phpsettings` text NOT NULL,
-  PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
-
-
-
-INSERT INTO `panel_phpconfigs` (`id`, `description`, `binary`, `file_extensions`, `mod_fcgid_starter`, `mod_fcgid_maxrequests`, `phpsettings`) VALUES
-(1, 'Default Config', '/usr/bin/php-cgi', 'php', '-1', '-1', 'allow_call_time_pass_reference = Off\r\nallow_url_fopen = Off\r\nasp_tags = Off\r\ndisable_classes =\r\ndisable_functions = curl_exec,curl_multi_exec,exec,parse_ini_file,passthru,popen,proc_close,proc_get_status,proc_nice,proc_open,proc_terminate,shell_exec,show_source,system\r\ndisplay_errors = Off\r\ndisplay_startup_errors = Off\r\nenable_dl = Off\r\nerror_reporting = E_ALL & ~E_NOTICE\r\nexpose_php = Off\r\nfile_uploads = On\r\ncgi.force_redirect = 1\r\ngpc_order = "GPC"\r\nhtml_errors = Off\r\nignore_repeated_errors = Off\r\nignore_repeated_source = Off\r\ninclude_path = ".:{PEAR_DIR}"\r\nlog_errors = On\r\nlog_errors_max_len = 1024\r\nmagic_quotes_gpc = Off\r\nmagic_quotes_runtime = Off\r\nmagic_quotes_sybase = Off\r\nmax_execution_time = 30\r\nmax_input_time = 60\r\nmemory_limit = 128\r\n{OPEN_BASEDIR_C}open_basedir = "{OPEN_BASEDIR}"\r\noutput_buffering = 4096\r\npost_max_size = 16M\r\nprecision = 14\r\nregister_argc_argv = Off\r\nregister_globals = Off\r\nreport_memleaks = On\r\nsendmail_path = "/usr/sbin/sendmail -t -i -f {CUSTOMER_EMAIL}"\r\nsession.auto_start = 0\r\nsession.bug_compat_42 = 0\r\nsession.bug_compat_warn = 1\r\nsession.cache_expire = 180\r\nsession.cache_limiter = nocache\r\nsession.cookie_domain =\r\nsession.cookie_lifetime = 0\r\nsession.cookie_path = /\r\nsession.entropy_file = /dev/urandom\r\nsession.entropy_length = 16\r\nsession.gc_divisor = 1000\r\nsession.gc_maxlifetime = 1440\r\nsession.gc_probability = 1\r\nsession.name = PHPSESSID\r\nsession.referer_check =\r\nsession.save_handler = files\r\nsession.save_path = "{TMP_DIR}"\r\nsession.serialize_handler = php\r\nsession.use_cookies = 1\r\nsession.use_trans_sid = 0\r\nshort_open_tag = On\r\nsuhosin.mail.protect = 1\r\nsuhosin.simulation = Off\r\ntrack_errors = Off\r\nupload_max_filesize = 32M\r\nupload_tmp_dir = "{TMP_DIR}"\r\nvariables_order = "GPCS"\r\n;mail.add_x_header = On\r\n;mail.log = "/var/log/phpmail.log"\r\n'),
-(2, 'Froxlor Vhost Config', '/usr/bin/php-cgi', 'php', '-1', '-1', 'allow_call_time_pass_reference = Off\r\nallow_url_fopen = On\r\nasp_tags = Off\r\ndisable_classes =\r\ndisable_functions = curl_multi_exec,exec,parse_ini_file,passthru,popen,proc_close,proc_get_status,proc_nice,proc_open,proc_terminate,shell_exec,show_source,system\r\ndisplay_errors = Off\r\ndisplay_startup_errors = Off\r\nenable_dl = Off\r\nerror_reporting = E_ALL & ~E_NOTICE\r\nexpose_php = Off\r\nfile_uploads = On\r\ncgi.force_redirect = 1\r\ngpc_order = "GPC"\r\nhtml_errors = Off\r\nignore_repeated_errors = Off\r\nignore_repeated_source = Off\r\ninclude_path = ".:{PEAR_DIR}"\r\nlog_errors = On\r\nlog_errors_max_len = 1024\r\nmagic_quotes_gpc = Off\r\nmagic_quotes_runtime = Off\r\nmagic_quotes_sybase = Off\r\nmax_execution_time = 60\r\nmax_input_time = 60\r\nmemory_limit = 128M\r\nnoutput_buffering = 4096\r\npost_max_size = 16M\r\nprecision = 14\r\nregister_argc_argv = Off\r\nregister_globals = Off\r\nreport_memleaks = On\r\nsendmail_path = "/usr/sbin/sendmail -t -i -f {CUSTOMER_EMAIL}"\r\nsession.auto_start = 0\r\nsession.bug_compat_42 = 0\r\nsession.bug_compat_warn = 1\r\nsession.cache_expire = 180\r\nsession.cache_limiter = nocache\r\nsession.cookie_domain =\r\nsession.cookie_lifetime = 0\r\nsession.cookie_path = /\r\nsession.entropy_file = /dev/urandom\r\nsession.entropy_length = 16\r\nsession.gc_divisor = 1000\r\nsession.gc_maxlifetime = 1440\r\nsession.gc_probability = 1\r\nsession.name = PHPSESSID\r\nsession.referer_check =\r\nsession.save_handler = files\r\nsession.save_path = "{TMP_DIR}"\r\nsession.serialize_handler = php\r\nsession.use_cookies = 1\r\nsession.use_trans_sid = 0\r\nshort_open_tag = On\r\nsuhosin.mail.protect = 1\r\nsuhosin.simulation = Off\r\ntrack_errors = Off\r\nupload_max_filesize = 32M\r\nupload_tmp_dir = "{TMP_DIR}"\r\nvariables_order = "GPCS"\r\n;mail.add_x_header = On\r\n;mail.log = "/var/log/phpmail.log"\r\n');
 
 
 DROP TABLE IF EXISTS `cronjobs_run`;
@@ -737,7 +792,7 @@ CREATE TABLE IF NOT EXISTS `cronjobs_run` (
   `isactive` tinyint(1) DEFAULT '1',
   `desc_lng_key` varchar(100) NOT NULL DEFAULT 'cron_unknown_desc',
   PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 INSERT INTO `cronjobs_run` (`id`, `module`, `cronfile`, `interval`, `isactive`, `desc_lng_key`) VALUES
@@ -762,7 +817,7 @@ CREATE TABLE IF NOT EXISTS `ftp_quotalimits` (
   `files_in_avail` int(10) unsigned NOT NULL,
   `files_out_avail` int(10) unsigned NOT NULL,
   `files_xfer_avail` int(10) unsigned NOT NULL
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -781,7 +836,7 @@ CREATE TABLE IF NOT EXISTS `ftp_quotatallies` (
   `files_in_used` int(10) unsigned NOT NULL,
   `files_out_used` int(10) unsigned NOT NULL,
   `files_xfer_used` int(10) unsigned NOT NULL
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -791,8 +846,8 @@ CREATE TABLE IF NOT EXISTS `redirect_codes` (
   `code` varchar(3) NOT NULL,
   `desc` varchar(200) NOT NULL,
   `enabled` tinyint(1) DEFAULT '1',
-  PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 
@@ -809,26 +864,40 @@ DROP TABLE IF EXISTS `domain_redirect_codes`;
 CREATE TABLE IF NOT EXISTS `domain_redirect_codes` (
   `rid` int(5) NOT NULL,
   `did` int(11) unsigned NOT NULL,
-  UNIQUE KEY `rc` (`rid`, `did`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  UNIQUE KEY `rc` (`rid`, `did`),
+  FOREIGN KEY `fk_redirect` (rid)
+    REFERENCES redirect_codes(id)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_domain` (did)
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 DROP TABLE IF EXISTS `domain_ssl_settings`;
 CREATE TABLE IF NOT EXISTS `domain_ssl_settings` (
   `id` int(5) NOT NULL auto_increment,
-  `domainid` int(11) NOT NULL,
+  `domainid` int(11) unsigned NOT NULL,
   `ssl_cert_file` mediumtext NOT NULL,
   `ssl_key_file` mediumtext NOT NULL,
   `ssl_ca_file` mediumtext,
   `ssl_cert_chainfile` mediumtext,
-  PRIMARY KEY  (`id`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
+  PRIMARY KEY (`id`),
+  FOREIGN KEY `fk_domain` (domainid) 
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;
 
 
 DROP TABLE IF EXISTS `panel_domaintoip`;
 CREATE TABLE IF NOT EXISTS `panel_domaintoip` (
   `id_domain` int(11) unsigned NOT NULL,
   `id_ipandports` int(11) unsigned NOT NULL,
-  PRIMARY KEY (`id_domain`,`id_ipandports`)
-) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
-
+  PRIMARY KEY (`id_domain`,`id_ipandports`),
+  FOREIGN KEY `fk_domain` (id_domain)
+    REFERENCES panel_domains(id)
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY `fk_ipandport` (id_ipandports)
+    REFERENCES panel_ipsandports(id)
+    ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB CHARSET=utf8 COLLATE=utf8_general_ci;

--- a/lib/classes/webserver/class.DomainSSL.php
+++ b/lib/classes/webserver/class.DomainSSL.php
@@ -46,7 +46,7 @@ class DomainSSL {
 				|| $dom_certs['ssl_cert_file'] == ''
 		) {
 			// maybe its parent?
-			if ($domain['parentdomainid'] != 0) {
+			if ($domain['parentdomainid'] != null) {
 				$dom_certs = Database::pexecute_first($dom_certs_stmt, array('domid' => $domain['parentdomainid']));
 			}
 		}

--- a/lib/formfields/customer/domains/formfield.domains_edit.php
+++ b/lib/formfields/customer/domains/formfield.domains_edit.php
@@ -61,14 +61,14 @@ return array(
 						'select_var' => $redirectcode
 					),
 					'selectserveralias' => array(
-						'visible' => (($result['parentdomainid'] == '0' && $userinfo['subdomains'] != '0') ? true : false),
+						'visible' => (($result['parentdomainid'] == null && $userinfo['subdomains'] != '0') ? true : false),
 						'label' => $lng['admin']['selectserveralias'],
 						'desc' => $lng['admin']['selectserveralias_desc'],
 						'type' => 'select',
 						'select_var' => $serveraliasoptions
 					),
 					'isemaildomain' => array(
-						'visible' => ((( $result['subcanemaildomain'] == '1' || $result['subcanemaildomain'] == '2' ) && $result['parentdomainid'] != '0') ? true : false),
+						'visible' => ((( $result['subcanemaildomain'] == '1' || $result['subcanemaildomain'] == '2' ) && $result['parentdomainid'] != null) ? true : false),
 						'label' => 'Emaildomain',
 						'type' => 'checkbox',
 						'values' => array(

--- a/lib/formfields/customer/email/formfield.emails_edit.php
+++ b/lib/formfields/customer/email/formfield.emails_edit.php
@@ -31,19 +31,19 @@ return array(
 						'value' => $result['email_full']
 					),
 					'account_yes' => array(
-						'visible' => ($result['popaccountid'] != 0 ? true : false),
+						'visible' => ($result['popaccountid'] != null ? true : false),
 						'label' => $lng['emails']['account'],
 						'type' => 'label',
 						'value' => $lng['panel']['yes'].'&nbsp;[<a href="'.$filename.'?page=accounts&amp;action=changepw&amp;id='.$result['id'].'&amp;s='.$s.'">'.$lng['menue']['main']['changepassword'].'</a>] [<a href="'.$filename.'?page=accounts&amp;action=delete&amp;id='.$result['id'].'&amp;s='.$s.'">'.$lng['emails']['account_delete'].'</a>]'
 					),
 					'account_no' => array(
-						'visible' => ($result['popaccountid'] == 0 ? true : false),
+						'visible' => ($result['popaccountid'] == null ? true : false),
 						'label' => $lng['emails']['account'],
 						'type' => 'label',
 						'value' => $lng['panel']['no'].'&nbsp;[<a href="'.$filename.'?page=accounts&amp;action=add&amp;id='.$result['id'].'&amp;s='.$s.'">'.$lng['emails']['account_add'].'</a>]'
 					),
 					'mail_quota' => array(
-						'visible' => ($result['popaccountid'] != 0 && Settings::Get('system.mail_quota_enabled')),
+						'visible' => ($result['popaccountid'] != null && Settings::Get('system.mail_quota_enabled')),
 						'label' => $lng['customer']['email_quota'],
 						'type' => 'label',
 						'value' => $result['quota'].' MiB [<a href="'.$filename.'?page=accounts&amp;action=changequota&amp;id='.$result['id'].'&amp;s='.$s.'">'.$lng['emails']['quota_edit'].'</a>]'

--- a/lib/functions/froxlor/function.updateCounters.php
+++ b/lib/functions/froxlor/function.updateCounters.php
@@ -99,7 +99,7 @@ function updateCounters($returndebuginfo = false) {
 		$customer_tickets = Database::pexecute_first($customer_tickets_stmt, array("cid" => $customer['customerid']));
 		$customer['tickets_used_new'] = (int)$customer_tickets['number_tickets'];
 		
-		$customer_subdomains_stmt = Database::prepare('SELECT COUNT(*) AS `number_subdomains` FROM `' . TABLE_PANEL_DOMAINS . '` WHERE `customerid` = :cid AND `parentdomainid` NOT NULL');
+		$customer_subdomains_stmt = Database::prepare('SELECT COUNT(*) AS `number_subdomains` FROM `' . TABLE_PANEL_DOMAINS . '` WHERE `customerid` = :cid AND `parentdomainid` IS NOT NULL');
 		$customer_subdomains = Database::pexecute_first($customer_subdomains_stmt, array("cid" => $customer['customerid']));
 		$customer['subdomains_used_new'] = (int)$customer_subdomains['number_subdomains'];
 		

--- a/lib/functions/froxlor/function.updateCounters.php
+++ b/lib/functions/froxlor/function.updateCounters.php
@@ -99,7 +99,7 @@ function updateCounters($returndebuginfo = false) {
 		$customer_tickets = Database::pexecute_first($customer_tickets_stmt, array("cid" => $customer['customerid']));
 		$customer['tickets_used_new'] = (int)$customer_tickets['number_tickets'];
 		
-		$customer_subdomains_stmt = Database::prepare('SELECT COUNT(*) AS `number_subdomains` FROM `' . TABLE_PANEL_DOMAINS . '` WHERE `customerid` = :cid AND `parentdomainid` <> "0"');
+		$customer_subdomains_stmt = Database::prepare('SELECT COUNT(*) AS `number_subdomains` FROM `' . TABLE_PANEL_DOMAINS . '` WHERE `customerid` = :cid AND `parentdomainid` NOT NULL');
 		$customer_subdomains = Database::pexecute_first($customer_subdomains_stmt, array("cid" => $customer['customerid']));
 		$customer['subdomains_used_new'] = (int)$customer_subdomains['number_subdomains'];
 		

--- a/lib/version.inc.php
+++ b/lib/version.inc.php
@@ -16,7 +16,7 @@
  */
 
 // Main version variable
-$version = '0.9.34-dev3';
+$version = '0.9.34-dev4';
 
 // Database version (unused, old stuff from SysCP)
 $dbversion = '2';

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -497,7 +497,7 @@ class apache {
 		$stats_text = '';
 
 		if ($domain['speciallogfile'] == '1') {
-			$statDomain = ($domain['parentdomainid'] == '0') ? $domain['domain'] : $domain['parentdomain'];
+			$statDomain = ($domain['parentdomainid'] == null) ? $domain['domain'] : $domain['parentdomain'];
 			if (Settings::Get('system.awstats_enabled') == '1') {
 				$stats_text .= '  Alias /awstats "' . makeCorrectFile($domain['customerroot'] . '/awstats/' . $statDomain) . '"' . "\n";
 				$stats_text .= '  Alias /awstats-icon "' . makeCorrectDir(Settings::Get('system.awstats_icons')) . '"' . "\n";
@@ -535,7 +535,7 @@ class apache {
 		$logfiles_text = '';
 
 		if ($domain['speciallogfile'] == '1') {
-			if ($domain['parentdomainid'] == '0') {
+			if ($domain['parentdomainid'] == null) {
 				$speciallogfile = '-' . $domain['domain'];
 			} else {
 				$speciallogfile = '-' . $domain['parentdomain'];

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -497,7 +497,7 @@ class lighttpd {
 
 		$speciallogfile = '';
 		if ($domain['speciallogfile'] == '1') {
-			if ($domain['parentdomainid'] == '0') {
+			if ($domain['parentdomainid'] == null) {
 				$speciallogfile = '-' . $domain['domain'];
 			} else {
 				$speciallogfile = '-' . $domain['parentdomain'];
@@ -784,7 +784,7 @@ class lighttpd {
 		$stats_text = '';
 
 		if ($domain['speciallogfile'] == '1') {
-			if ($domain['parentdomainid'] == '0') {
+			if ($domain['parentdomainid'] == null) {
 				if (Settings::Get('system.awstats_enabled') == '1') {
 					$stats_text.= '  alias.url = ( "/awstats/" => "'.makeCorrectFile($domain['customerroot'] . '/awstats/' . $domain['domain']).'" )' . "\n";
 					$stats_text.= '  alias.url += ( "/awstats-icon" => "' . makeCorrectDir(Settings::Get('system.awstats_icons')) . '" )' . "\n";

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -805,7 +805,7 @@ class nginx {
 		}
 
 		// if this is a parentdomain, we use this domain-name
-		if ($domain['parentdomainid'] == '0') {
+		if ($domain['parentdomainid'] == null) {
 			$alias_dir = makeCorrectDir($alias_dir.'/'.$domain['domain']);
 		} else {
 			$alias_dir = makeCorrectDir($alias_dir.'/'.$domain['parentdomain']);
@@ -840,7 +840,7 @@ class nginx {
 
 		$speciallogfile = '';
 		if ($domain['speciallogfile'] == '1') {
-			if ($domain['parentdomainid'] == '0') {
+			if ($domain['parentdomainid'] == null) {
 				$speciallogfile = '-' . $domain['domain'];
 			} else {
 				$speciallogfile = '-' . $domain['parentdomain'];

--- a/scripts/jobs/cron_traffic.php
+++ b/scripts/jobs/cron_traffic.php
@@ -89,7 +89,7 @@ while ($row_domainlist = $result_domainlist_stmt->fetch(PDO::FETCH_ASSOC)) {
 
 	$domainlist[$row_domainlist['customerid']][$row_domainlist['id']] = $row_domainlist['domain'];
 
-	if ($row_domainlist['parentdomainid'] == '0'
+	if ($row_domainlist['parentdomainid'] == null
 		&& $row_domainlist['speciallogfile'] == '1'
 	) {
 		if (!isset($speciallogfile_domainlist[$row_domainlist['customerid']])) {

--- a/templates/Sparkle/customer/email/emails_email.tpl
+++ b/templates/Sparkle/customer/email/emails_email.tpl
@@ -1,7 +1,7 @@
 <tr>
 	<td>{$row['email_full']}</td>
 	<td><if $row['destination'] == ''>&nbsp;<else>{$row['destination']}</if></td>
-	<td><if $row['popaccountid'] != 0>{$lng['panel']['yes']} ({$row['mboxsize']})</if><if $row['popaccountid'] == 0>{$lng['panel']['no']}</if></td>
+	<td><if $row['popaccountid'] != null>{$lng['panel']['yes']} ({$row['mboxsize']})</if><if $row['popaccountid'] == null>{$lng['panel']['no']}</if></td>
 	<if Settings::Get('catchall.catchall_enabled') == '1'><td><if $row['iscatchall'] != 0>{$lng['panel']['yes']}</if><if $row['iscatchall'] == 0>{$lng['panel']['no']}</if></td></if>
 	<if Settings::Get('system.mail_quota_enabled') == '1'><td><if $row['quota'] == 0>{$lng['emails']['noquota']}<else>{$row['quota']} MiB</if></if></td>
 	<td>


### PR DESCRIPTION
This PR adds foreign key constraints to the database, and additionally normalizes the values for `panel_domains.parentdomainid` and `mail_virtual.popaccountid` (both columns do allow and use `NULL` now for empty values, instead of `0`, which would violate the foreign key constraint).

#### Notes
* all tables are switched from the (deprecated) MyISAM engine to InnoDB, which is the recommended engine nowadays (MyISAM does not recognize foreign key constraints)
* some foreign key fields have been switched from `int(11)` to `int(11) unsigned`, because for foreign key constraints, the type must match the key of the referred table
* while this patch does not add new functionality in itself, it is a necessary groundwork for adding an ORM later (which would allow us to get rid of a lot of cruft in the long run)
* Another nice feat of referential integrity is that you can move IDs now easily - this is useful if you want to join two or more Froxlor databases, for example. Just update, for example, the `customerid` for some customer, and `ON UPDATE CASCADE` will update all the related fields as well.