### PR TITLE
.gitignore update for Idea or WebStorm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ install/update.log
 *.diff
 *~
 .well-known
+.idea
+*.iml


### PR DESCRIPTION
Stop Git-tracking internal files from Intellij IDEA or WebStorm (cf. Eclipse project files)