### PR TITLE
Feature: vHost templates (version 2)

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -97,7 +97,7 @@ if ($page == 'domains'
 			}
 			$row['ipandport'] = substr($row['ipandport'], 0, -1);
                         $row['termination_date'] = str_replace("0000-00-00", "", $row['termination_date']);
-                        
+
                         if($row['termination_date'] != "")
                         {
                             $cdate = strtotime($row['termination_date'] . " 23:59:59");
@@ -434,7 +434,7 @@ if ($page == 'domains'
 				}
 
 				$vhostsettingid = 0;
-				$vhost_usedefaultlocation = 0;
+				$vhost_usedefaultlocation = 1;
 				if ($userinfo['caneditphpsettings'] == '1'
 					|| $userinfo['change_serversettings'] == '1'
 				) {
@@ -446,7 +446,7 @@ if ($page == 'domains'
 					) {
 						$phpsettingid = (int)$_POST['phpsettingid'];
 						$vhostsettingid = (int)$_POST['vhostsettingid'];
-						$vhost_usedefaultlocation = (int)$_POST['vhost_usedefaultlocation'];
+						$vhost_usedefaultlocation = isset($_POST['vhost_usedefaultlocation']) ? (int)$_POST['vhost_usedefaultlocation'] : 1;
 						$phpsettingid_check_stmt = Database::prepare("
 							SELECT * FROM `" . TABLE_PANEL_PHPCONFIGS . "`
 							WHERE `id` = :phpsettingid"
@@ -1288,7 +1288,7 @@ if ($page == 'domains'
 					) {
 						$phpsettingid = (int)$_POST['phpsettingid'];
 						$vhostsettingid = (int)$_POST['vhostsettingid'];
-						$vhost_usedefaultlocation = (int)$_POST['vhost_usedefaultlocation'];
+						$vhost_usedefaultlocation = isset($_POST['vhost_usedefaultlocation']) ? (int)$_POST['vhost_usedefaultlocation'] : $vhost_usedefaultlocation;
 						$phpsettingid_check_stmt = Database::prepare("
 							SELECT * FROM `" . TABLE_PANEL_PHPCONFIGS . "` WHERE `id` = :phpid
 						");
@@ -1979,7 +1979,7 @@ if ($page == 'domains'
 				// Fudge the result for ssl_redirect to hide the Let's Encrypt steps
 				$result['temporary_ssl_redirect'] = $result['ssl_redirect'];
 				$result['ssl_redirect'] = ($result['ssl_redirect'] == 0 ? 0 : 1);
-				
+
 				$serveraliasoptions .= makeoption($lng['domains']['serveraliasoption_wildcard'], '0', $_value, true, true);
 				$serveraliasoptions .= makeoption($lng['domains']['serveraliasoption_www'], '1', $_value, true, true);
 				$serveraliasoptions .= makeoption($lng['domains']['serveraliasoption_none'], '2', $_value, true, true);

--- a/admin_domains.php
+++ b/admin_domains.php
@@ -433,6 +433,8 @@ if ($page == 'domains'
 					$specialsettings = '';
 				}
 
+				$vhostsettingid = 0;
+				$vhost_usedefaultlocation = 0;
 				if ($userinfo['caneditphpsettings'] == '1'
 					|| $userinfo['change_serversettings'] == '1'
 				) {
@@ -443,6 +445,8 @@ if ($page == 'domains'
 						|| (int)Settings::Get('phpfpm.enabled') == 1
 					) {
 						$phpsettingid = (int)$_POST['phpsettingid'];
+						$vhostsettingid = (int)$_POST['vhostsettingid'];
+						$vhost_usedefaultlocation = (int)$_POST['vhost_usedefaultlocation'];
 						$phpsettingid_check_stmt = Database::prepare("
 							SELECT * FROM `" . TABLE_PANEL_PHPCONFIGS . "`
 							WHERE `id` = :phpsettingid"
@@ -734,6 +738,8 @@ if ($page == 'domains'
 						'ssl_ipandport' => serialize($ssl_ipandports),
 						'openbasedir' => $openbasedir,
 						'phpsettingid' => $phpsettingid,
+						'vhostsettingid' => $vhostsettingid,
+						'vhost_usedefaultlocation' => $vhost_usedefaultlocation,
 						'mod_fcgid_starter' => $mod_fcgid_starter,
 						'mod_fcgid_maxrequests' => $mod_fcgid_maxrequests,
 						'specialsettings' => $specialsettings,
@@ -788,6 +794,8 @@ if ($page == 'domains'
 						'registration_date' => $registration_date,
                                                 'termination_date' => $termination_date,
 						'phpsettingid' => $phpsettingid,
+						'vhostsettingid' => $vhostsettingid,
+						'vhost_usedefaultlocation' => $vhost_usedefaultlocation,
 						'mod_fcgid_starter' => $mod_fcgid_starter,
 						'mod_fcgid_maxrequests' => $mod_fcgid_maxrequests,
 						'ismainbutsubto' => $issubof,
@@ -821,6 +829,8 @@ if ($page == 'domains'
 						`registration_date` = :registration_date,
                                                 `termination_date` = :termination_date,
 						`phpsettingid` = :phpsettingid,
+						`vhostsettingid` = :vhostsettingid,
+						`vhost_usedefaultlocation` = :vhost_usedefaultlocation,
 						`mod_fcgid_starter` = :mod_fcgid_starter,
 						`mod_fcgid_maxrequests` = :mod_fcgid_maxrequests,
 						`ismainbutsubto` = :ismainbutsubto,
@@ -1000,6 +1010,15 @@ if ($page == 'domains'
 					} else {
 						$phpconfigs.= makeoption($row['description'], $row['id'], Settings::Get('system.mod_fcgid_defaultini'), true, true);
 					}
+				}
+
+				// vhost configs
+				$vhostconfigs = '';
+				$configsvhost = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` ORDER BY description ASC");
+
+				$vhostconfigs.= makeoption($lng['admin']['vhostsettings']['novhostsettings'], 0);
+				while ($row = $configsvhost->fetch(PDO::FETCH_ASSOC)) {
+					$vhostconfigs.= makeoption($row['description'], $row['id'], '', true, true);
 				}
 
 				// create serveralias options
@@ -1255,6 +1274,8 @@ if ($page == 'domains'
 				}
 
 				$speciallogverified = (isset($_POST['speciallogverified']) ? (int)$_POST['speciallogverified'] : 0);
+				$vhostsettingid = $result['vhostsettingid'];
+				$vhost_usedefaultlocation = $result['vhost_usedefaultlocation'];
 
 				if ($userinfo['caneditphpsettings'] == '1'
 					|| $userinfo['change_serversettings'] == '1'
@@ -1266,6 +1287,8 @@ if ($page == 'domains'
 						|| (int)Settings::Get('phpfpm.enabled') == 1
 					) {
 						$phpsettingid = (int)$_POST['phpsettingid'];
+						$vhostsettingid = (int)$_POST['vhostsettingid'];
+						$vhost_usedefaultlocation = (int)$_POST['vhost_usedefaultlocation'];
 						$phpsettingid_check_stmt = Database::prepare("
 							SELECT * FROM `" . TABLE_PANEL_PHPCONFIGS . "` WHERE `id` = :phpid
 						");
@@ -1496,6 +1519,8 @@ if ($page == 'domains'
 					'ssl_redirect' => $ssl_redirect,
 					'openbasedir' => $openbasedir,
 					'phpsettingid' => $phpsettingid,
+					'vhost_usedefaultlocation' => $vhost_usedefaultlocation,
+					'vhostsettingid' => $vhostsettingid,
 					'mod_fcgid_starter' => $mod_fcgid_starter,
 					'mod_fcgid_maxrequests' => $mod_fcgid_maxrequests,
 					'specialsettings' => $specialsettings,
@@ -1534,6 +1559,8 @@ if ($page == 'domains'
 					|| $iswildcarddomain != $result['iswildcarddomain']
 					|| $openbasedir != $result['openbasedir']
 					|| $phpsettingid != $result['phpsettingid']
+					|| $vhostsettingid != $result['vhostsettingid']
+					|| $vhost_usedefaultlocation != $result['vhost_usedefaultlocation']
 					|| $mod_fcgid_starter != $result['mod_fcgid_starter']
 					|| $mod_fcgid_maxrequests != $result['mod_fcgid_maxrequests']
 					|| $specialsettings != $result['specialsettings']
@@ -1672,6 +1699,8 @@ if ($page == 'domains'
 				$update_data['openbasedir'] = $openbasedir;
 				$update_data['speciallogfile'] = $speciallogfile;
 				$update_data['phpsettingid'] = $phpsettingid;
+				$update_data['vhostsettingid'] = $vhostsettingid;
+				$update_data['vhost_usedefaultlocation'] = $vhost_usedefaultlocation;
 				$update_data['mod_fcgid_starter'] = $mod_fcgid_starter;
 				$update_data['mod_fcgid_maxrequests'] = $mod_fcgid_maxrequests;
 				$update_data['specialsettings'] = $specialsettings;
@@ -1700,6 +1729,8 @@ if ($page == 'domains'
 					`openbasedir` = :openbasedir,
 					`speciallogfile` = :speciallogfile,
 					`phpsettingid` = :phpsettingid,
+					`vhostsettingid` = :vhostsettingid,
+					`vhost_usedefaultlocation` = :vhost_usedefaultlocation,
 					`mod_fcgid_starter` = :mod_fcgid_starter,
 					`mod_fcgid_maxrequests` = :mod_fcgid_maxrequests,
 					`specialsettings` = :specialsettings,
@@ -1715,6 +1746,8 @@ if ($page == 'domains'
 				$_update_data['adminid'] = $adminid;
 				$_update_data['openbasedir'] = $openbasedir;
 				$_update_data['phpsettingid'] = $phpsettingid;
+				$_update_data['vhost_usedefaultlocation'] = $vhost_usedefaultlocation;
+				$_update_data['vhostsettingid'] = $vhostsettingid;
 				$_update_data['mod_fcgid_starter'] = $mod_fcgid_starter;
 				$_update_data['mod_fcgid_maxrequests'] = $mod_fcgid_maxrequests;
 				$_update_data['parentdomainid'] = $id;
@@ -1732,6 +1765,8 @@ if ($page == 'domains'
 					`customerid` = :customerid,
 					`adminid` = :adminid,
 					`openbasedir` = :openbasedir,
+					`vhostsettingid` = :vhostsettingid,
+					`vhost_usedefaultlocation` = :vhost_usedefaultlocation,
 					`phpsettingid` = :phpsettingid,
 					`mod_fcgid_starter` = :mod_fcgid_starter,
 					`mod_fcgid_maxrequests` = :mod_fcgid_maxrequests
@@ -1961,6 +1996,14 @@ if ($page == 'domains'
 
 				while ($phpconfigs_row = $phpconfigs_result_stmt->fetch(PDO::FETCH_ASSOC)) {
 					$phpconfigs.= makeoption($phpconfigs_row['description'], $phpconfigs_row['id'], $result['phpsettingid'], true, true);
+				}
+
+				// vhost configs
+				$vhostconfigs = '';
+				$vhostconfigs_result_stmt = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` ORDER BY description ASC");
+				$vhostconfigs .= makeoption($lng['admin']['vhostsettings']['novhostsettings'], 0);
+				while ($vhostconfig_row = $vhostconfigs_result_stmt->fetch(PDO::FETCH_ASSOC)) {
+					$vhostconfigs .= makeoption($vhostconfig_row['description'], $vhostconfig_row['id'], $result['vhostsettingid'], true, true);
 				}
 
 				$result = htmlentities_array($result);

--- a/admin_phpsettings.php
+++ b/admin_phpsettings.php
@@ -62,6 +62,7 @@ if ($page == 'overview') {
 				}
 			}
 
+			$query .= " ORDER BY domain ASC";
 			$domainresult_stmt = Database::prepare($query);
 			Database::pexecute($domainresult_stmt, $query_params);
 

--- a/admin_vhostsettings.php
+++ b/admin_vhostsettings.php
@@ -2,18 +2,18 @@
 
 /**
  * This file is part of the Froxlor project.
- * Copyright (c) 2003-2009 the SysCP Team (see authors).
- * Copyright (c) 2010 the Froxlor Team (see authors).
+ * Copyright (c) 2016 the Froxlor Team (see authors).
  *
  * For the full copyright and license information, please view the COPYING
  * file that was distributed with this source code. You can also view the
  * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
  *
  * @copyright  (c) the authors
- * @author     Florian Lippert <flo@syscp.org> (2003-2009)
  * @author     Froxlor team <team@froxlor.org> (2010-)
  * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
  * @package    Panel
+ *
+ * @since      0.9.35
  *
  */
 

--- a/admin_vhostsettings.php
+++ b/admin_vhostsettings.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2003-2009 the SysCP Team (see authors).
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Florian Lippert <flo@syscp.org> (2003-2009)
+ * @author     Froxlor team <team@froxlor.org> (2010-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Panel
+ *
+ */
+
+define('AREA', 'admin');
+require './lib/init.php';
+
+$id = 0;
+if (isset($_POST['id'])) {
+	$id = intval($_POST['id']);
+} elseif (isset($_GET['id'])) {
+	$id = intval($_GET['id']);
+}
+
+if ($page == 'overview') {
+	if ($action == '') {
+		$tablecontent = '';
+		$count = 0;
+		$result = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` ORDER BY description ASC");
+
+		while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
+
+			$domainresult = false;
+			$query_params = array('id' => $row['id']);
+
+			$query = "SELECT * FROM `".TABLE_PANEL_DOMAINS."`
+					WHERE `vhostsettingid` = :id
+					AND `parentdomainid` = '0'";
+
+			if ((int)$userinfo['domains_see_all'] == 0) {
+				$query .= " AND `adminid` = :adminid";
+				$query_params['adminid'] = $userinfo['adminid'];
+			}
+
+			if ((int)Settings::Get('panel.phpconfigs_hidestdsubdomain') == 1) {
+				$ssdids_res = Database::query("
+					SELECT DISTINCT `standardsubdomain` FROM `".TABLE_PANEL_CUSTOMERS."`
+					WHERE `standardsubdomain` > 0 ORDER BY `standardsubdomain` ASC;"
+				);
+				$ssdids = array();
+				while ($ssd = $ssdids_res->fetch(PDO::FETCH_ASSOC)) {
+					$ssdids[] = $ssd['standardsubdomain'];
+				}
+				if (count($ssdids) > 0) {
+					$query .= " AND `id` NOT IN (".implode(', ', $ssdids).")";
+				}
+			}
+
+			$domainresult_stmt = Database::prepare($query);
+			Database::pexecute($domainresult_stmt, $query_params);
+
+			$domains = '';
+			if (Database::num_rows() > 0) {
+				while ($row2 = $domainresult_stmt->fetch(PDO::FETCH_ASSOC)) {
+					$domains.= $row2['domain'] . '<br/>';
+				}
+			}
+
+			if ($domains == '') {
+				$domains = $lng['admin']['phpsettings']['notused'];
+			}
+
+			// check whether this is our default config
+			if ((Settings::Get('system.mod_fcgid') == '1'
+					&& Settings::Get('system.mod_fcgid_defaultini') == $row['id'])
+				|| (Settings::Get('phpfpm.enabled') == '1'
+					&& Settings::Get('phpfpm.defaultini') == $row['id'])
+			) {
+				$row['description'] = '<b>'.$row['description'].'</b>';
+			}
+
+			$count++;
+			eval("\$tablecontent.=\"" . getTemplate("vhostconfig/overview_overview") . "\";");
+		}
+
+		eval("echo \"" . getTemplate("vhostconfig/overview") . "\";");
+	}
+
+	if ($action == 'add') {
+
+		if ((int)$userinfo['change_serversettings'] == 1) {
+
+			if (isset($_POST['send'])
+				&& $_POST['send'] == 'send'
+			) {
+				$description = validate($_POST['description'], 'description');
+				$vhostsettings = validate(trim(str_replace("\r\n", "\n", $_POST['vhostsettings'])), 'vhostsettings', '/^[^\0]*$/');
+
+				if (strlen($description) == 0
+					|| strlen($description) > 50
+				) {
+					standard_error('descriptioninvalid');
+				}
+
+				$ins_stmt = Database::prepare("
+					INSERT INTO `" . TABLE_PANEL_VHOSTCONFIGS . "` SET
+						`description` = :desc,
+						`vhostsettings` = :vhostsettings"
+				);
+				$ins_data = array(
+					'desc' => $description,
+					'vhostsettings' => $vhostsettings
+				);
+				Database::pexecute($ins_stmt, $ins_data);
+
+				inserttask('1');
+				$log->logAction(ADM_ACTION, LOG_INFO, "vhost config setting with description '" . $description . "' has been created by '" . $userinfo['loginname'] . "'");
+				redirectTo($filename, array('page' => $page, 's' => $s));
+
+			} else {
+
+				$result_stmt = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = 1");
+				$result = $result_stmt->fetch(PDO::FETCH_ASSOC);
+
+				$vhostconfig_add_data = include_once dirname(__FILE__).'/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php';
+				$vhostconfig_add_form = htmlform::genHTMLForm($vhostconfig_add_data);
+
+				$title = $vhostconfig_add_data['vhostconfig_add']['title'];
+				$image = $vhostconfig_add_data['vhostconfig_add']['image'];
+
+				eval("echo \"" . getTemplate("vhostconfig/overview_add") . "\";");
+			}
+
+		} else {
+			standard_error('nopermissionsorinvalidid');
+		}
+	}
+
+	if ($action == 'delete') {
+
+		$result_stmt = Database::prepare("
+			SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id"
+		);
+		$result = Database::pexecute_first($result_stmt, array('id' => $id));
+
+		if ($result['id'] != 0
+			&& $result['id'] == $id
+			&& (int)$userinfo['change_serversettings'] == 1
+		) {
+
+			if (isset($_POST['send'])
+				&& $_POST['send'] == 'send'
+			) {
+				$del_stmt = Database::prepare("
+					DELETE FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id"
+				);
+				Database::pexecute($del_stmt, array('id' => $id));
+
+				inserttask('1');
+				$log->logAction(ADM_ACTION, LOG_INFO, "vhost config setting with id #" . (int)$id . " has been deleted by '" . $userinfo['loginname'] . "'");
+				redirectTo($filename, array('page' => $page, 's' => $s));
+
+			} else {
+				ask_yesno('vhostsetting_reallydelete', $filename, array('id' => $id, 'page' => $page, 'action' => $action), $result['description']);
+			}
+		} else {
+			standard_error('nopermissionsorinvalidid');
+		}
+	}
+
+	if ($action == 'edit') {
+
+		$result_stmt = Database::prepare("
+			SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id"
+		);
+		$result = Database::pexecute_first($result_stmt, array('id' => $id));
+
+		if ($result['id'] != 0
+			&& $result['id'] == $id
+			&& (int)$userinfo['change_serversettings'] == 1
+		) {
+
+			if (isset($_POST['send'])
+				&& $_POST['send'] == 'send'
+			) {
+				$description = validate($_POST['description'], 'description');
+				$vhostsettings = validate(trim(str_replace("\r\n", "\n", $_POST['vhostsettings'])), 'vhostsettings', '/^[^\0]*$/');
+
+				if (strlen($description) == 0
+					|| strlen($description) > 50
+				) {
+					standard_error('descriptioninvalid');
+				}
+
+				$upd_stmt = Database::prepare("
+					UPDATE `" . TABLE_PANEL_VHOSTCONFIGS . "` SET
+						`description` = :desc,
+						`vhostsettings` = :vhostsettings
+					WHERE `id` = :id"
+				);
+				$upd_data = array(
+						'desc' => $description,
+						'vhostsettings' => $vhostsettings,
+						'id' => $id
+				);
+				Database::pexecute($upd_stmt, $upd_data);
+
+				inserttask('1');
+				$log->logAction(ADM_ACTION, LOG_INFO, "vhost setting with description '" . $description . "' has been changed by '" . $userinfo['loginname'] . "'");
+				redirectTo($filename, array('page' => $page, 's' => $s));
+
+			} else {
+
+				$vhostconfig_edit_data = include_once dirname(__FILE__).'/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php';
+				$vhostconfig_edit_form = htmlform::genHTMLForm($vhostconfig_edit_data);
+
+				$title = $vhostconfig_edit_data['vhostconfig_edit']['title'];
+				$image = $vhostconfig_edit_data['vhostconfig_edit']['image'];
+
+				eval("echo \"" . getTemplate("vhostconfig/overview_edit") . "\";");
+			}
+
+		} else {
+			standard_error('nopermissionsorinvalidid');
+		}
+	}
+}

--- a/admin_vhostsettings.php
+++ b/admin_vhostsettings.php
@@ -61,6 +61,7 @@ if ($page == 'overview') {
 				}
 			}
 
+			$query .= " ORDER BY domain ASC";
 			$domainresult_stmt = Database::prepare($query);
 			Database::pexecute($domainresult_stmt, $query_params);
 

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -240,6 +240,8 @@ CREATE TABLE `panel_domains` (
   `openbasedir_path` tinyint(1) NOT NULL default '0',
   `speciallogfile` tinyint(1) NOT NULL default '0',
   `ssl_redirect` tinyint(4) NOT NULL default '0',
+  `vhost_usedefaultlocation` tinyint(1) NOT NULL default '1',
+  `vhostsettingid` tinyint(11) NOT NULL default '0',
   `specialsettings` text,
   `deactivated` tinyint(1) NOT NULL default '0',
   `bindserial` varchar(10) NOT NULL default '2000010100',
@@ -554,7 +556,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('panel', 'password_numeric', '0'),
 	('panel', 'password_special_char_required', '0'),
 	('panel', 'password_special_char', '!?<>§$%+#=@'),
-	('panel', 'version', '0.9.35-dev5');
+	('panel', 'version', '0.9.35-dev6');
 
 
 DROP TABLE IF EXISTS `panel_tasks`;
@@ -783,7 +785,7 @@ CREATE TABLE IF NOT EXISTS `ftp_quotalimits` (
 
 
 
-INSERT INTO `ftp_quotalimits` (`name`, `quota_type`, `per_session`, `limit_type`, `bytes_in_avail`, `bytes_out_avail`, `bytes_xfer_avail`, `files_in_avail`, `files_out_avail`, `files_xfer_avail`) VALUES 
+INSERT INTO `ftp_quotalimits` (`name`, `quota_type`, `per_session`, `limit_type`, `bytes_in_avail`, `bytes_out_avail`, `bytes_xfer_avail`, `files_in_avail`, `files_out_avail`, `files_xfer_avail`) VALUES
 	('froxlor', 'user', 'false', 'hard', 0, 0, 0, 0, 0, 0);
 
 
@@ -851,3 +853,10 @@ CREATE TABLE IF NOT EXISTS `panel_domaintoip` (
   PRIMARY KEY (`id_domain`,`id_ipandports`)
 ) ENGINE=MyISAM CHARSET=utf8 COLLATE=utf8_general_ci;
 
+DROP TABLE IF EXISTS `panel_vhostconfigs`;
+CREATE TABLE IF NOT EXISTS `panel_vhostconfigs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `description` varchar(50) NOT NULL,
+  `vhostsettings` text NOT NULL,
+  PRIMARY KEY (`id`)
+) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3095,3 +3095,26 @@ if (isFroxlorVersion('0.9.35-dev4')) {
 
 	updateToVersion('0.9.35-dev5');
 }
+
+if (isFroxlorVersion('0.9.35-dev5')) {
+
+	showUpdateStep("Updating from 0.9.35-dev5 to 0.9.35-dev6", false);
+
+	showUpdateStep("Adding new panel_vhostconfigs table");
+	Database::query("DROP TABLE IF EXISTS `panel_vhostconfigs`;");
+	$sql = "CREATE TABLE `" . TABLE_PANEL_VHOSTCONFIGS . "` (
+      `id` int(11) NOT NULL AUTO_INCREMENT,
+      `description` varchar(50) NOT NULL,
+      `vhostsettings` text NOT NULL,
+      PRIMARY KEY (`id`)
+    ) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;";
+	Database::query($sql);
+	lastStepStatus(0);
+
+	showUpdateStep("Adding new fields to panel_domains table");
+	Database::query("ALTER TABLE `" . TABLE_PANEL_DOMAINS ."` ADD `vhost_usedefaultlocation` tinyint(1) NOT NULL default '1' AFTER `ssl_redirect`;");
+	Database::query("ALTER TABLE `" . TABLE_PANEL_DOMAINS ."` ADD `vhostsettingid` tinyint(11) NOT NULL default '0' AFTER `vhost_usedefaultlocation`;");
+	lastStepStatus(0);
+
+	updateToVersion('0.9.35-dev6');
+}

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3103,11 +3103,11 @@ if (isFroxlorVersion('0.9.35-dev5')) {
 	showUpdateStep("Adding new panel_vhostconfigs table");
 	Database::query("DROP TABLE IF EXISTS `panel_vhostconfigs`;");
 	$sql = "CREATE TABLE `" . TABLE_PANEL_VHOSTCONFIGS . "` (
-      `id` int(11) NOT NULL AUTO_INCREMENT,
-      `description` varchar(50) NOT NULL,
-      `vhostsettings` text NOT NULL,
-      PRIMARY KEY (`id`)
-    ) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;";
+			`id` int(11) NOT NULL AUTO_INCREMENT,
+			`description` varchar(50) NOT NULL,
+			`vhostsettings` text NOT NULL,
+			PRIMARY KEY (`id`)
+			) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;";
 	Database::query($sql);
 	lastStepStatus(0);
 

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -151,6 +151,7 @@ return array(
 						'value' => array()
 					),
 					'vhost_usedefaultlocation' => array(
+						'visible' => (Settings::Get('system.webserver') == 'nginx' ? true : false),
 						'label' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'],
 						'desc' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'],
 						'type' => 'checkbox',

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -150,6 +150,21 @@ return array(
 						),
 						'value' => array()
 					),
+					'vhost_usedefaultlocation' => array(
+						'label' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'],
+						'desc' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'],
+						'type' => 'checkbox',
+						'values' => array(
+							array ('label' => $lng['panel']['yes'], 'value' => '1')
+						),
+						'value' => array()
+					),
+					'vhostsettingid' => array(
+						'visible' => ($userinfo['change_serversettings'] == '1' ? true : false),
+						'label' => $lng['admin']['vhostsettings']['vhostsettings'],
+						'type' => 'select',
+						'select_var' => $vhostconfigs
+					),
 					'specialsettings' => array(
 						'visible' => ($userinfo['change_serversettings'] == '1' ? true : false),
 						'style' => 'align-top',

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -157,7 +157,7 @@ return array(
 						'values' => array(
 							array ('label' => $lng['panel']['yes'], 'value' => '1')
 						),
-						'value' => array()
+						'value' => array('1')
 					),
 					'vhostsettingid' => array(
 						'visible' => ($userinfo['change_serversettings'] == '1' ? true : false),

--- a/lib/formfields/admin/domains/formfield.domains_edit.php
+++ b/lib/formfields/admin/domains/formfield.domains_edit.php
@@ -84,7 +84,7 @@ return array(
 						'value' => $result['registration_date'],
 						'size' => 10
 					),
-                                        'termination_date' => array(
+          'termination_date' => array(
 						'label' => $lng['domains']['termination_date'],
 						'desc' => $lng['panel']['dateformat'],
 						'type' => 'text',
@@ -163,6 +163,7 @@ return array(
 						'value' => array($result['speciallogfile'])
 					),
 					'vhost_usedefaultlocation' => array(
+						'visible' => (Settings::Get('system.webserver') == 'nginx' ? true : false),
 						'label' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'],
 						'desc' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'],
 						'type' => 'checkbox',

--- a/lib/formfields/admin/domains/formfield.domains_edit.php
+++ b/lib/formfields/admin/domains/formfield.domains_edit.php
@@ -162,6 +162,21 @@ return array(
 						),
 						'value' => array($result['speciallogfile'])
 					),
+					'vhost_usedefaultlocation' => array(
+						'label' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'],
+						'desc' => $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'],
+						'type' => 'checkbox',
+						'values' => array(
+							array ('label' => $lng['panel']['yes'], 'value' => '1')
+						),
+						'value' => array($result['vhost_usedefaultlocation'])
+					),
+					'vhostsettingid' => array(
+						'visible' => ($userinfo['change_serversettings'] == '1' ? true : false),
+						'label' => $lng['admin']['vhostsettings']['vhostsettings'],
+						'type' => 'select',
+						'select_var' => $vhostconfigs
+					),
 					'specialsettings' => array(
 						'visible' => ($userinfo['change_serversettings'] == '1' ? true : false),
 						'style' => 'align-top',

--- a/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php
+++ b/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Froxlor team <team@froxlor.org> (2010-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Formfields
+ *
+ */
+
+return array(
+	'vhostconfig_add' => array(
+		'title' => $lng['admin']['vhostsettings']['addsettings'],
+		'image' => 'icons/vhostsettings_add.png',
+		'sections' => array(
+			'section_a' => array(
+				'title' => $lng['admin']['vhostsettings']['addnew'],
+				'image' => 'icons/vhostsettings_add.png',
+				'fields' => array(
+					'description' => array(
+						'label' => $lng['admin']['phpsettings']['description'],
+						'type' => 'text',
+						'maxlength' => 50
+					),
+					'vhostsettings' => array(
+						'style' => 'align-top',
+						'label' => $lng['admin']['vhostsettings']['vhostsettings'],
+						'type' => 'textarea',
+						'cols' => 100,
+						'rows' => 30
+					)
+				)
+			)
+		)
+	)
+);

--- a/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php
+++ b/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php
@@ -2,7 +2,7 @@
 
 /**
  * This file is part of the Froxlor project.
- * Copyright (c) 2010 the Froxlor Team (see authors).
+ * Copyright (c) 2016 the Froxlor Team (see authors).
  *
  * For the full copyright and license information, please view the COPYING
  * file that was distributed with this source code. You can also view the

--- a/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php
+++ b/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Froxlor team <team@froxlor.org> (2010-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Formfields
+ *
+ */
+
+return array(
+	'vhostconfig_edit' => array(
+		'title' => $lng['admin']['vhostsettings']['editsettings'],
+		'image' => 'icons/vhostsettings_edit.png',
+		'sections' => array(
+			'section_a' => array(
+				'title' => $lng['admin']['vhostsettings']['editsettings'],
+				'image' => 'icons/vhostsettings_edit.png',
+				'fields' => array(
+					'description' => array(
+						'label' => $lng['admin']['phpsettings']['description'],
+						'type' => 'text',
+						'maxlength' => 50,
+						'value' => $result['description']
+					),
+					'vhostsettings' => array(
+						'style' => 'align-top',
+						'label' => $lng['admin']['vhostsettings']['vhostsettings'],
+						'type' => 'textarea',
+						'cols' => 100,
+						'rows' => 30,
+						'value' => $result['vhostsettings']
+					)
+				)
+			)
+		)
+	)
+);

--- a/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php
+++ b/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php
@@ -2,7 +2,7 @@
 
 /**
  * This file is part of the Froxlor project.
- * Copyright (c) 2010 the Froxlor Team (see authors).
+ * Copyright (c) 2016 the Froxlor Team (see authors).
  *
  * For the full copyright and license information, please view the COPYING
  * file that was distributed with this source code. You can also view the

--- a/lib/navigation/00.froxlor.main.php
+++ b/lib/navigation/00.froxlor.main.php
@@ -246,6 +246,14 @@ return array (
 					'label' => $lng['admin']['integritycheck'],
 					'required_resources' => 'change_serversettings',
 				),
+				array (
+					'url' => 'admin_vhostsettings.php?page=overview',
+					'label' => $lng['menue']['vhostsettings']['maintitle'],
+					'show_element' => (
+						Settings::Get('system.mod_fcgid') == true ||
+						Settings::Get('phpfpm.enabled') == true
+					),
+				),
 			    array (
 			        'url' => 'admin_autoupdate.php?page=overview',
 			        'label' => $lng['admin']['autoupdate'],

--- a/lib/tables.inc.php
+++ b/lib/tables.inc.php
@@ -45,6 +45,7 @@ define('TABLE_PANEL_TICKETS', 'panel_tickets');
 define('TABLE_PANEL_TICKET_CATS', 'panel_ticket_categories');
 define('TABLE_PANEL_LOG', 'panel_syslog');
 define('TABLE_PANEL_PHPCONFIGS', 'panel_phpconfigs');
+define('TABLE_PANEL_VHOSTCONFIGS', 'panel_vhostconfigs');
 define('TABLE_PANEL_CRONRUNS', 'cronjobs_run');
 define('TABLE_PANEL_REDIRECTCODES', 'redirect_codes');
 define('TABLE_PANEL_DOMAINREDIRECTS', 'domain_redirect_codes');

--- a/lib/version.inc.php
+++ b/lib/version.inc.php
@@ -16,7 +16,7 @@
  */
 
 // Main version variable
-$version = '0.9.35-dev5';
+$version = '0.9.35-dev6';
 
 // Database version (unused, old stuff from SysCP)
 $dbversion = '2';

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1970,3 +1970,20 @@ $lng['domains']['termination_date'] = 'Date of termination';
 $lng['domains']['termination_date_overview'] = 'canceled until ';
 
 $lng['panel']['set'] = 'Apply';
+
+// Added for Vhost templates
+$lng['menue']['vhostsettings']['maintitle'] = 'VHost Configurations';
+$lng['admin']['vhostsettings']['title'] = 'VHost Configuration';
+$lng['admin']['vhostsettings']['addnew'] = 'Add new configuration';
+$lng['admin']['vhostsettings']['addsettings'] = 'Create a VHost configuration';
+$lng['admin']['vhostsettings']['editsettings'] = 'Edit a VHost configuration';
+$lng['admin']['vhostsettings']['vhostsettings'] = 'Predefined VHost configuration';
+$lng['admin']['vhostsettings']['novhostsettings'] = 'No predefined VHost configuration';
+$lng['admin']['vhostconfig']['socket_dir'] = 'Will be replaced with the corresponding Unix socket path, e.g. /var/run/domain-php-fpm.socket.';
+$lng['admin']['vhostconfig']['docroot'] = 'Will be replaced with the DocumentRoot.';
+$lng['admin']['vhostconfig']['ip'] = 'Will be replaced with the IP address of the Vhost.';
+$lng['admin']['vhostconfig']['port'] = 'Will be replaced with the port number of the Vhost.';
+$lng['admin']['vhostconfig']['scheme'] = 'Will be set to <strong>http</strong> or <strong>https</strong> in case SSL / TLS is activated for the Vhost.';
+$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'] = 'Use the standard Vhost location directives';
+$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'] = 'If activated, the standard Vhost location directives, such as <br>location / { ... }<br> location @rewrites { ... }<br> location ~ ^(.+?\.php)(/.*)?$ { ... }<br> are excluded from the Vhost configuration file.';
+$lng['question']['vhostsetting_reallydelete'] = 'Do you really want to delete the Vhost template?';

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1985,5 +1985,5 @@ $lng['admin']['vhostconfig']['ip'] = 'Will be replaced with the IP address of th
 $lng['admin']['vhostconfig']['port'] = 'Will be replaced with the port number of the Vhost.';
 $lng['admin']['vhostconfig']['scheme'] = 'Will be set to <strong>http</strong> or <strong>https</strong> in case SSL / TLS is activated for the Vhost.';
 $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'] = 'Use the standard Vhost location directives';
-$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'] = 'If activated, the standard Vhost location directives, such as <br>location / { ... }<br> location @rewrites { ... }<br> location ~ ^(.+?\.php)(/.*)?$ { ... }<br> are excluded from the Vhost configuration file.';
+$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'] = 'If deactivated, the standard Vhost location directives, such as <br>location / { ... }<br> location @rewrites { ... }<br> location ~ ^(.+?\.php)(/.*)?$ { ... }<br> are excluded from the Vhost configuration file.';
 $lng['question']['vhostsetting_reallydelete'] = 'Do you really want to delete the Vhost template?';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1625,5 +1625,5 @@ $lng['admin']['vhostconfig']['ip'] = 'Wird mit der IP-Adresse des Vhosts ersetzt
 $lng['admin']['vhostconfig']['port'] = 'Wird mit dem Port des Vhosts ersetzt.';
 $lng['admin']['vhostconfig']['scheme'] = 'Wird mit <strong>http</strong> bzw. mit <strong>https</strong> ersetzt, sofern der Vhost SSL/TLS aktiviert hat.';
 $lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'] = 'Standard VHost location-Direktiven verwenden';
-$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'] = 'Wenn aktiviert, werden die Standard VHost-Direktiven wie <br>location / { ... }<br> location @rewrites { ... }<br> location ~ ^(.+?\.php)(/.*)?$ { ... }<br> nicht in die Konfigurationsdatei geschrieben.';
+$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'] = 'Wenn deaktiviert, werden Standard VHost-Direktiven wie <br>location / { ... }<br> location @rewrites { ... }<br> location ~ ^(.+?\.php)(/.*)?$ { ... }<br> nicht in die Konfigurationsdatei geschrieben.';
 $lng['question']['vhostsetting_reallydelete'] = 'Wollen Sie diese VHost-Vorlage wirklich löschen?';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1610,3 +1610,20 @@ $lng['domains']['termination_date'] = 'K&uuml;ndigungsdatum';
 $lng['domains']['termination_date_overview'] = 'gek&uuml;ndigt zum ';
 
 $lng['panel']['set'] = 'Setzen';
+
+// Added for Vhost templates
+$lng['menue']['vhostsettings']['maintitle'] = 'VHost-Konfigurationen';
+$lng['admin']['vhostsettings']['title'] = 'VHost-Konfiguration';
+$lng['admin']['vhostsettings']['addnew'] = 'Neue Konfiguration erstellen';
+$lng['admin']['vhostsettings']['addsettings'] = 'VHost-Konfiguration erstellen';
+$lng['admin']['vhostsettings']['editsettings'] = 'VHost-Konfiguration bearbeiten';
+$lng['admin']['vhostsettings']['vhostsettings'] = 'Vordefinierte VHost-Konfiguration';
+$lng['admin']['vhostsettings']['novhostsettings'] = 'Keine VHost-Konfiguration';
+$lng['admin']['vhostconfig']['socket_dir'] = 'Wird mit dem jeweiligen Unix Socket Pfad ersetzt (z.B. /var/run/domain-php-fpm.socket).';
+$lng['admin']['vhostconfig']['docroot'] = 'Wird mit dem DocumentRoot ersetzt.';
+$lng['admin']['vhostconfig']['ip'] = 'Wird mit der IP-Adresse des Vhosts ersetzt.';
+$lng['admin']['vhostconfig']['port'] = 'Wird mit dem Port des Vhosts ersetzt.';
+$lng['admin']['vhostconfig']['scheme'] = 'Wird mit <strong>http</strong> bzw. mit <strong>https</strong> ersetzt, sofern der Vhost SSL/TLS aktiviert hat.';
+$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['title'] = 'Standard VHost location-Direktiven verwenden';
+$lng['admin']['vhostconfig']['vhost_usedefaultlocation']['desc'] = 'Wenn aktiviert, werden die Standard VHost-Direktiven wie <br>location / { ... }<br> location @rewrites { ... }<br> location ~ ^(.+?\.php)(/.*)?$ { ... }<br> nicht in die Konfigurationsdatei geschrieben.';
+$lng['question']['vhostsetting_reallydelete'] = 'Wollen Sie diese VHost-Vorlage wirklich löschen?';

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -261,7 +261,7 @@ class apache extends HttpConfigBase {
 					if ($row_ipsandports['ssl']) {
 						$srvName = substr(md5($ipport),0,4).'.ssl-fpm.external';
 					}
-					
+
 					// mod_proxy stuff for apache-2.4
 					if (Settings::Get('system.apache24') == '1'
 							&& Settings::Get('phpfpm.use_mod_proxy') == '1'
@@ -269,7 +269,7 @@ class apache extends HttpConfigBase {
 						$this->virtualhosts_data[$vhosts_filename] .= '  <FilesMatch \.php$>'. "\n";
 						$this->virtualhosts_data[$vhosts_filename] .= '  SetHandler proxy:unix:' . $php->getInterface()->getSocketFile()  . '|fcgi://localhost'. "\n";
 						$this->virtualhosts_data[$vhosts_filename] .= '  </FilesMatch>' . "\n";
-					
+
 					} else {
 						$this->virtualhosts_data[$vhosts_filename] .= '  FastCgiExternalServer ' . $php->getInterface()->getAliasConfigDir() . $srvName .' -socket ' . $php->getInterface()->getSocketFile() . ' -idle-timeout ' . Settings::Get('phpfpm.idle_timeout') . "\n";
 						$this->virtualhosts_data[$vhosts_filename] .= '  <Directory "' . $mypath . '">' . "\n";
@@ -867,6 +867,19 @@ class apache extends HttpConfigBase {
 				$vhost_content .= $this->getStats($domain);
 			}
 			$vhost_content .= $this->getLogfiles($domain);
+
+			// check if vhost config template is set and if so, merge it
+			if ($domain['vhostsettingid'] != 0) {
+				$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . " WHERE `id` = :id LIMIT 1;");
+				$vhostconfig = Database::pexecute_first($vhostsettings_stmt, array('id' => $domain['vhostsettingid']));
+
+				$vhost_content .= $this->processSpecialConfigTemplate(
+						$vhostconfig['vhostsettings'],
+						$domain,
+						$domain['ip'],
+						$domain['port'],
+						$ssl_vhost) . "\n";
+			}
 
 			if ($domain['specialsettings'] != '') {
 				$vhost_content .= $this->processSpecialConfigTemplate(

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -164,7 +164,7 @@ class lighttpd extends HttpConfigBase {
 				}
 
 				if ($row_ipsandports['ssl_cert_file'] != '') {
-				    
+
 				    // check for existence, #1485
 				    if (!file_exists($row_ipsandports['ssl_cert_file'])) {
 				        $this->logger->logAction(CRON_ACTION, LOG_ERR, $ip.':'.$port . ' :: certificate file "'.$row_ipsandports['ssl_cert_file'].'" does not exist! Cannot create ssl-directives');
@@ -175,7 +175,7 @@ class lighttpd extends HttpConfigBase {
     					$this->lighttpd_data[$vhost_filename].= 'ssl.cipher-list = "' . Settings::Get('system.ssl_cipher_list') . '"' . "\n";
     					$this->lighttpd_data[$vhost_filename].= 'ssl.honor-cipher-order = "enable"' . "\n";
     					$this->lighttpd_data[$vhost_filename].= 'ssl.pemfile = "' . makeCorrectFile($row_ipsandports['ssl_cert_file']) . '"' . "\n";
-    
+
     					if ($row_ipsandports['ssl_ca_file'] != '') {
     					    // check for existence, #1485
     					    if (!file_exists($row_ipsandports['ssl_ca_file'])) {
@@ -455,6 +455,19 @@ class lighttpd extends HttpConfigBase {
 
 					$vhost_content.= $this->getSslSettings($domain, $ssl_vhost);
 
+					// check if vhost config template is set and if so, merge it
+					if ($domain['vhostsettingid'] != 0) {
+						$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . " WHERE `id` = :id LIMIT 1;");
+						$vhostconfig = Database::pexecute_first($vhostsettings_stmt, array('id' => $domain['vhostsettingid']));
+
+						$vhost_content .= $this->processSpecialConfigTemplate(
+								$vhostconfig['vhostsettings'],
+								$domain,
+								$domain['ip'],
+								$domain['port'],
+								$ssl_vhost) . "\n";
+					}
+
 					if ($domain['specialsettings'] != "") {
 						$vhost_content.= $this->processSpecialConfigTemplate(
 								$domain['specialsettings'],
@@ -508,7 +521,7 @@ class lighttpd extends HttpConfigBase {
 			}
 
 			if ($domain['ssl_cert_file'] != '') {
-			    
+
 				$ssl_settings.= 'ssl.engine = "enable"' . "\n";
 				$ssl_settings.= 'ssl.use-sslv2 = "disable"' . "\n";
 				$ssl_settings.= 'ssl.cipher-list = "' . Settings::Get('system.ssl_cipher_list') . '"' . "\n";

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -443,6 +443,24 @@ class nginx extends HttpConfigBase {
 
 				$vhost_content.= isset($this->needed_htpasswds[$domain['id']]) ? $this->needed_htpasswds[$domain['id']] . "\n" : '';
 
+				// check if vhost config template is set and if so, merge it
+				if ($domain['vhostsettingid'] != 0) {
+					$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . " WHERE `id` = :id LIMIT 1;");
+					$vhostconfig = Database::pexecute_first($vhostsettings_stmt, array('id' => $domain['vhostsettingid']));
+
+					// replace {SOCKET} var with unix socket
+					$php = new phpinterface($domain);
+					$vhostconfig['vhostsettings'] = str_replace("{SOCKET}", $php->getInterface()->getSocketFile(), $vhostconfig['vhostsettings']);
+
+					$vhost_content = $this->mergeVhostCustom($vhost_content, $this->processSpecialConfigTemplate(
+						$vhostconfig['vhostsettings'],
+						$domain,
+						$domain['ip'],
+						$domain['port'],
+						$ssl_vhost
+					));
+				}
+
 				if ($domain['specialsettings'] != "") {
 					$vhost_content = $this->mergeVhostCustom($vhost_content, $this->processSpecialConfigTemplate(
 						$domain['specialsettings'],
@@ -854,19 +872,22 @@ class nginx extends HttpConfigBase {
 			$this->_deactivated = false;
 		}
 
-		$webroot_text .= "\t" . 'index    index.php index.html index.htm;'."\n";
-		$webroot_text .= "\n\t".'location / {'."\n";
-		$webroot_text .= "\t\t" . 'try_files $uri $uri/ @rewrites;'."\n";
+		// write directives only when vhost_usedefaultlocation is activated in panel domain settings
+		if ($domain['vhost_usedefaultlocation'] == '1') {
+			$webroot_text .= "\t" . 'index    index.php index.html index.htm;'."\n";
+			$webroot_text .= "\n\t" . 'location / {' . "\n";
+			$webroot_text .= "\t\t" . 'try_files $uri $uri/ @rewrites;' . "\n";
 
-		if ($this->vhost_root_autoindex) {
-			$webroot_text .= "\t\t".'autoindex on;'."\n";
-			$this->vhost_root_autoindex = false;
+			if ($this->vhost_root_autoindex) {
+				$webroot_text .= "\t\t" . 'autoindex on;' . "\n";
+				$this->vhost_root_autoindex = false;
+			}
+
+			$webroot_text .= "\t" . '}' . "\n\n";
+			$webroot_text .= "\tlocation @rewrites {\n";
+			$webroot_text .= "\t\trewrite ^ /index.php last;\n";
+			$webroot_text .= "\t}\n\n";
 		}
-
-		$webroot_text .= "\t".'}'."\n\n";
-		$webroot_text .= "\tlocation @rewrites {\n";
-		$webroot_text .= "\t\trewrite ^ /index.php last;\n";
-		$webroot_text .= "\t}\n\n";
 
 		return $webroot_text;
 	}

--- a/templates/Sparkle/admin/vhostconfig/overview.tpl
+++ b/templates/Sparkle/admin/vhostconfig/overview.tpl
@@ -1,0 +1,40 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="templates/{$theme}/assets/img/icons/phpsettings_big.png" alt="" />&nbsp;
+				{$lng['menue']['vhostsettings']['maintitle']}
+			</h2>
+		</header>
+
+		<section>
+
+			<div class="overviewadd">
+				<img src="templates/{$theme}/assets/img/icons/add.png" alt="" />&nbsp;
+				<a href="{$linker->getLink(array('section' => 'vhostsettings', 'page' => $page, 'action' => 'add'))}">{$lng['admin']['vhostsettings']['addnew']}</a>
+			</div>
+
+			<table class="full hl">
+				<thead>
+					<tr>
+						<th>{$lng['admin']['phpsettings']['description']}</th>
+						<th>{$lng['admin']['phpsettings']['activedomains']}</th>
+						<th>{$lng['panel']['options']}</th>
+                                        </tr>
+				</thead>
+				<tbody>
+					$tablecontent
+				</tbody>
+			</table>
+
+			<if 15 < $count>
+				<div class="overviewadd">
+					<img src="templates/{$theme}/assets/img/icons/add.png" alt="" />&nbsp;
+					<a href="{$linker->getLink(array('section' => 'vhostsettings', 'page' => $page, 'action' => 'add'))}">{$lng['admin']['vhostsettings']['addnew']}</a>
+				</div>
+			</if>
+
+		</section>
+
+	</article>
+$footer

--- a/templates/Sparkle/admin/vhostconfig/overview_add.tpl
+++ b/templates/Sparkle/admin/vhostconfig/overview_add.tpl
@@ -1,0 +1,76 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="templates/{$theme}/assets/img/icons/phpsettings_add_big.png" alt="{$title}" />&nbsp;
+				{$title}
+			</h2>
+		</header>
+
+		<section>
+
+			<form action="{$linker->getLink(array('section' => 'vhostsettings'))}" method="post" enctype="application/x-www-form-urlencoded">
+				<input type="hidden" name="s" value="$s" />
+				<input type="hidden" name="page" value="$page" />
+				<input type="hidden" name="action" value="$action" />
+				<input type="hidden" name="send" value="send" />
+
+				<table class="full">
+					{$vhostconfig_add_form}
+				</table>
+			</form>
+		</section>
+	</article>
+	<br />
+	<article>
+		<header>
+			<h3>
+				{$lng['admin']['templates']['template_replace_vars']}
+			</h3>
+		</header>
+
+		<section>
+
+			<table class="full">
+			<thead>
+				<tr>
+					<th>{$lng['panel']['variable']}</th>
+					<th>{$lng['panel']['description']}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><em>{CUSTOMER}</em></td>
+					<td>{$lng['admin']['phpconfig']['customer']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOCROOT}</em></td>
+					<td>{$lng['admin']['vhostconfig']['docroot']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOMAIN}</em></td>
+					<td>{$lng['admin']['phpconfig']['domain']}</td>
+				</tr>
+				<tr>
+					<td><em>{IP}</em></td>
+					<td>{$lng['admin']['vhostconfig']['ip']}</td>
+				</tr>
+				<tr>
+					<td><em>{PORT}</em></td>
+					<td>{$lng['admin']['vhostconfig']['port']}</td>
+				</tr>
+				<tr>
+					<td><em>{SCHEME}</em></td>
+					<td>{$lng['admin']['vhostconfig']['scheme']}</td>
+				</tr>
+				<tr>
+					<td><em>{SOCKET}</em></td>
+					<td>{$lng['admin']['vhostconfig']['socket_dir']}</td>
+				</tr>
+			</tbody>
+			</table>
+
+		</section>
+
+	</article>
+$footer

--- a/templates/Sparkle/admin/vhostconfig/overview_edit.tpl
+++ b/templates/Sparkle/admin/vhostconfig/overview_edit.tpl
@@ -1,0 +1,77 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="templates/{$theme}/assets/img/icons/phpsettings_edit_big.png" alt="{$title}" />&nbsp;
+				{$title}
+			</h2>
+		</header>
+
+		<section>
+
+			<form action="{$linker->getLink(array('section' => 'vhostsettings'))}" method="post" enctype="application/x-www-form-urlencoded">
+				<input type="hidden" name="s" value="$s"/>
+				<input type="hidden" name="page" value="$page"/>
+				<input type="hidden" name="action" value="edit"/>
+				<input type="hidden" name="id" value="$id"/>
+				<input type="hidden" name="send" value="send" />
+
+				<table class="full">
+					{$vhostconfig_edit_form}
+				</table>
+			</form>
+		</section>
+	</article>
+	<br />
+	<article>
+		<header>
+			<h3>
+				{$lng['admin']['templates']['template_replace_vars']}
+			</h3>
+		</header>
+
+		<section>
+
+			<table class="full">
+			<thead>
+				<tr>
+					<th>{$lng['panel']['variable']}</th>
+					<th>{$lng['panel']['description']}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><em>{CUSTOMER}</em></td>
+					<td>{$lng['admin']['phpconfig']['customer']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOCROOT}</em></td>
+					<td>{$lng['admin']['vhostconfig']['docroot']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOMAIN}</em></td>
+					<td>{$lng['admin']['phpconfig']['domain']}</td>
+				</tr>
+				<tr>
+					<td><em>{IP}</em></td>
+					<td>{$lng['admin']['vhostconfig']['ip']}</td>
+				</tr>
+				<tr>
+					<td><em>{PORT}</em></td>
+					<td>{$lng['admin']['vhostconfig']['port']}</td>
+				</tr>
+				<tr>
+					<td><em>{SCHEME}</em></td>
+					<td>{$lng['admin']['vhostconfig']['scheme']}</td>
+				</tr>
+				<tr>
+					<td><em>{SOCKET}</em></td>
+					<td>{$lng['admin']['vhostconfig']['socket_dir']}</td>
+				</tr>
+			</tbody>
+			</table>
+
+		</section>
+
+	</article>
+$footer

--- a/templates/Sparkle/admin/vhostconfig/overview_overview.tpl
+++ b/templates/Sparkle/admin/vhostconfig/overview_overview.tpl
@@ -1,0 +1,12 @@
+<tr class="top">
+	<td><strong>{$row['description']}</strong></td>
+	<td>{$domains}</td>
+	<td>
+		<a href="{$linker->getLink(array('section' => 'vhostsettings', 'page' => $page, 'action' => 'edit', 'id' => $row['id']))}">
+			<img src="templates/{$theme}/assets/img/icons/edit.png" alt="{$lng['panel']['edit']}" title="{$lng['panel']['edit']}" />
+		</a>
+		&nbsp;<a href="{$linker->getLink(array('section' => 'vhostsettings', 'page' => $page, 'action' => 'delete', 'id' => $row['id']))}">
+			<img src="templates/{$theme}/assets/img/icons/delete.png" alt="{$lng['panel']['delete']}" title="{$lng['panel']['delete']}" />
+		</a>
+	</td>
+</tr>


### PR DESCRIPTION
@hpmewes presented a nice implementation of pre-definable vHost templates in PR #233 .
Presumably due to some unresolved issues, his implementation has not been merged finally and remained as a pending pull request.

In this PR, a reworked implementation is provided with:
- bugfixes all over
- added support for apache and lighttpd also
- added an update sequence (instead of only modifying froxlor.sql)
- added english language variables
- added missing parts in admin_vhostsettings.php
- added parameter replacements as available since PR #244 

The solution has been tested working on different setups and should integrate / upgrade flawlessly.