### PR TITLE
Fixes nginx error due to duplicate fastcgi parameters

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -209,7 +209,6 @@ class nginx extends HttpConfigBase {
 
 				$this->nginx_data[$vhost_filename] .= "\tlocation ~ \.php {\n";
 				$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_split_path_info ^(.+\.php)(/.+)\$;\n";
-				$this->nginx_data[$vhost_filename] .= "\t\tinclude fastcgi_params;\n";
 				$this->nginx_data[$vhost_filename] .= "\t\tinclude ".Settings::Get('nginx.fastcgiparams').";\n";
 				$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n";
 				$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param PATH_INFO \$fastcgi_path_info;\n";


### PR DESCRIPTION
Including fastcgi_params twice is causing these errors when generating the config with Froxlor:
[emerg] "fastcgi_connect_timeout" directive is duplicate in /etc/nginx/fastcgi_params:1

I removed the "standard" fastcgi_params but left the parameters in the database, that way an individual could change the parameters on a case-by-case basis without touching the 'native' stuff the packager has put in.