### PR TITLE
Nginx: Security-critical fix for faulty directory protection

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.35.nginx_phpfpm.php
+++ b/scripts/jobs/cron_tasks.inc.http.35.nginx_phpfpm.php
@@ -25,6 +25,10 @@ class nginx_phpfpm extends nginx
 			$phpconfig = $php->getPhpConfig((int)$domain['phpsettingid']);
 			
 			$php_options_text = "\t" . 'location ~ ^(.+?\.php)(/.*)?$ {' . "\n";
+			$php_options_text .= "\t\t" . 'try_files ' . $domain['nonexistinguri'] . ' @php;' . "\n";
+			$php_options_text .= "\t" . '}' . "\n\n";
+
+			$php_options_text .= "\t" . 'location @php {' . "\n";
 			$php_options_text .= "\t\t" . 'try_files $1 = 404;' . "\n\n";
 			$php_options_text .= "\t\t" . 'include ' . Settings::Get('nginx.fastcgiparams') . ";\n";
 			$php_options_text .= "\t\t" . 'fastcgi_split_path_info ^(.+\.php)(/.+)\$;' . "\n";


### PR DESCRIPTION
**Problem:**
The implemented directory protection does not reliably prevent access to PHP scripts.

Having set a username/password for a specific folder, you are shown a prompt when accessing http://...com/protectedir/
Nevertheless, it is still possible to call http://...com/protectedir/script.php
**directly without having to enter credentials**.

This vulnerability emerges from the precedence order of "location" statements. The RegEx matching the PHP script is triggered before the directory protection is evaluated. As a result, the PHP script is
interpreted and path parsing stops due to the circumflex (see http://nginx.org/en/docs/http/ngx_http_core_module.html#location).

**Solution:**
The fix involves adding a separate PHP parsing snippet to every protected block. In order to prevent inserting PHP-related config params repeatedly, the required section is referenced using a prefix.