### PR TITLE
Vhost templates: Added a field to select the target webserver

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -1012,7 +1012,8 @@ if ($page == 'domains'
 
 				// vhost configs
 				$vhostconfigs = '';
-				$configsvhost = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` ORDER BY description ASC");
+				$configsvhost = Database::prepare("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `webserver` = :webserver ORDER BY description ASC");
+				Database::pexecute($configsvhost, array('webserver' => Settings::Get('system.webserver')));
 
 				$vhostconfigs.= makeoption($lng['admin']['vhostsettings']['novhostsettings'], 0);
 				while ($row = $configsvhost->fetch(PDO::FETCH_ASSOC)) {
@@ -1997,7 +1998,9 @@ if ($page == 'domains'
 
 				// vhost configs
 				$vhostconfigs = '';
-				$vhostconfigs_result_stmt = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` ORDER BY description ASC");
+				$vhostconfigs_result_stmt = Database::prepare("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `webserver` = :webserver ORDER BY description ASC");
+				Database::pexecute($vhostconfigs_result_stmt, array('webserver' => Settings::Get('system.webserver')));
+
 				$vhostconfigs .= makeoption($lng['admin']['vhostsettings']['novhostsettings'], 0);
 				while ($vhostconfig_row = $vhostconfigs_result_stmt->fetch(PDO::FETCH_ASSOC)) {
 					$vhostconfigs .= makeoption($vhostconfig_row['description'], $vhostconfig_row['id'], $result['vhostsettingid'], true, true);

--- a/admin_vhostsettings.php
+++ b/admin_vhostsettings.php
@@ -28,17 +28,17 @@ if (isset($_POST['id'])) {
 }
 
 if ($page == 'overview') {
+	$supported_webservers = [ 'apache2' => 'Apache 2', 'lighttpd' => 'ligHTTPd', 'nginx' => 'Nginx' ];
+
 	if ($action == '') {
 		$tablecontent = '';
 		$count = 0;
 		$result = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` ORDER BY description ASC");
 
 		while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
-
-			$domainresult = false;
 			$query_params = array('id' => $row['id']);
 
-			$query = "SELECT * FROM `".TABLE_PANEL_DOMAINS."`
+			$query = "SELECT * FROM `" . TABLE_PANEL_DOMAINS . "`
 					WHERE `vhostsettingid` = :id
 					AND `parentdomainid` = '0'";
 
@@ -76,90 +76,72 @@ if ($page == 'overview') {
 				$domains = $lng['admin']['phpsettings']['notused'];
 			}
 
-			// check whether this is our default config
-			if ((Settings::Get('system.mod_fcgid') == '1'
-					&& Settings::Get('system.mod_fcgid_defaultini') == $row['id'])
-				|| (Settings::Get('phpfpm.enabled') == '1'
-					&& Settings::Get('phpfpm.defaultini') == $row['id'])
-			) {
-				$row['description'] = '<b>'.$row['description'].'</b>';
-			}
+			$webserver = str_replace(array_keys($supported_webservers), array_values($supported_webservers), $row['webserver']);
 
 			$count++;
 			eval("\$tablecontent.=\"" . getTemplate("vhostconfig/overview_overview") . "\";");
 		}
 
 		eval("echo \"" . getTemplate("vhostconfig/overview") . "\";");
-	}
 
-	if ($action == 'add') {
+	} else if ($action == 'add') {
 
-		if ((int)$userinfo['change_serversettings'] == 1) {
-
-			if (isset($_POST['send'])
-				&& $_POST['send'] == 'send'
-			) {
-				$description = validate($_POST['description'], 'description');
-				$vhostsettings = validate(trim(str_replace("\r\n", "\n", $_POST['vhostsettings'])), 'vhostsettings', '/^[^\0]*$/');
-
-				if (strlen($description) == 0
-					|| strlen($description) > 50
-				) {
-					standard_error('descriptioninvalid');
-				}
-
-				$ins_stmt = Database::prepare("
-					INSERT INTO `" . TABLE_PANEL_VHOSTCONFIGS . "` SET
-						`description` = :desc,
-						`vhostsettings` = :vhostsettings"
-				);
-				$ins_data = array(
-					'desc' => $description,
-					'vhostsettings' => $vhostsettings
-				);
-				Database::pexecute($ins_stmt, $ins_data);
-
-				inserttask('1');
-				$log->logAction(ADM_ACTION, LOG_INFO, "vhost config setting with description '" . $description . "' has been created by '" . $userinfo['loginname'] . "'");
-				redirectTo($filename, array('page' => $page, 's' => $s));
-
-			} else {
-
-				$result_stmt = Database::query("SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = 1");
-				$result = $result_stmt->fetch(PDO::FETCH_ASSOC);
-
-				$vhostconfig_add_data = include_once dirname(__FILE__).'/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php';
-				$vhostconfig_add_form = htmlform::genHTMLForm($vhostconfig_add_data);
-
-				$title = $vhostconfig_add_data['vhostconfig_add']['title'];
-				$image = $vhostconfig_add_data['vhostconfig_add']['image'];
-
-				eval("echo \"" . getTemplate("vhostconfig/overview_add") . "\";");
-			}
-
-		} else {
+		if ((int)$userinfo['change_serversettings'] != 1) {
 			standard_error('nopermissionsorinvalidid');
 		}
-	}
 
-	if ($action == 'delete') {
+		if (isset($_POST['send']) && $_POST['send'] == 'send') {
+			$description = validate($_POST['description'], 'description');
+			$vhostsettings = validate(trim(str_replace("\r\n", "\n", $_POST['vhostsettings'])), 'vhostsettings', '/^[^\0]*$/');
+			$webserver = validate($_POST['webserver'], 'webserver', '/^(' . implode("|", array_keys($supported_webservers)) . ')$/');
+
+			if (strlen($description) == 0 || strlen($description) > 50) {
+				standard_error('descriptioninvalid');
+			}
+
+			$ins_stmt = Database::prepare("
+				INSERT INTO `" . TABLE_PANEL_VHOSTCONFIGS . "` SET
+					`description` = :description,
+					`vhostsettings` = :vhostsettings,
+					`webserver` = :webserver
+			");
+			$ins_data = array('description' => $description, 'vhostsettings' => $vhostsettings, 'webserver' => $webserver);
+			Database::pexecute($ins_stmt, $ins_data);
+
+			inserttask('1');
+			$log->logAction(ADM_ACTION, LOG_INFO, "vhost config setting with description '" . $description . "' has been created by '" . $userinfo['loginname'] . "'");
+			redirectTo($filename, array('page' => $page, 's' => $s));
+
+		} else {
+			$webserver_options = '';
+			while (list($webserver, $webserver_friendlyName) = each($supported_webservers)) {
+				$webserver_options .= makeoption($webserver_friendlyName, $webserver, Settings::Get('system.webserver'), true);
+			}
+
+			$vhostconfig_add_data = include_once dirname(__FILE__).'/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php';
+			$vhostconfig_add_form = htmlform::genHTMLForm($vhostconfig_add_data);
+
+			$title = $vhostconfig_add_data['vhostconfig_add']['title'];
+			$image = $vhostconfig_add_data['vhostconfig_add']['image'];
+
+			eval("echo \"" . getTemplate("vhostconfig/overview_add") . "\";");
+		}
+	} else if ($action == 'delete') {
 
 		$result_stmt = Database::prepare("
 			SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id"
 		);
 		$result = Database::pexecute_first($result_stmt, array('id' => $id));
 
-		if ($result['id'] != 0
-			&& $result['id'] == $id
-			&& (int)$userinfo['change_serversettings'] == 1
-		) {
-
-			if (isset($_POST['send'])
-				&& $_POST['send'] == 'send'
-			) {
-				$del_stmt = Database::prepare("
-					DELETE FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id"
+		if ($result['id'] != 0 && $result['id'] == $id && (int)$userinfo['change_serversettings'] == 1) {
+			if (isset($_POST['send']) && $_POST['send'] == 'send') {
+				// Remove a reference to this template from all domains using it
+				$upd_stmt = Database::prepare("UPDATE `" . TABLE_PANEL_DOMAINS . "` SET
+					`vhostsettingid` = 0 WHERE `vhostsettingid` = :id"
 				);
+				Database::pexecute($upd_stmt, array('id' => $id));
+
+				$del_stmt = Database::prepare("DELETE FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id");
 				Database::pexecute($del_stmt, array('id' => $id));
 
 				inserttask('1');
@@ -172,43 +154,31 @@ if ($page == 'overview') {
 		} else {
 			standard_error('nopermissionsorinvalidid');
 		}
-	}
-
-	if ($action == 'edit') {
+	} else if ($action == 'edit') {
 
 		$result_stmt = Database::prepare("
 			SELECT * FROM `" . TABLE_PANEL_VHOSTCONFIGS . "` WHERE `id` = :id"
 		);
 		$result = Database::pexecute_first($result_stmt, array('id' => $id));
 
-		if ($result['id'] != 0
-			&& $result['id'] == $id
-			&& (int)$userinfo['change_serversettings'] == 1
-		) {
-
-			if (isset($_POST['send'])
-				&& $_POST['send'] == 'send'
-			) {
+		if ($result['id'] != 0 && $result['id'] == $id && (int)$userinfo['change_serversettings'] == 1) {
+			if (isset($_POST['send']) && $_POST['send'] == 'send') {
 				$description = validate($_POST['description'], 'description');
 				$vhostsettings = validate(trim(str_replace("\r\n", "\n", $_POST['vhostsettings'])), 'vhostsettings', '/^[^\0]*$/');
+				$webserver = validate($_POST['webserver'], 'webserver', '/^(' . implode("|", array_keys($supported_webservers)) . ')$/');
 
-				if (strlen($description) == 0
-					|| strlen($description) > 50
-				) {
+				if (strlen($description) == 0 || strlen($description) > 50) {
 					standard_error('descriptioninvalid');
 				}
 
 				$upd_stmt = Database::prepare("
 					UPDATE `" . TABLE_PANEL_VHOSTCONFIGS . "` SET
-						`description` = :desc,
-						`vhostsettings` = :vhostsettings
+						`description` = :description,
+						`vhostsettings` = :vhostsettings,
+						`webserver` = :webserver
 					WHERE `id` = :id"
 				);
-				$upd_data = array(
-						'desc' => $description,
-						'vhostsettings' => $vhostsettings,
-						'id' => $id
-				);
+				$upd_data = array('description' => $description, 'vhostsettings' => $vhostsettings, 'webserver' => $webserver, 'id' => $id);
 				Database::pexecute($upd_stmt, $upd_data);
 
 				inserttask('1');
@@ -216,6 +186,10 @@ if ($page == 'overview') {
 				redirectTo($filename, array('page' => $page, 's' => $s));
 
 			} else {
+				$webserver_options = '';
+				while (list($webserver, $webserver_friendlyName) = each($supported_webservers)) {
+					$webserver_options .= makeoption($webserver_friendlyName, $webserver, $result['webserver'], true);
+				}
 
 				$vhostconfig_edit_data = include_once dirname(__FILE__).'/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php';
 				$vhostconfig_edit_form = htmlform::genHTMLForm($vhostconfig_edit_data);
@@ -225,7 +199,6 @@ if ($page == 'overview') {
 
 				eval("echo \"" . getTemplate("vhostconfig/overview_edit") . "\";");
 			}
-
 		} else {
 			standard_error('nopermissionsorinvalidid');
 		}

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -556,7 +556,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('panel', 'password_numeric', '0'),
 	('panel', 'password_special_char_required', '0'),
 	('panel', 'password_special_char', '!?<>§$%+#=@'),
-	('panel', 'version', '0.9.35-dev6');
+	('panel', 'version', '0.9.35-dev7');
 
 
 DROP TABLE IF EXISTS `panel_tasks`;
@@ -858,5 +858,6 @@ CREATE TABLE IF NOT EXISTS `panel_vhostconfigs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `description` varchar(50) NOT NULL,
   `vhostsettings` text NOT NULL,
+  `webserver` varchar(255) NOT NULL default '',
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3124,3 +3124,15 @@ if (isFroxlorVersion('0.9.35-dev5')) {
 
 	updateToVersion('0.9.35-dev6');
 }
+
+if (isFroxlorVersion('0.9.35-dev6')) {
+
+	showUpdateStep("Updating from 0.9.35-dev6 to 0.9.35-dev7", false);
+
+	showUpdateStep("Adding a new field to the panel_vhostconfigs table");
+	$webserver = Settings::Get('system.webserver');
+	Database::query("ALTER TABLE `" . TABLE_PANEL_VHOSTCONFIGS ."` ADD `webserver` VARCHAR(255) NOT NULL DEFAULT '" . $webserver . "' AFTER `vhostsettings`;");
+	lastStepStatus(0);
+
+	updateToVersion('0.9.35-dev7');
+}

--- a/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php
+++ b/lib/formfields/admin/vhostconfig/formfield.vhostconfig_add.php
@@ -29,6 +29,11 @@ return array(
 						'type' => 'text',
 						'maxlength' => 50
 					),
+					'webserver' => array(
+						'label' => $lng['admin']['webserver'],
+						'type' => 'select',
+						'select_var' => $webserver_options
+					),
 					'vhostsettings' => array(
 						'style' => 'align-top',
 						'label' => $lng['admin']['vhostsettings']['vhostsettings'],

--- a/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php
+++ b/lib/formfields/admin/vhostconfig/formfield.vhostconfig_edit.php
@@ -30,6 +30,11 @@ return array(
 						'maxlength' => 50,
 						'value' => $result['description']
 					),
+					'webserver' => array(
+						'label' => $lng['admin']['webserver'],
+						'type' => 'select',
+						'select_var' => $webserver_options
+					),
 					'vhostsettings' => array(
 						'style' => 'align-top',
 						'label' => $lng['admin']['vhostsettings']['vhostsettings'],

--- a/lib/version.inc.php
+++ b/lib/version.inc.php
@@ -16,7 +16,7 @@
  */
 
 // Main version variable
-$version = '0.9.35-dev6';
+$version = '0.9.35-dev7';
 
 // Database version (unused, old stuff from SysCP)
 $dbversion = '2';

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -868,15 +868,18 @@ class apache extends HttpConfigBase {
 
 			// check if vhost config template is set and if so, merge it
 			if ($domain['vhostsettingid'] != 0) {
-				$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . " WHERE `id` = :id LIMIT 1;");
+				$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . "
+					WHERE `webserver` = 'apache2' AND `id` = :id LIMIT 1;");
 				$vhostconfig = Database::pexecute_first($vhostsettings_stmt, array('id' => $domain['vhostsettingid']));
 
-				$vhost_content .= $this->processSpecialConfigTemplate(
-						$vhostconfig['vhostsettings'],
-						$domain,
-						$domain['ip'],
-						$domain['port'],
-						$ssl_vhost) . "\n";
+				if (is_array($vhostconfig)) {
+					$vhost_content .= $this->processSpecialConfigTemplate(
+							$vhostconfig['vhostsettings'],
+							$domain,
+							$domain['ip'],
+							$domain['port'],
+							$ssl_vhost) . "\n";
+				}
 			}
 
 			if ($domain['specialsettings'] != '') {

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -457,15 +457,18 @@ class lighttpd extends HttpConfigBase {
 
 					// check if vhost config template is set and if so, merge it
 					if ($domain['vhostsettingid'] != 0) {
-						$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . " WHERE `id` = :id LIMIT 1;");
+						$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . "
+							WHERE `webserver` = 'lighttpd' AND `id` = :id LIMIT 1;");
 						$vhostconfig = Database::pexecute_first($vhostsettings_stmt, array('id' => $domain['vhostsettingid']));
 
-						$vhost_content .= $this->processSpecialConfigTemplate(
-								$vhostconfig['vhostsettings'],
-								$domain,
-								$domain['ip'],
-								$domain['port'],
-								$ssl_vhost) . "\n";
+						if (is_array($vhostconfig)) {
+							$vhost_content .= $this->processSpecialConfigTemplate(
+									$vhostconfig['vhostsettings'],
+									$domain,
+									$domain['ip'],
+									$domain['port'],
+									$ssl_vhost) . "\n";
+						}
 					}
 
 					if ($domain['specialsettings'] != "") {
@@ -531,7 +534,7 @@ class lighttpd extends HttpConfigBase {
 				if ($domain['ssl_ca_file'] != '') {
 					$ssl_settings.= 'ssl.ca-file = "' . makeCorrectFile($domain['ssl_ca_file']) . '"' . "\n";
 				}
-				
+
 				if ($domain['hsts'] > 0) {
 
 					$vhost_content .= '$HTTP["scheme"] == "https" { setenv.add-response-header  = ( "Strict-Transport-Security" => "max-age=' . $domain['hsts'];

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -207,11 +207,11 @@ class nginx extends HttpConfigBase {
 				$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;\n";
 				$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param PATH_INFO \$fastcgi_path_info;\n";
 				$this->nginx_data[$vhost_filename] .= "\t\ttry_files \$fastcgi_script_name =404;\n";
-				
+
 				if ($row_ipsandports['ssl'] == '1') {
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param HTTPS on;\n";
 				}
-				
+
 				if ((int)Settings::Get('phpfpm.enabled') == 1 && (int)Settings::Get('phpfpm.enabled_ownvhost') == 1) {
 					$domain = array(
 						'id' => 'none',
@@ -225,16 +225,16 @@ class nginx extends HttpConfigBase {
 						'loginname' => 'froxlor.panel',
 						'documentroot' => $mypath,
 					);
-					
+
 					$php = new phpinterface($domain);
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_pass unix:".$php->getInterface()->getSocketFile().";\n";
 				} else {
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_pass ".Settings::Get('system.nginx_php_backend').";\n";
 				}
-				
+
 				$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_index index.php;\n";
 				$this->nginx_data[$vhost_filename] .= "\t}\n";
-				
+
 				$this->nginx_data[$vhost_filename] .= "}\n\n";
 				// End of Froxlor server{}-part
 			}
@@ -446,20 +446,23 @@ class nginx extends HttpConfigBase {
 
 				// check if vhost config template is set and if so, merge it
 				if ($domain['vhostsettingid'] != 0) {
-					$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . " WHERE `id` = :id LIMIT 1;");
+					$vhostsettings_stmt = Database::prepare("SELECT `description`, `vhostsettings` FROM " . TABLE_PANEL_VHOSTCONFIGS . "
+						WHERE `webserver` = 'nginx' AND `id` = :id LIMIT 1;");
 					$vhostconfig = Database::pexecute_first($vhostsettings_stmt, array('id' => $domain['vhostsettingid']));
 
-					// replace {SOCKET} var with unix socket
-					$php = new phpinterface($domain);
-					$vhostconfig['vhostsettings'] = str_replace("{SOCKET}", $php->getInterface()->getSocketFile(), $vhostconfig['vhostsettings']);
+					if (is_array($vhostconfig)) {
+						// replace {SOCKET} var with unix socket
+						$php = new phpinterface($domain);
+						$vhostconfig['vhostsettings'] = str_replace("{SOCKET}", $php->getInterface()->getSocketFile(), $vhostconfig['vhostsettings']);
 
-					$vhost_content = $this->mergeVhostCustom($vhost_content, $this->processSpecialConfigTemplate(
-						$vhostconfig['vhostsettings'],
-						$domain,
-						$domain['ip'],
-						$domain['port'],
-						$ssl_vhost
-					));
+						$vhost_content = $this->mergeVhostCustom($vhost_content, $this->processSpecialConfigTemplate(
+							$vhostconfig['vhostsettings'],
+							$domain,
+							$domain['ip'],
+							$domain['port'],
+							$ssl_vhost
+						));
+					}
 				}
 
 				if ($domain['specialsettings'] != "") {
@@ -580,7 +583,7 @@ class nginx extends HttpConfigBase {
 		}
 
 		if ($domain_or_ip['ssl_cert_file'] != '') {
-		    
+
 		    // check for existence, #1485
 		    if (!file_exists($domain_or_ip['ssl_cert_file'])) {
 		        $this->logger->logAction(CRON_ACTION, LOG_ERR, $domain_or_ip['domain'] . ' :: certificate file "'.$domain_or_ip['ssl_cert_file'].'" does not exist! Cannot create ssl-directives');
@@ -593,7 +596,7 @@ class nginx extends HttpConfigBase {
 					$sslsettings .= "\t" . 'ssl_ecdh_curve secp384r1;' . "\n";
     			$sslsettings .= "\t" . 'ssl_prefer_server_ciphers on;' . "\n";
     			$sslsettings .= "\t" . 'ssl_certificate ' . makeCorrectFile($domain_or_ip['ssl_cert_file']) . ';' . "\n";
-    
+
     			if ($domain_or_ip['ssl_key_file'] != '') {
     			    // check for existence, #1485
     			    if (!file_exists($domain_or_ip['ssl_key_file'])) {
@@ -603,7 +606,7 @@ class nginx extends HttpConfigBase {
     				    $sslsettings .= "\t" . 'ssl_certificate_key ' .makeCorrectFile($domain_or_ip['ssl_key_file']) . ';' .  "\n";
     			    }
     			}
-    
+
     			if ($domain_or_ip['ssl_ca_file'] != '') {
     			    // check for existence, #1485
     			    if (!file_exists($domain_or_ip['ssl_ca_file'])) {
@@ -613,7 +616,7 @@ class nginx extends HttpConfigBase {
     				    $sslsettings.= "\t" . 'ssl_client_certificate ' . makeCorrectFile($domain_or_ip['ssl_ca_file']) . ';' . "\n";
     			    }
     			}
-    			
+
 				if (isset($domain_or_ip['hsts']) && $domain_or_ip['hsts'] > 0) {
 
 					$vhost_content .= 'add_header Strict-Transport-Security "max-age=' . $domain_or_ip['hsts'];
@@ -853,11 +856,11 @@ class nginx extends HttpConfigBase {
 				$phpopts .= "\t\tfastcgi_param HTTPS on;\n";
 			}
 			$phpopts .= "\t}\n\n";
-			
+
 		}
 		return $phpopts;
 	}
-	
+
 
 	protected function getWebroot($domain, $ssl) {
 		$webroot_text = '';

--- a/templates/Sparkle/admin/vhostconfig/overview.tpl
+++ b/templates/Sparkle/admin/vhostconfig/overview.tpl
@@ -19,8 +19,9 @@ $header
 					<tr>
 						<th>{$lng['admin']['phpsettings']['description']}</th>
 						<th>{$lng['admin']['phpsettings']['activedomains']}</th>
+						<th>{$lng['admin']['webserver']}</th>
 						<th>{$lng['panel']['options']}</th>
-                                        </tr>
+					</tr>
 				</thead>
 				<tbody>
 					$tablecontent

--- a/templates/Sparkle/admin/vhostconfig/overview_overview.tpl
+++ b/templates/Sparkle/admin/vhostconfig/overview_overview.tpl
@@ -1,6 +1,7 @@
 <tr class="top">
 	<td><strong>{$row['description']}</strong></td>
 	<td>{$domains}</td>
+	<td>{$webserver}</td>
 	<td>
 		<a href="{$linker->getLink(array('section' => 'vhostsettings', 'page' => $page, 'action' => 'edit', 'id' => $row['id']))}">
 			<img src="templates/{$theme}/assets/img/icons/edit.png" alt="{$lng['panel']['edit']}" title="{$lng['panel']['edit']}" />


### PR DESCRIPTION
This PR enables Vhost templates to be assigned a specific webserver. 

This is not only useful if you consider switching from one server system to another, e.g. nginx -> Apache. It also prevents that a template is loaded for a webserver it is not suited for.

Other improvements in this PR:
- Cleaned admin_vhostsettings.php from useless overhead and tried to make it easier readable.
- Refential integrity is now provided: The cron scripts check whether the referenced template is actually existing before proceeding. Likewise, if a template is deleted, the reference is reset for the domains using it.