### PR TITLE
Insert new feature: custom dns records

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -368,11 +368,13 @@ if ($page == 'domains'
 
 					$isbinddomain = '0';
 					$zonefile = '';
+					$dnsrecords = '';
 					if (Settings::Get('system.bind_enable') == '1') {
 						if (isset($_POST['isbinddomain'])) {
 							$isbinddomain = intval($_POST['isbinddomain']);
 						}
 						$zonefile = validate($_POST['zonefile'], 'zonefile');
+						$dnsrecords = validate($_POST['dnsrecords'], 'dnsrecords');
 					}
 
 					if (isset($_POST['dkim'])) {
@@ -410,6 +412,7 @@ if ($page == 'domains'
 					}
 					$caneditdomain = '1';
 					$zonefile = '';
+					$dnsrecords = '';
 					$dkim = '1';
 					$specialsettings = '';
 				}
@@ -690,6 +693,7 @@ if ($page == 'domains'
 						'subcanemaildomain' => $subcanemaildomain,
 						'caneditdomain' => $caneditdomain,
 						'zonefile' => $zonefile,
+						'dnsrecords' => $dnsrecords,
 						'dkim' => $dkim,
 						'speciallogfile' => $speciallogfile,
 						'selectserveralias' => $serveraliasoption,
@@ -734,6 +738,7 @@ if ($page == 'domains'
 						'documentroot' => $documentroot,
 						'aliasdomain' => ($aliasdomain != 0 ? $aliasdomain : null),
 						'zonefile' => $zonefile,
+						'dnsrecords' => $dnsrecords,
 						'dkim' => $dkim,
 						'wwwserveralias' => $wwwserveralias,
 						'iswildcarddomain' => $iswildcarddomain,
@@ -762,6 +767,7 @@ if ($page == 'domains'
 						`documentroot` = :documentroot,
 						`aliasdomain` = :aliasdomain,
 						`zonefile` = :zonefile,
+						`dnsrecords` = :dnsrecords,
 						`dkim` = :dkim,
 						`dkim_id` = '0',
 						`dkim_privkey` = '',
@@ -1168,6 +1174,7 @@ if ($page == 'domains'
 				if ($userinfo['change_serversettings'] == '1') {
 					$isbinddomain = $result['isbinddomain'];
 					$zonefile = $result['zonefile'];
+						$dnsrecords = validate(str_replace("\r\n", "\n", $_POST['dnsrecords']), 'dnsrecords', '/^[^\0]*$/');
 					if (Settings::Get('system.bind_enable') == '1') {
 						if (isset($_POST['isbinddomain'])) {
 							$isbinddomain = (int)$_POST['isbinddomain'];
@@ -1175,6 +1182,7 @@ if ($page == 'domains'
 							$isbinddomain = 0;
 						}
 						$zonefile = validate($_POST['zonefile'], 'zonefile');
+						$dnsrecords = validate(str_replace("\r\n", "\n", $_POST['dnsrecords']), 'dnsrecords', '/^[^\0]*$/');
 					}
 
 					if (Settings::Get('dkim.use_dkim') == '1') {
@@ -1205,6 +1213,7 @@ if ($page == 'domains'
 				} else {
 					$isbinddomain = $result['isbinddomain'];
 					$zonefile = $result['zonefile'];
+					$dnsrecords = validate(str_replace("\r\n", "\n", $_POST['dnsrecords']), 'dnsrecords', '/^[^\0]*$/');
 					$dkim = $result['dkim'];
 					$specialsettings = $result['specialsettings'];
 					$documentroot = $result['documentroot'];
@@ -1430,6 +1439,7 @@ if ($page == 'domains'
 					'subcanemaildomain' => $subcanemaildomain,
 					'caneditdomain' => $caneditdomain,
 					'zonefile' => $zonefile,
+					'dnsrecords' => $dnsrecords,
 					'dkim' => $dkim,
 					'selectserveralias' => $serveraliasoption,
 					'ssl_redirect' => $ssl_redirect,
@@ -1488,6 +1498,7 @@ if ($page == 'domains'
 
 				if ($isbinddomain != $result['isbinddomain']
 					|| $zonefile != $result['zonefile']
+					|| $dnsrecords != $result['dnsrecords']
 					|| $dkim != $result['dkim']
 				) {
 					inserttask('4');
@@ -1603,6 +1614,7 @@ if ($page == 'domains'
 				$update_data['dkim'] = $dkim;
 				$update_data['caneditdomain'] = $caneditdomain;
 				$update_data['zonefile'] = $zonefile;
+				$update_data['dnsrecords'] = $dnsrecords;
 				$update_data['wwwserveralias'] = $wwwserveralias;
 				$update_data['iswildcarddomain'] = $iswildcarddomain;
 				$update_data['openbasedir'] = $openbasedir;
@@ -1629,6 +1641,7 @@ if ($page == 'domains'
 					`dkim` = :dkim,
 					`caneditdomain` = :caneditdomain,
 					`zonefile` = :zonefile,
+					`dnsrecords` = :dnsrecords,
 					`wwwserveralias` = :wwwserveralias,
 					`iswildcarddomain` = :iswildcarddomain,
 					`openbasedir` = :openbasedir,

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -228,6 +228,7 @@ CREATE TABLE `panel_domains` (
   `subcanemaildomain` tinyint(1) NOT NULL default '0',
   `caneditdomain` tinyint(1) NOT NULL default '1',
   `zonefile` varchar(255) NOT NULL default '',
+  `dnsrecords` text,
   `dkim` tinyint(1) NOT NULL default '0',
   `dkim_id` int(11) unsigned NOT NULL default '0',
   `dkim_privkey` text,

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3002,5 +3002,7 @@ if (isFroxlorVersion('0.9.34-dev4')) {
     showUpdateStep("Updating from 0.9.34-dev4 to 0.9.34 final");
     lastStepStatus(0);
 
+	Database::query("ALTER TABLE `".TABLE_PANEL_DOMAINS."` ADD `dnsrecords` text;");
+	
     updateToVersion('0.9.34');
 }

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -193,6 +193,15 @@ return array(
 						'label' => 'Zonefile',
 						'desc' => $lng['panel']['emptyfordefault'],
 						'type' => 'text'
+					),
+					'dnsrecords' => array(
+						'style' => 'align-top',
+						'label' => 'DNS-Records',
+						'desc' => $lng['admin']['dnsrecords'],
+						'type' => 'textarea',
+						'value' => $result['dnsrecords'],
+						'cols' => 60,
+						'rows' => 12
 					)
 				)
 			),

--- a/lib/formfields/admin/domains/formfield.domains_edit.php
+++ b/lib/formfields/admin/domains/formfield.domains_edit.php
@@ -218,6 +218,15 @@ return array(
 						'desc' => $lng['panel']['emptyfordefault'],
 						'type' => 'text',
 						'value' => $result['zonefile']
+					),
+					'dnsrecords' => array(
+						'style' => 'align-top',
+						'label' => 'DNS-Records',
+						'desc' => $lng['admin']['dnsrecords'],
+						'type' => 'textarea',
+						'value' => $result['dnsrecords'],
+						'cols' => 60,
+						'rows' => 12
 					)
 				)
 			),

--- a/lng/dutch.lng.php
+++ b/lng/dutch.lng.php
@@ -284,6 +284,7 @@ $lng['admin']['templates']['NAME'] = 'Vervangen door de naam van de klant.';
 $lng['admin']['templates']['USERNAME'] = 'Vervangen door de gebruikersnaam van de klant.';
 $lng['admin']['templates']['PASSWORD'] = 'Vervangen door het wachtwoord van de klant.';
 $lng['admin']['templates']['EMAIL'] = 'Vervangen door het adres van het POP3/IMAP account.';
+$lng['admin']['dnsrecords'] = 'Own DNS-Records which should be saved in the zonefile<br /><strong>Attention:</strong> The code won\'t be checked for any errors. If it contains errors, webserver might not start again!'; // ToDo: Translante
 
 /**
  * Serversettings

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -318,6 +318,7 @@ $lng['admin']['templates']['USERNAME'] = 'Replaced with the customers account us
 $lng['admin']['templates']['PASSWORD'] = 'Replaced with the customers account password.';
 $lng['admin']['templates']['EMAIL'] = 'Replaced with the address of the POP3/IMAP account.';
 $lng['admin']['webserver'] = 'Webserver';
+$lng['admin']['dnsrecords'] = 'Own DNS-Records which should be saved in the zonefile<br /><strong>Attention:</strong> The code won\'t be checked for any errors. If it contains errors, webserver might not start again!';
 
 /**
  * Serversettings

--- a/lng/french.lng.php
+++ b/lng/french.lng.php
@@ -432,6 +432,7 @@ $lng['panel']['ascending'] = 'ascendant';
 $lng['panel']['decending'] = 'descendant';
 $lng['panel']['search'] = 'Rechercher';
 $lng['panel']['used'] = 'utilisé';
+$lng['admin']['dnsrecords'] = 'Own DNS-Records which should be saved in the zonefile<br /><strong>Attention:</strong> The code won\'t be checked for any errors. If it contains errors, webserver might not start again!'; // ToDo: Translante
 
 // ADDED IN 1.2.14-rc3
 

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -316,6 +316,7 @@ $lng['admin']['templates']['COMPANY'] = 'Wird mit dem Firmennamen des Kunden ers
 $lng['admin']['templates']['USERNAME'] = 'Wird mit dem Benutzernamen des neuen Kundenkontos ersetzt.';
 $lng['admin']['templates']['PASSWORD'] = 'Wird mit dem Passwort des neuen Kundenkontos ersetzt.';
 $lng['admin']['templates']['EMAIL'] = 'Wird mit der Adresse des neuen E-Mail-Kontos ersetzt.';
+$lng['admin']['dnsrecords'] = 'Eigene DNS-Records welche in der Zonefile gespeichert werden sollen<br /><strong>ACHTUNG:</strong> Der Code wird nicht auf Fehler geprüft. Etwaige Fehler werden also auch übernommen. Der DNS-Server könnte nicht mehr starten!';
 
 /**
  * Serversettings

--- a/lng/italian.lng.php
+++ b/lng/italian.lng.php
@@ -309,6 +309,7 @@ $lng['admin']['templates']['USERNAME'] = 'Rimpiazzato con il nome utente dell\'a
 $lng['admin']['templates']['PASSWORD'] = 'Rimpiazzato con la password dell\'account.';
 $lng['admin']['templates']['EMAIL'] = 'Rimapiazzato con l\'indirizzo dell\'account.';
 $lng['admin']['webserver'] = 'Webserver';
+$lng['admin']['dnsrecords'] = 'Own DNS-Records which should be saved in the zonefile<br /><strong>Attention:</strong> The code won\'t be checked for any errors. If it contains errors, webserver might not start again!'; // ToDo: Translante
 
 /**
  * Serversettings

--- a/lng/portugues.lng.php
+++ b/lng/portugues.lng.php
@@ -312,6 +312,7 @@ $lng['admin']['templates']['NAME'] = 'Altere para o nome do cliente.';
 $lng['admin']['templates']['USERNAME'] = 'Altere para nome da conta do cliente.';
 $lng['admin']['templates']['PASSWORD'] = 'Altere com a senha da conta do cliente.';
 $lng['admin']['templates']['EMAIL'] = 'Altere com os dados do servidor POP3/IMAP.';
+$lng['admin']['dnsrecords'] = 'Own DNS-Records which should be saved in the zonefile<br /><strong>Attention:</strong> The code won\'t be checked for any errors. If it contains errors, webserver might not start again!'; // ToDo: Translante
 
 /**
  * Serversettings

--- a/lng/swedish.lng.php
+++ b/lng/swedish.lng.php
@@ -301,6 +301,7 @@ $lng['admin']['templates']['NAME'] = 'Ändra till kundens efternamn.';
 $lng['admin']['templates']['USERNAME'] = 'Ändra till kundens kontonamns användarnamn.';
 $lng['admin']['templates']['PASSWORD'] = 'Ändra till kundens kontonamns lösenord.';
 $lng['admin']['templates']['EMAIL'] = 'Ändra till adressen för POP3/IMAP kontot.';
+$lng['admin']['dnsrecords'] = 'Own DNS-Records which should be saved in the zonefile<br /><strong>Attention:</strong> The code won\'t be checked for any errors. If it contains errors, webserver might not start again!'; // ToDo: Translante
 
 /**
  * Serversettings

--- a/scripts/jobs/cron_tasks.inc.dns.10.bind.php
+++ b/scripts/jobs/cron_tasks.inc.dns.10.bind.php
@@ -365,6 +365,17 @@ class bind {
 				$zonefile.= $record . "\tIN\t" . $ip_a_record . "\n";
 			}
 		}
+		
+		// Append custom DNS-Records
+		$domain_stmt = Database::prepare("
+			SELECT `dnsrecords` FROM `" . TABLE_PANEL_DOMAINS . "`
+			WHERE `id` = :domainid
+		");
+		Database::pexecute($domain_stmt, array('domainid' => $domain['id']));
+						
+		while ($dnsrecords = $domain_stmt->fetch(PDO::FETCH_ASSOC)) {
+			$zonefile .= $dnsrecords['dnsrecords'];
+		}
 
 		return $zonefile;
 	}


### PR DESCRIPTION
This patch would add the possibility to add custom dns entries to each domain.
The custom entries are appended at the bottom of the zonefile generated by Froxlor.
Users can add custom entries at a text field while editing/adding domains.