### PR TITLE
Zeige die neue vHost-Konfiguration auch wenn nur mod_php installiert ist.

### DIFF
--- a/lib/navigation/00.froxlor.main.php
+++ b/lib/navigation/00.froxlor.main.php
@@ -254,10 +254,6 @@ return array (
 	            array (
 	                'url' => 'admin_vhostsettings.php?page=overview',
 	                'label' => $lng['menue']['vhostsettings']['maintitle'],
-	                'show_element' => (
-	                    Settings::Get('system.mod_fcgid') == true ||
-	                    Settings::Get('phpfpm.enabled') == true
-	                ),
 	                'required_resources' => 'change_serversettings'
 	            ),
 	            array (


### PR DESCRIPTION
Ich behaupte mal das weder fpm noch fcgid nötig sind dafür. Vermutlich einfach copy&paste gewesen? :P