### PR TITLE
Improve autoupdate against HTTP MITM and MD5 collisions

### DIFF
--- a/admin_autoupdate.php
+++ b/admin_autoupdate.php
@@ -22,9 +22,9 @@ define('AREA', 'admin');
 require './lib/init.php';
 
 // define update-uri
-define('UPDATE_URI', "http://version.froxlor.org/Froxlor/legacy/" . $version);
-define('RELEASE_URI', "http://autoupdate.froxlor.org/froxlor-{version}.zip");
-define('MD5SUM_URI', "http://autoupdate.froxlor.org/froxlor-{version}.zip.md5");
+define('UPDATE_URI', "https://version.froxlor.org/Froxlor/legacy/" . $version);
+define('RELEASE_URI', "https://autoupdate.froxlor.org/froxlor-{version}.zip");
+define('CHECKSUM_URI', "https://autoupdate.froxlor.org/froxlor-{version}.zip.sha256");
 
 // check for allow_url_fopen
 if (ini_get('allow_url_fopen') === false) {
@@ -105,8 +105,8 @@ elseif ($page == 'getdownload') {
 
 		// define files to get
 		$toLoad = str_replace('{version}', $newversion, RELEASE_URI);
-		$toCheck = str_replace('{version}', $newversion, MD5SUM_URI);
-		
+		$toCheck = str_replace('{version}', $newversion, CHECKSUM_URI);
+
 		// get archive data
 		$newArchive = @file_get_contents($toLoad);
 
@@ -133,8 +133,8 @@ elseif ($page == 'getdownload') {
 
 		// close file-handle
 		fclose($fh);
-		
-		// validate MD5
+
+		// validate the integrity of the downloaded file
 		$_shouldsum = @file_get_contents($toCheck);
 		if (!empty($_shouldsum)) {
 		    $_t = explode(" ", $_shouldsum);
@@ -142,8 +142,8 @@ elseif ($page == 'getdownload') {
 		} else {
 		    $shouldsum = null;
 		}
-		$filesum = md5_file($localArchive);
-		
+		$filesum = hash_file('sha256', $localArchive);
+
 		if ($filesum != $shouldsum) {
 		    redirectTo($filename, array('s' => $s, 'page' => 'error', 'errno' => 9));
 		}
@@ -204,6 +204,6 @@ elseif ($page == 'error') {
 	// 6 = download without valid version
 	// 7 = local archive does not exist
 	// 8 = could not extract archive
-	// 9 = md5 mismatch
+	// 9 = checksum mismatch
 	standard_error ('autoupdate_'.$errno);
 }

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1954,14 +1954,14 @@ $lng['domains']['ssl_redirect_temporarilydisabled'] = "<br>The SSL redirect is t
 $lng['admin']['autoupdate'] = 'Auto-Update';
 $lng['error']['customized_version'] = 'It looks like your Froxlor installation has been customized, no support sorry.';
 $lng['error']['autoupdate_0'] = 'Unknown error';
-$lng['error']['autoupdate_1'] = 'PHP setting allow_url_fopen is disabled. Autoupdate needs this setting to be enabled in the php.ini';
+$lng['error']['autoupdate_1'] = 'PHP setting allow_url_fopen is disabled. Autoupdate needs this setting to be enabled in php.ini';
 $lng['error']['autoupdate_2'] = 'PHP extension Zlib not found, please ensure it is installed and activated';
 $lng['error']['autoupdate_4'] = 'The froxlor archive could not be stored to the disk :(';
 $lng['error']['autoupdate_5'] = 'version.froxlor.org returned inacceptable values :(';
 $lng['error']['autoupdate_6'] = 'Woops, there was no (valid) version given to download :(';
 $lng['error']['autoupdate_7'] = 'The downloaded archive could not be found :(';
-$lng['error']['autoupdate_8'] = 'The archive could not be extraxted :(';
-$lng['error']['autoupdate_9'] = 'The MD5 sum of the downloaded file is not correct. Please try to update again.';
+$lng['error']['autoupdate_8'] = 'The archive could not be extracted :(';
+$lng['error']['autoupdate_9'] = 'The downloaded file did not pass the integrity check. Please try to update again.';
 
 $lng['admin']['server_php'] = 'PHP';
 


### PR DESCRIPTION
**Problem:**
Currently, the autoupdater suffers from two vulnerabilities:

1. The Froxlor host can be tricked into updating with a non-official (or even backdoored) update archive. Using DNS spoofing an attacker is able to perform Cache Poisoning on the host running Froxlor. For an attacker, it is then easy to masquerade as autoupdate.froxlor.org since the connection is HTTP only.

2. It is trivial to produce an update archive which has the same MD5 hashsum as the official one. MD5 is known to be officially broken for more than 10 years now, it takes modern GPUs only < 30min to find a collision. Any modification to the update file would hence not be detectable. However, since the checksum is delivered using HTTP anyway, an attacker may deliver any hashsum.

**Solution**:
- Change HTTP to HTTPS. Therefore, you also have to roll-out the updates via HTTPS on the server-side. Also enable HSTS on autoupdate.froxlor.org in order to prevent an sslstrip attack.
- Prevent trivial collisions by relying on a currently more secure hash function, e.g. SHA-256

Enable HPKP on autoupdate.froxlor.org, store the fingerprint in Froxlor as a constant and verify it upon connecting to the host.