### PR TITLE
Nginx: Fix for redundantly inserted auth blocks

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -788,7 +788,18 @@ class nginx extends HttpConfigBase {
 
 				$returnval[$x]['path'] = $path;
 				$returnval[$x]['root'] = makeCorrectDir($domain['documentroot']);
-				$returnval[$x]['authname'] = $row_htpasswds['authname'];
+
+				// Ensure there is only one auth name per password block, otherwise
+				// the directives are inserted multiple times -> invalid config
+				$authname = $row_htpasswds['authname'];
+				for ($i = 0; $i < $x; $i++) {
+					if ($returnval[$i]['usrf'] == $htpasswd_filename) {
+						$authname = $returnval[$i]['authname'];
+						break;
+					}
+				}
+				$returnval[$x]['authname'] = $authname;
+
 				$returnval[$x]['usrf'] = $htpasswd_filename;
 				$x++;
 			}

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -427,7 +427,7 @@ class nginx extends HttpConfigBase {
 			if (substr($uri, -1) == '/') {
 				$uri = substr($uri, 0, -1);
 			}
-			$vhost_content .= "\t".'rewrite ^(.*) '.$uri.'$1 permanent;'."\n";
+			$vhost_content .= "\t".'return 301 '.$uri.'$request_uri;'."\n";
 		} else {
 			mkDirWithCorrectOwnership($domain['customerroot'], $domain['documentroot'], $domain['guid'], $domain['guid'], true);
 


### PR DESCRIPTION
The problem occurs if a Vhost is assigned multiple different auth names
in Froxlor. Each block is then added repeatedly, leading to an
unparseable configuration