### PR TITLE
cron_tasks/bind: cleanup conditions for creation of mail-related and www DNS records

### DIFF
--- a/scripts/jobs/cron_tasks.inc.dns.10.bind.php
+++ b/scripts/jobs/cron_tasks.inc.dns.10.bind.php
@@ -333,10 +333,11 @@ class bind {
 		}
 
 		$records[] = '@';
-		$records[] = 'www';
 
 		if ($domain['iswildcarddomain'] == '1') {
 			$records[] = '*';
+		} else if ($domain['wwwserveralias'] == '1') {
+			$records[] = 'www';
 		}
 
 		if (!$froxlorhost) {


### PR DESCRIPTION
These patches take into account a domain's setting of isemaildomain and wwwserveralias for the creation of A/AAAA-records (www, pop3, imap, smtp) and TXT-records (SPF)