### PR TITLE
Nginx: Set default curve to secp384r1

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -571,6 +571,7 @@ class nginx extends HttpConfigBase {
     			//$sslsettings .= "\t" . 'ssl on;' . "\n";
     			$sslsettings .= "\t" . 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2;' . "\n";
     			$sslsettings .= "\t" . 'ssl_ciphers ' . Settings::Get('system.ssl_cipher_list') . ';' . "\n";
+					$sslsettings .= "\t" . 'ssl_ecdh_curve secp384r1;' . "\n";
     			$sslsettings .= "\t" . 'ssl_prefer_server_ciphers on;' . "\n";
     			$sslsettings .= "\t" . 'ssl_certificate ' . makeCorrectFile($domain_or_ip['ssl_cert_file']) . ';' . "\n";
     


### PR DESCRIPTION
Why change the curve for ECDH key exchange from secp256r1 to secp384r1?
Because in the security world, we are practically heading towards RSA 4096-bit keypairs for TLS usage. An elliptic curve with primes of 256 bits relates to the cryptographic strength of a 3072-bits RSA key. Hence, for a sufficiently strong key exchange, we may also choose a curve for ECDH key exchange that is at least 384-bits. For a comparison, this corresponds to the equivalent of a 7680-bits RSA key or a 192-bits of symmetric key.

Basically, all browsers and servers supporting secp256r1 also provide secp384r1. Hence, compatibility issues are almost not existing. The change towards secp384r1 may involve only one downside: the used openssl implementation might not be as optimized as the one for secp256r1.