### PR TITLE
mkDirWithCorrectOwnership() Handle empty subdir

### DIFF
--- a/lib/functions/filedir/function.mkDirWithCorrectOwnership.php
+++ b/lib/functions/filedir/function.mkDirWithCorrectOwnership.php
@@ -56,6 +56,11 @@ function mkDirWithCorrectOwnership($homeDir, $dirToCreate, $uid, $gid, $placeind
 			$within_homedir = false;
 		}
 
+		if(empty($subdir))
+		{
+			return $returncode;
+		}
+
 		$subdir = makeCorrectDir($subdir);
 		$subdirs = array();		
 


### PR DESCRIPTION
Wenn beim Aufruf von 

mkDirWithCorrectOwnership()

das Kundenverzeichnis als CreateDir übergeben wird, läuft die Funktion mit leerem $subdir durch.
