### PR TITLE
Apache 2.4: Add AllowOverride All, otherwise Apache ignores .htaccess files

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -84,6 +84,7 @@ class apache extends HttpConfigBase {
 			// >=apache-2.4 enabled?
 			if (Settings::Get('system.apache24') == '1') {
 				$this->virtualhosts_data[$vhosts_filename].= '    Require all granted' . "\n";
+				$this->virtualhosts_data[$vhosts_filename].= '    AllowOverride All' . "\n";
 			} else {
 				$this->virtualhosts_data[$vhosts_filename].= '    Order allow,deny' . "\n";
 				$this->virtualhosts_data[$vhosts_filename].= '    allow from all' . "\n";
@@ -230,6 +231,7 @@ class apache extends HttpConfigBase {
 							// for this path, as this would be the first require and therefore grant all access
 							if ($mypath_dir->isUserProtected() == false) {
 								$this->virtualhosts_data[$vhosts_filename].= '    Require all granted' . "\n";
+								$this->virtualhosts_data[$vhosts_filename].= '    AllowOverride All' . "\n";
 							}
 						} else {
 							$this->virtualhosts_data[$vhosts_filename].= '    Order allow,deny' . "\n";
@@ -284,6 +286,7 @@ class apache extends HttpConfigBase {
 							// for this path, as this would be the first require and therefore grant all access
 							if ($mypath_dir->isUserProtected() == false) {
 								$this->virtualhosts_data[$vhosts_filename] .= '    Require all granted' . "\n";
+								$this->virtualhosts_data[$vhosts_filename] .= '    AllowOverride All' . "\n";
 							}
 						} else {
 							$this->virtualhosts_data[$vhosts_filename] .= '    Order allow,deny' . "\n";
@@ -1049,6 +1052,7 @@ class apache extends HttpConfigBase {
 						// for this path, as this would be the first require and therefore grant all access
 						if ($mypath_dir->isUserProtected() == false) {
 							$this->diroptions_data[$diroptions_filename] .= '  Require all granted' . "\n";
+							//$this->diroptions_data[$diroptions_filename] .= '  AllowOverride All' . "\n";
 						}
 					} else {
 						$this->diroptions_data[$diroptions_filename] .= '  Order allow,deny' . "\n";

--- a/scripts/jobs/cron_tasks.inc.http.15.apache_fcgid.php
+++ b/scripts/jobs/cron_tasks.inc.http.15.apache_fcgid.php
@@ -55,6 +55,7 @@ class apache_fcgid extends apache
 				    if ($mypath_dir->isUserProtected() == false) {
 						$php_options_text.= '  <Directory "' . makeCorrectDir($domain['documentroot']) . '">' . "\n";
 					    $php_options_text.= '    Require all granted' . "\n";
+						$php_options_text.= '    AllowOverride All' . "\n";
 						$php_options_text.= '  </Directory>' . "\n";
 				    }
 
@@ -73,6 +74,7 @@ class apache_fcgid extends apache
 					    // for this path, as this would be the first require and therefore grant all access
 					    if ($mypath_dir->isUserProtected() == false) {
 						    $php_options_text.= '    Require all granted' . "\n";
+							$php_options_text.= '    AllowOverride All' . "\n";
 					    }
 					} else {
 						$php_options_text.= '    Order allow,deny' . "\n";
@@ -110,6 +112,7 @@ class apache_fcgid extends apache
 					    // for this path, as this would be the first require and therefore grant all access
 					    if ($mypath_dir->isUserProtected() == false) {
 						    $php_options_text.= '    Require all granted' . "\n";
+							$php_options_text.= '    AllowOverride All' . "\n";
 					    }
 					} else {
 						$php_options_text.= '    Order allow,deny' . "\n";


### PR DESCRIPTION
Problem:
Since Apache 2.3.9 the default setting for AllowOverride has been changed to None [1]. Now without a permissive setting of AllowOverride, this leads to an error, such as:
(13)Permission denied: /var/customers/webs/.../.htaccess pcfg_openfile: unable to check htaccess file, ensure it is readable

Manual fixes have been suggested several times [2][3][4][5][6]. However, instead of setting custom Vhost settings for every client who needs .htaccess files, or instead of writing a global diroptions file manually, it seems more reasonable to simply add the option when creating a Vhost. This adds no problems with Apache 2.2 (since it is the standard settings there anyway) and solves the annoying error with Apache 2.4.

[1] https://httpd.apache.org/docs/2.4/mod/core.html#allowoverride
[2] https://forum.froxlor.org/index.php/topic/13258-php-fpm-und-mod-rewrite/
[3] https://forum.froxlor.org/index.php/topic/12290-solved-apache-246-mod-rewrite-funktioniert-nicht/
[4] https://forum.froxlor.org/index.php/topic/403-missing-directives-in-apache-domain-configuration/
[5] https://forum.froxlor.org/index.php/topic/12367-probleme-mit-allowoverride-all/
[6] https://forum.froxlor.org/index.php/topic/498-options-in-der-vhostconfig-aendern/