### PR TITLE
Nginx: Change fastcgi IPC dir to a path that is definitely existing

### DIFF
--- a/install/lib/class.FroxlorInstall.php
+++ b/install/lib/class.FroxlorInstall.php
@@ -470,7 +470,7 @@ class FroxlorInstall {
 			$this->_updateSetting($upd_stmt, '/etc/nginx/froxlor-htpasswd/', 'system', 'apacheconf_htpasswddir');
 			$this->_updateSetting($upd_stmt, '/etc/init.d/nginx reload', 'system', 'apachereload_command');
 			$this->_updateSetting($upd_stmt, '/etc/nginx/nginx.pem', 'system', 'ssl_cert_file');
-			$this->_updateSetting($upd_stmt, '/var/run/nginx/', 'phpfpm', 'fastcgi_ipcdir');
+			$this->_updateSetting($upd_stmt, '/var/run/', 'phpfpm', 'fastcgi_ipcdir');
 		}
 		
 		$this->_updateSetting($upd_stmt, dirname(dirname(dirname(__FILE__))), 'system', 'letsencryptchallengepath');


### PR DESCRIPTION
**Problem:**
The current _fastcgi_ipcdir_ refers to a directory that is not necessarily existing. Whether the path _/var/run/nginx/_ is created by Nginx depends on the used installation. When using the nginx package from Debian, the path is set-up upon installation. Otherwise, if nginx is compiled from source or fetched as package from the offical repo (nginx.org), the directory is not created.

**Solution:**
Set the path to a directory that is existing regardless of the provenience of the nginx installation.