### PR TITLE
Fix for case insensitivity bug in Apache 2.4.12 + PHP-FPM

### DIFF
--- a/lib/classes/phpinterface/class.phpinterface_fpm.php
+++ b/lib/classes/phpinterface/class.phpinterface_fpm.php
@@ -348,7 +348,7 @@ class phpinterface_fpm {
 	public function getSocketFile($createifnotexists = true) {
 
 		$socketdir = makeCorrectDir(Settings::Get('phpfpm.fastcgi_ipcdir'));
-		$socket = makeCorrectFile($socketdir.'/'.$this->_domain['loginname'].'-'.$this->_domain['domain'].'-php-fpm.socket');
+		$socket = strtolower(makeCorrectFile($socketdir.'/'.$this->_domain['loginname'].'-'.$this->_domain['domain'].'-php-fpm.socket'));
 
 		if (!is_dir($socketdir) && $createifnotexists) {
 			safe_exec('mkdir -p '.escapeshellarg($socketdir));


### PR DESCRIPTION
With Apache 2.4.12, the FPM socket path is always considered as a
lowercase file path regardless of the used capitalization.
If Froxlor creates a socket file containing uppercase characters, Apache fails to find to the socket.
See https://bz.apache.org/bugzilla/show_bug.cgi?id=57968