### PR TITLE
Duplicate fastcgi_index

### DIFF
--- a/lib/configfiles/gentoo.xml
+++ b/lib/configfiles/gentoo.xml
@@ -210,8 +210,6 @@ http {
 					</file>
 					<file name="/etc/nginx/fastcgi_params">
 						<content><![CDATA[
-fastcgi_index index.php;
-
 fastcgi_connect_timeout 65;
 fastcgi_send_timeout    180;
 fastcgi_read_timeout    180;

--- a/lib/configfiles/jessie.xml
+++ b/lib/configfiles/jessie.xml
@@ -242,8 +242,6 @@ http {
 					</file>
 					<file name="/etc/nginx/fastcgi_params">
 						<content><![CDATA[
-fastcgi_index index.php;
-
 fastcgi_connect_timeout 65;
 fastcgi_send_timeout    180;
 fastcgi_read_timeout    180;

--- a/lib/configfiles/precise.xml
+++ b/lib/configfiles/precise.xml
@@ -200,8 +200,6 @@ http {
 					</file>
 					<file name="/etc/nginx/fastcgi_params">
 						<content><![CDATA[
-fastcgi_index index.php;
-
 fastcgi_connect_timeout 65;
 fastcgi_send_timeout    180;
 fastcgi_read_timeout    180;

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -220,8 +220,6 @@ http {
 					</file>
 					<file name="/etc/nginx/fastcgi_params">
 						<content><![CDATA[
-fastcgi_index index.php;
-
 fastcgi_connect_timeout 65;
 fastcgi_send_timeout    180;
 fastcgi_read_timeout    180;

--- a/lib/configfiles/wheezy.xml
+++ b/lib/configfiles/wheezy.xml
@@ -260,8 +260,6 @@ http {
 					</file>
 					<file name="/etc/nginx/fastcgi_params">
 						<content><![CDATA[
-fastcgi_index index.php;
-
 fastcgi_connect_timeout 65;
 fastcgi_send_timeout    180;
 fastcgi_read_timeout    180;


### PR DESCRIPTION
remove duplicate fastcgi_index from config templates