### PR TITLE
fix blacklisting of characters in paths

### DIFF
--- a/lib/functions/filedir/function.makeSecurePath.php
+++ b/lib/functions/filedir/function.makeSecurePath.php
@@ -47,7 +47,7 @@ function makeSecurePath($path) {
 	// thx to aaronmueller for this snipped
 	$badchars = array(':', ';', '|', '&', '>', '<', '`', '$', '~', '?');
 	foreach ($badchars as $bc) {
-		str_replace($bc, "", $path);
+		$path = str_replace($bc, "", $path);
 	}
 
 	return $path;


### PR DESCRIPTION
This fix ensures that the result of str_replace() is taken into account for the path that is returned.