### PR TITLE
Feature: Enable multiple standard IPs

### DIFF
--- a/actions/admin/settings/120.system.php
+++ b/actions/admin/settings/120.system.php
@@ -55,7 +55,7 @@ return array(
 					'settinggroup' => 'system',
 					'varname' => 'defaultip',
 					'type' => 'option',
-					'option_mode' => 'one',
+					'option_mode' => 'multiple',
 					'option_options_method' => 'getIpPortCombinations',
 					'default' => '',
 					'save_method' => 'storeSettingDefaultIp',

--- a/admin_customers.php
+++ b/admin_customers.php
@@ -914,10 +914,10 @@ if ($page == 'customers'
 
 						// set ip <-> domain connection
 						$defaultips = explode(',', Settings::Get('system.defaultip'));
-						foreach ($defaultips as $defaultip) {
-							$ins_stmt = Database::prepare("
+						$ins_stmt = Database::prepare("
 							  INSERT INTO `" . TABLE_DOMAINTOIP . "` SET `id_domain` = :domainid, `id_ipandports` = :ipid"
-							);
+						);
+						foreach ($defaultips as $defaultip) {
 							Database::pexecute($ins_stmt, array('domainid' => $domainid, 'ipid' => $defaultip));
 						}
 
@@ -1276,10 +1276,10 @@ if ($page == 'customers'
 
 						// set ip <-> domain connection
 						$defaultips = explode(',', Settings::Get('system.defaultip'));
-						foreach ($defaultips as $defaultip) {
-							$ins_stmt = Database::prepare("
+						$ins_stmt = Database::prepare("
 							  INSERT INTO `" . TABLE_DOMAINTOIP . "` SET `id_domain` = :domainid, `id_ipandports` = :ipid"
-							);
+						);
+						foreach ($defaultips as $defaultip) {
 							Database::pexecute($ins_stmt, array('domainid' => $domainid, 'ipid' => $defaultip));
 						}
 

--- a/admin_customers.php
+++ b/admin_customers.php
@@ -913,10 +913,13 @@ if ($page == 'customers'
 						$domainid = Database::lastInsertId();
 
 						// set ip <-> domain connection
-						$ins_stmt = Database::prepare("
-							INSERT INTO `".TABLE_DOMAINTOIP."` SET `id_domain` = :domainid, `id_ipandports` = :ipid"
-						);
-						Database::pexecute($ins_stmt, array('domainid' => $domainid, 'ipid' => Settings::Get('system.defaultip')));
+						$defaultips = explode(',', Settings::Get('system.defaultip'));
+						foreach ($defaultips as $defaultip) {
+							$ins_stmt = Database::prepare("
+							  INSERT INTO `" . TABLE_DOMAINTOIP . "` SET `id_domain` = :domainid, `id_ipandports` = :ipid"
+							);
+							Database::pexecute($ins_stmt, array('domainid' => $domainid, 'ipid' => $defaultip));
+						}
 
 						$upd_stmt = Database::prepare("
 							UPDATE `" . TABLE_PANEL_CUSTOMERS . "` SET `standardsubdomain` = :domainid WHERE `customerid` = :customerid"
@@ -937,7 +940,7 @@ if ($page == 'customers'
 							SELECT ip, port FROM `".TABLE_PANEL_IPSANDPORTS."`
 							WHERE `id` = :defaultip
 						");
-						$srv_ip = Database::pexecute_first($srv_ip_stmt, array('defaultip' => Settings::Get('system.defaultip')));
+						$srv_ip = Database::pexecute_first($srv_ip_stmt, array('defaultip' => reset(explode(',', Settings::Get('system.defaultip')))));
 
 						$replace_arr = array(
 							'FIRSTNAME' => $firstname,
@@ -1272,10 +1275,13 @@ if ($page == 'customers'
 						$domainid = Database::lastInsertId();
 
 						// set ip <-> domain connection
-						$ins_stmt = Database::prepare("
-							INSERT INTO `".TABLE_DOMAINTOIP."` SET `id_domain` = :domainid, `id_ipandports` = :ipid"
-						);
-						Database::pexecute($ins_stmt, array('domainid' => $domainid, 'ipid' => Settings::Get('system.defaultip')));
+						$defaultips = explode(',', Settings::Get('system.defaultip'));
+						foreach ($defaultips as $defaultip) {
+							$ins_stmt = Database::prepare("
+							  INSERT INTO `" . TABLE_DOMAINTOIP . "` SET `id_domain` = :domainid, `id_ipandports` = :ipid"
+							);
+							Database::pexecute($ins_stmt, array('domainid' => $domainid, 'ipid' => $defaultip));
+						}
 
 						$upd_stmt = Database::prepare("
 							UPDATE `" . TABLE_PANEL_CUSTOMERS . "` SET `standardsubdomain` = :domainid WHERE `customerid` = :customerid"

--- a/admin_ipsandports.php
+++ b/admin_ipsandports.php
@@ -83,7 +83,7 @@ if ($page == 'ipsandports'
 			$result_checkdomain = Database::pexecute_first($result_checkdomain_stmt, array('id' => $id));
 
 			if ($result_checkdomain['id'] == '') {
-				if ($result['id'] != Settings::Get('system.defaultip')) {
+				if (!in_array($result['id'], explode(',', Settings::Get('system.defaultip')))) {
 
 					$result_sameipotherport_stmt = Database::prepare("
 						SELECT `id` FROM `" . TABLE_PANEL_IPSANDPORTS . "`
@@ -324,7 +324,7 @@ if ($page == 'ipsandports'
 					$ssl_ca_file = '';
 					$ssl_cert_chainfile = '';
 				}
-				
+
 				if ($listen_statement != '1') {
 					$listen_statement = '0';
 				}
@@ -344,7 +344,7 @@ if ($page == 'ipsandports'
 				if ($ssl != '1') {
 					$ssl = '0';
 				}
-				
+
 				if ($ssl_cert_file != '') {
 					$ssl_cert_file = makeCorrectFile($ssl_cert_file);
 				}
@@ -426,7 +426,7 @@ if ($page == 'ipsandports'
 
 				$ipsandports_edit_data = include_once dirname(__FILE__).'/lib/formfields/admin/ipsandports/formfield.ipsandports_edit.php';
 				$ipsandports_edit_form = htmlform::genHTMLForm($ipsandports_edit_data);
-	
+
 				$title = $ipsandports_edit_data['ipsandports_edit']['title'];
 				$image = $ipsandports_edit_data['ipsandports_edit']['image'];
 

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -97,7 +97,7 @@ return array(
 						'desc' => $lng['domains']['ipandport_multi']['description'],
 						'type' => 'checkbox',
 						'values' => $ipsandports,
-						'value' => array(Settings::Get('system.defaultip')),
+						'value' => explode(',', Settings::Get('system.defaultip')),
 						'is_array' => 1,
 						'mandatory' => true
 					),

--- a/lib/functions/settings/function.storeSettingDefaultIp.php
+++ b/lib/functions/settings/function.storeSettingDefaultIp.php
@@ -47,7 +47,7 @@ function storeSettingDefaultIp($fieldname, $fielddata, $newfieldvalue) {
 			$del_stmt = Database::prepare("
 					DELETE FROM `" . TABLE_DOMAINTOIP . "`
 					WHERE `id_domain` IN (" . implode(', ', $ids) . ")
-					AND `id_ipandports` IN (" . $defaultips_old . ")
+					AND `id_ipandports` IN (" . $defaultips_old . ", " . $newfieldvalue . ")
 			");
 			Database::pexecute($del_stmt);
 


### PR DESCRIPTION
**Problem:**
Until now, it was only possible to specify one IP address used for new domains by default. This is annoying if you run a dual-stack setup with IPv4 and IPv6 (cf. https://redmine.froxlor.org/issues/1509). 

**Solution:**
Make more than one IP address eligible by default. The solution has been tested working on many different hosts and is also suited to be applied as an update on-top of the existing setting.