### PR TITLE
add function getFormFieldDataText()

### DIFF
--- a/lib/functions/formfields/text/function.getFormFieldDataText.php
+++ b/lib/functions/formfields/text/function.getFormFieldDataText.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Daniel Reichelt <hacking@nachtgeist.net> (2016-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Functions
+ *
+ */
+
+function getFormFieldDataText($fieldname, $fielddata, &$input) {
+	if(isset($input[$fieldname])) {
+		$newfieldvalue = str_replace("\r\n", "\n", $input[$fieldname]);
+	} else {
+		$newfieldvalue = $fielddata['default'];
+	}
+
+	return $newfieldvalue;
+}


### PR DESCRIPTION
Previously webserver configs would contain CRLFs from
system.default_vhostconf on admin_settings.php.

This patch adds a new function which automatically gets recognized by
getFormFieldData() and mangles textarea form elements through
str_replace("\r\n", "\n", ...).