### PR TITLE
prevent directory traversal in paths

### DIFF
--- a/lib/functions/filedir/function.makeSecurePath.php
+++ b/lib/functions/filedir/function.makeSecurePath.php
@@ -26,29 +26,27 @@
  */
 function makeSecurePath($path) {
 
+	// check for bad characters, some are allowed with escaping
+	// but we generally don't want them in our directory-names,
+	// thx to aaronmueller for this snipped
+	$badchars = array(':', ';', '|', '&', '>', '<', '`', '$', '~', '?', "\0");
+	foreach ($badchars as $bc) {
+		$path = str_replace($bc, "", $path);
+	}
+
 	$search = array(
 		'#/+#',
-		'#\.+#',
-		'#\0+#'
+		'#\.+#'
 	);
 	$replace = array(
 		'/',
-		'.',
-		''
+		'.'
 	);
 	$path = preg_replace($search, $replace, $path);
 	// don't just replace a space with an escaped space
 	// it might be escaped already
 	$path = str_replace("\ ", " ", $path);
 	$path = str_replace(" ", "\ ", $path);
-
-	// check for bad characters, some are allowed with escaping
-	// but we generally don't want them in our directory-names,
-	// thx to aaronmueller for this snipped
-	$badchars = array(':', ';', '|', '&', '>', '<', '`', '$', '~', '?');
-	foreach ($badchars as $bc) {
-		$path = str_replace($bc, "", $path);
-	}
 
 	return $path;
 }


### PR DESCRIPTION
This fix prevents directory traverals where a blacklisted character is injected in between two dots: `"/.\0./"`