### PR TITLE
IPs and Ports: Only show attributes used by the current webserver

### DIFF
--- a/admin_ipsandports.php
+++ b/admin_ipsandports.php
@@ -29,6 +29,10 @@ if (isset($_POST['id'])) {
 if ($page == 'ipsandports'
 	|| $page == 'overview'
 ) {
+	// Do not display attributes that are not used by the current webserver
+	$websrv = Settings::Get('system.webserver');
+	$is_nginx = ($websrv == 'nginx');
+	$is_apache = ($websrv == 'apache2');
 
 	if ($action == '') {
 

--- a/lib/formfields/admin/ipsandports/formfield.ipsandports_add.php
+++ b/lib/formfields/admin/ipsandports/formfield.ipsandports_add.php
@@ -40,6 +40,7 @@ return array(
 				'image' => 'icons/ipsports_add.png',
 				'fields' => array(
 					'listen_statement' => array(
+						'visible' => !$is_nginx,
 						'label' => $lng['admin']['ipsandports']['create_listen_statement'],
 						'type' => 'checkbox',
 						'values' => array(
@@ -48,6 +49,7 @@ return array(
 						'value' => array('1')
 					),
 					'namevirtualhost_statement' => array(
+						'visible' => $is_apache,
 						'label' => $lng['admin']['ipsandports']['create_namevirtualhost_statement'],
 						'type' => 'checkbox',
 						'values' => array(
@@ -77,6 +79,7 @@ return array(
 						'rows' => 12
 					),
 					'vhostcontainer_servername_statement' => array(
+						'visible' => $is_apache,
 						'label' => $lng['admin']['ipsandports']['create_vhostcontainer_servername_statement'],
 						'type' => 'checkbox',
 						'values' => array(

--- a/lib/formfields/admin/ipsandports/formfield.ipsandports_edit.php
+++ b/lib/formfields/admin/ipsandports/formfield.ipsandports_edit.php
@@ -42,6 +42,7 @@ return array(
 				'image' => 'icons/ipsports_edit.png',
 				'fields' => array(
 					'listen_statement' => array(
+						'visible' => !$is_nginx,
 						'label' => $lng['admin']['ipsandports']['create_listen_statement'],
 						'type' => 'checkbox',
 						'values' => array(
@@ -50,6 +51,7 @@ return array(
 						'value' => array($result['listen_statement'])
 					),
 					'namevirtualhost_statement' => array(
+						'visible' => $is_apache,
 						'label' => $lng['admin']['ipsandports']['create_namevirtualhost_statement'],
 						'type' => 'checkbox',
 						'values' => array(
@@ -81,6 +83,7 @@ return array(
 						'value' => $result['specialsettings']
 					),
 					'vhostcontainer_servername_statement' => array(
+						'visible' => $is_apache,
 						'label' => $lng['admin']['ipsandports']['create_vhostcontainer_servername_statement'],
 						'type' => 'checkbox',
 						'values' => array(

--- a/templates/Sparkle/admin/ipsandports/ipsandports.tpl
+++ b/templates/Sparkle/admin/ipsandports/ipsandports.tpl
@@ -8,29 +8,29 @@ $header
 		</header>
 
 		<section>
-			
+
 			<form action="{$linker->getLink(array('section' => 'ipsandports'))}" method="post" enctype="application/x-www-form-urlencoded">
 				<input type="hidden" name="s" value="$s"/>
 				<input type="hidden" name="page" value="$page"/>
 				<div class="overviewsearch">
 					{$searchcode}
 				</div>
-	
+
 				<div class="overviewadd">
 					<img src="templates/{$theme}/assets/img/icons/add.png" alt="" />&nbsp;
 					<a href="{$linker->getLink(array('section' => 'ipsandports', 'page' => $page, 'action' => 'add'))}">{$lng['admin']['ipsandports']['add']}</a>
 				</div>
-	
+
 				<table class="full hl">
 					<thead>
 						<tr>
 							<th>{$lng['admin']['ipsandports']['ip']}&nbsp;{$arrowcode['ip']}</th>
 							<th>{$lng['admin']['ipsandports']['port']}&nbsp;{$arrowcode['port']}</th>
-							<th>Listen</th>
-							<th>NameVirtualHost</th>
+							<if !$is_nginx><th>Listen</th></if>
+							<if $is_apache><th>NameVirtualHost</th></if>
 							<th>vHost-Container</th>
 							<th>Specialsettings</th>
-							<th>ServerName</th>
+							<if $is_apache><th>ServerName</th></if>
 							<th>SSL</th>
 							<th>{$lng['panel']['options']}</th>
 						</tr>
@@ -39,7 +39,7 @@ $header
 					<if $pagingcode != ''>
 					<tfoot>
 						<tr>
-							<td colspan="8">{$pagingcode}</td>
+							<td colspan="<if $is_apache>8<else>6</if>">{$pagingcode}</td>
 						</tr>
 					</tfoot>
 					</if>

--- a/templates/Sparkle/admin/ipsandports/ipsandports_ipandport.tpl
+++ b/templates/Sparkle/admin/ipsandports/ipsandports_ipandport.tpl
@@ -1,11 +1,11 @@
 <tr>
 	<td>{$row['ip']}</td>
 	<td>{$row['port']}</td>
-	<td><if $row['listen_statement']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td>
-	<td><if $row['namevirtualhost_statement']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td>
+	<if !$is_nginx><td><if $row['listen_statement']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td></if>
+	<if $is_apache><td><if $row['namevirtualhost_statement']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td></if>
 	<td><if $row['vhostcontainer']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td>
 	<td><if $row['specialsettings']!=''>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td>
-	<td><if $row['vhostcontainer_servername_statement']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td>
+	<if $is_apache><td><if $row['vhostcontainer_servername_statement']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td></if>
 	<td><if $row['ssl']=='1'>{$lng['panel']['yes']}<else>{$lng['panel']['no']}</if></td>
 	<td>
 		<a href="{$linker->getLink(array('section' => 'ipsandports', 'page' => $page, 'action' => 'edit', 'id' => $row['id']))}">


### PR DESCRIPTION
**Problem:**
Nginx does not know listen statements, NameVirtualHost and ServerName unknown to lighttpd and nginx.
Nevertheless, these directives are outlined when using webservers that do not support them.

**Solution:**
Only show options that are relevant for the currently active webserver.

_Note:_ In practice, it is conceivable that someone would switch the Webserver from nginx to Apache. However, this should be no problem either since all fields are assigned default values in the db schema.