### PR TITLE
Various fixes for failing nginx/LetsEncrypt

### DIFF
--- a/lib/classes/ssl/class.lescript.php
+++ b/lib/classes/ssl/class.lescript.php
@@ -324,7 +324,7 @@ keyUsage = nonRepudiation, digitalSignature, keyEncipherment');
     {
         $res = openssl_pkey_new(array(
             "private_key_type" => OPENSSL_KEYTYPE_RSA,
-            "private_key_bits" => Settings::Get('system.letsencryptkeysize'),
+            "private_key_bits" => (int)Settings::Get('system.letsencryptkeysize'),
         ));
 
         if(!openssl_pkey_export($res, $privateKey)) {

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -273,10 +273,10 @@ fastcgi_param  REDIRECT_STATUS    200;
 ]]>
 						</content>
 					</file>
-					<file name="/etc/nginx/conf.d/acme.conf">
+					<file name="/etc/nginx/acme.conf">
 						<content><![CDATA[
 location /.well-known/acme-challenge {
-	alias {{settings.system.letsencryptchallengepath}};
+	alias {{settings.system.letsencryptchallengepath}}/.well-known/acme-challenge;
 
 	location ~ /.well-known/acme-challenge/(.*) {
 		default_type text/plain;

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -422,6 +422,7 @@ class nginx extends HttpConfigBase {
 		) {
 			$vhost_content.= "\n" . $this->composeSslSettings($domain) . "\n";
 		}
+		$vhost_content.= "\t".'include /etc/nginx/acme.conf;'."\n";
 
 		// if the documentroot is an URL we just redirect
 		if (preg_match('/^https?\:\/\//', $domain['documentroot'])) {
@@ -567,7 +568,7 @@ class nginx extends HttpConfigBase {
 		        $this->logger->logAction(CRON_ACTION, LOG_ERR, $domain_or_ip['domain'] . ' :: certificate file "'.$domain_or_ip['ssl_cert_file'].'" does not exist! Cannot create ssl-directives');
 		        echo $domain_or_ip['domain'] . ' :: certificate file "'.$domain_or_ip['ssl_cert_file'].'" does not exist! Cannot create SSL-directives'."\n";
 		    } else {
-    			// obsolete: ssl on now belongs to the listen block as 'ssl' at the end
+			// obsolete: ssl on now belongs to the listen block as 'ssl' at the end
     			//$sslsettings .= "\t" . 'ssl on;' . "\n";
     			$sslsettings .= "\t" . 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2;' . "\n";
     			$sslsettings .= "\t" . 'ssl_ciphers ' . Settings::Get('system.ssl_cipher_list') . ';' . "\n";
@@ -595,13 +596,13 @@ class nginx extends HttpConfigBase {
     			    }
     			}
     			
-				if ($domain['hsts'] > 0) {
+				if (isset($domain_or_ip['hsts']) && $domain_or_ip['hsts'] > 0) {
 
-					$vhost_content .= 'add_header Strict-Transport-Security "max-age=' . $domain['hsts'];
-					if ($domain['hsts_sub'] == 1) {
+					$vhost_content .= 'add_header Strict-Transport-Security "max-age=' . $domain_or_ip['hsts'];
+					if ($domain_or_ip['hsts_sub'] == 1) {
 						$vhost_content .= '; includeSubdomains';
 					}
-					if ($domain['hsts_preload'] == 1) {
+					if ($domain_or_ip['hsts_preload'] == 1) {
 						$vhost_content .= '; preload';
 					}
 					$vhost_content .= '";' . "\n";


### PR DESCRIPTION
class.lescript.php: OpenSSL requires integer for key size. DB returns string. Cast string to integer
trusty.xml: All files in conf.d get automatically included causing the location to be out of place and nginx fails to start. Also, the alias works slightly different in nginx than it does in Apache.
cron_tasks.inc.http.30.nginx.php: Location directives should be included in a host, nginx doesn't have the concept of global location directives in the way apache does. When PHP variables aren't defined, it throws a warning polluting the cronjob logs and sending e-mails.