### PR TITLE
Feature: Make the MYSQL_PASSWORD string dynamically definable

### DIFF
--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1968,3 +1968,5 @@ $lng['admin']['server_php'] = 'PHP';
 // Added for Termination-date
 $lng['domains']['termination_date'] = 'Date of termination';
 $lng['domains']['termination_date_overview'] = 'canceled until ';
+
+$lng['panel']['set'] = 'Apply';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1498,7 +1498,7 @@ $lng['logger']['cron'] = "Cronjob";
 $lng['logger']['login'] = "Login";
 $lng['logger']['intern'] = "Intern";
 $lng['logger']['unknown'] = "Unbekannt";
-$lng['serversettings']['mailtraffic_enabled']['title'] = "Analysiere Mailtraffic"; 
+$lng['serversettings']['mailtraffic_enabled']['title'] = "Analysiere Mailtraffic";
 $lng['serversettings']['mailtraffic_enabled']['description'] = "Aktiviere das analysieren der Logdateien des Mailsystems um den verbrauchten Traffic zu berechnen";
 $lng['serversettings']['mdaserver']['title'] = "Typ des MDA";
 $lng['serversettings']['mdaserver']['description'] = "Der eingesetzte Mail Delivery Server";
@@ -1608,3 +1608,5 @@ $lng['domains']['ssl_redirect_temporarilydisabled'] = "<br>Die SSL-Umleitung ist
 // Added for Termination-date
 $lng['domains']['termination_date'] = 'K&uuml;ndigungsdatum';
 $lng['domains']['termination_date_overview'] = 'gek&uuml;ndigt zum ';
+
+$lng['panel']['set'] = 'Setzen';

--- a/templates/Sparkle/admin/configfiles/configfiles.tpl
+++ b/templates/Sparkle/admin/configfiles/configfiles.tpl
@@ -26,6 +26,10 @@ ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero
 eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
 no sea takimata sanctus est Lorem ipsum dolor sit amet.</textarea>
 				</p>
+				<form id="configfiles_setmysqlpw" action="#">
+					MYSQL_PASSWORD: <input type="text" class="text" id="configfiles_mysqlpw" name="configfiles_mysqlpw" value="" />
+					<input type="submit" value="{$lng['panel']['set']}" />
+				</form>
 			</div>
 		</section>
 

--- a/templates/Sparkle/assets/js/main.js
+++ b/templates/Sparkle/assets/js/main.js
@@ -202,4 +202,19 @@ $(document).ready(function() {
 		$("#mailTemplate").html(mailOptions);
 	});
 	$("#mailLanguage").trigger("change");
+
+	// Config files
+	var configfileTextareas = $("textarea.filecontent, textarea.shell");
+	var lastPw = "MYSQL_PASSWORD";
+	$("#configfiles_setmysqlpw").submit(function(event) {
+		event.preventDefault();
+		var inputVal = $("#configfiles_mysqlpw").val();
+		if (!inputVal.trim()) {
+			inputVal = "MYSQL_PASSWORD";
+		}
+		configfileTextareas.each(function() {
+			this.value = this.value.replace(lastPw, inputVal);
+		});
+		lastPw = inputVal;
+	});
 });


### PR DESCRIPTION
**Problem:**
All textarea fields are set read-only and cannot be changed inline. Depending on the service to configure, it might happen that you have to replace the MYSQL_PASSWORD numerous times, e.g. when setting up Postfix with all the mysql-* files.

Having to set this variable over and over is tedious, annoying and prone to typos. Aside from that, you may miss one occurrence to replace and then spend precious time on retracing your mistake.

**Solution:**
Once per template, make the MYSQL_PASSWORD field dynamically configurable. The admin enters the password on the client-side (only), it is propagated over all textareas of the current config template and you can then really simply copy-and-paste the resulting fragments.

![a](https://cloud.githubusercontent.com/assets/343448/13199082/84f16a44-d81b-11e5-870d-4319cf8cf1c0.png)
