### PR TITLE
Set myhostname to $mydomain in postfix

### DIFF
--- a/lib/configfiles/gentoo.xml
+++ b/lib/configfiles/gentoo.xml
@@ -1061,11 +1061,11 @@ program_directory = /usr/libexec/postfix
 sendmail_path = /usr/sbin/sendmail
 
 ## General Postfix configuration
-# should be the default domain from your provider eg. "server100.provider.tld"
+# FQDN from Froxlor
 mydomain = <SERVERNAME>
 
-# should be different from $mydomain eg. "mail.$mydomain"
-myhostname = mail.$mydomain
+# set myhostname to $mydomain because Froxlor alrady uses a FQDN
+myhostname = $mydomain
 
 mydestination = $myhostname,
 	$mydomain,

--- a/lib/configfiles/jessie.xml
+++ b/lib/configfiles/jessie.xml
@@ -1122,7 +1122,7 @@ data_directory = /var/lib/postfix
 # from gethostname(). $myhostname is used as a default value for many
 # other configuration parameters.
 #
-myhostname = mail.$mydomain
+myhostname = $mydomain
 #myhostname = virtual.domain.tld
 
 # The mydomain parameter specifies the local internet domain name.

--- a/lib/configfiles/jessie.xml
+++ b/lib/configfiles/jessie.xml
@@ -1115,22 +1115,11 @@ data_directory = /var/lib/postfix
 #
 #default_privs = nobody
 
-# INTERNET HOST AND DOMAIN NAMES
-#
-# The myhostname parameter specifies the internet hostname of this
-# mail system. The default is to use the fully-qualified domain name
-# from gethostname(). $myhostname is used as a default value for many
-# other configuration parameters.
-#
-myhostname = $mydomain
-#myhostname = virtual.domain.tld
-
-# The mydomain parameter specifies the local internet domain name.
-# The default is to use $myhostname minus the first component.
-# $mydomain is used as a default value for many other configuration
-# parameters.
-#
+# FQDN from Froxlor
 mydomain = <SERVERNAME>
+
+# set myhostname to $mydomain because Froxlor alrady uses a FQDN
+myhostname = $mydomain
 
 # SENDING MAIL
 #

--- a/lib/configfiles/precise.xml
+++ b/lib/configfiles/precise.xml
@@ -512,10 +512,10 @@ root:               root@<SERVERNAME>
 						backup="true">
 						<content><![CDATA[
 ## General Postfix configuration
-# should be the default domain from your provider eg. "server100.provider.tld"
+# FQDN from Froxlor
 mydomain = <SERVERNAME>
 
-# should be different from $mydomain eg. "mail.$mydomain"
+# set myhostname to $mydomain because Froxlor alrady uses a FQDN
 myhostname = $mydomain
 
 mydestination = $myhostname,

--- a/lib/configfiles/precise.xml
+++ b/lib/configfiles/precise.xml
@@ -516,7 +516,7 @@ root:               root@<SERVERNAME>
 mydomain = <SERVERNAME>
 
 # should be different from $mydomain eg. "mail.$mydomain"
-myhostname = mail.$mydomain
+myhostname = $mydomain
 
 mydestination = $myhostname,
 	$mydomain,

--- a/lib/configfiles/rhel_centos.xml
+++ b/lib/configfiles/rhel_centos.xml
@@ -176,10 +176,10 @@ query = SELECT gid FROM mail_users WHERE email = '%s'
 						backup="true">
 						<content><![CDATA[
 ## General Postfix configuration
-
+# FQDN from Froxlor
 mydomain = <SERVERNAME>
 
-# should be different from $mydomain eg. "mail.$mydomain"
+# set myhostname to $mydomain because Froxlor alrady uses a FQDN
 myhostname = $mydomain
 
 mydestination = $myhostname,

--- a/lib/configfiles/rhel_centos.xml
+++ b/lib/configfiles/rhel_centos.xml
@@ -180,7 +180,7 @@ query = SELECT gid FROM mail_users WHERE email = '%s'
 mydomain = <SERVERNAME>
 
 # should be different from $mydomain eg. "mail.$mydomain"
-myhostname = mail.$mydomain
+myhostname = $mydomain
 
 mydestination = $myhostname,
 	$mydomain,

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -545,7 +545,7 @@ root:               root@<SERVERNAME>
 mydomain = <SERVERNAME>
 
 # should be different from $mydomain eg. "mail.$mydomain"
-myhostname = mail.$mydomain
+myhostname = $mydomain
 
 mydestination = $myhostname,
 	$mydomain,

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -541,10 +541,10 @@ root:               root@<SERVERNAME>
 						backup="true">
 						<content><![CDATA[
 ## General Postfix configuration
-# should be the default domain from your provider eg. "server100.provider.tld"
+# FQDN from Froxlor
 mydomain = <SERVERNAME>
 
-# should be different from $mydomain eg. "mail.$mydomain"
+# set myhostname to $mydomain because Froxlor alrady uses a FQDN
 myhostname = $mydomain
 
 mydestination = $myhostname,

--- a/lib/configfiles/wheezy.xml
+++ b/lib/configfiles/wheezy.xml
@@ -961,7 +961,7 @@ data_directory = /var/lib/postfix
 # for the case of a subdomain, $mydomain *must* be equal to $myhostname,
 # otherwise you cannot use the main domain for virtual transport.
 # also check the note about $mydomain below.
-myhostname = mail.$mydomain
+myhostname = $mydomain
 #myhostname = virtual.domain.tld
 
 # The mydomain parameter specifies the local internet domain name.

--- a/lib/configfiles/wheezy.xml
+++ b/lib/configfiles/wheezy.xml
@@ -950,28 +950,11 @@ data_directory = /var/lib/postfix
 #default_privs = nobody
 
 # INTERNET HOST AND DOMAIN NAMES
-#
-# The myhostname parameter specifies the internet hostname of this
-# mail system. The default is to use the fully-qualified domain name
-# from gethostname(). $myhostname is used as a default value for many
-# other configuration parameters.
-#
-# Froxlor Note: $myhostname can and should be the same as $mydomain as long as
-# you don't intend to send mail to it (it will be considered local, not virtual)
-# for the case of a subdomain, $mydomain *must* be equal to $myhostname,
-# otherwise you cannot use the main domain for virtual transport.
-# also check the note about $mydomain below.
-myhostname = $mydomain
-#myhostname = virtual.domain.tld
-
-# The mydomain parameter specifies the local internet domain name.
-# The default is to use $myhostname minus the first component.
-# $mydomain is used as a default value for many other configuration
-# parameters.
-#
-# Froxlor Note: We are using a default here but that may or may not make sense,
-# depending on your dns configuration, please check yourself.
+# FQDN from Froxlor
 mydomain = <SERVERNAME>
+
+# set myhostname to $mydomain because Froxlor alrady uses a FQDN
+myhostname = $mydomain
 
 # SENDING MAIL
 #


### PR DESCRIPTION
If you configure Froxlor properly to a valid FQDN like srv.domain.tld you would want to set myhostname in postfix to that FQDN and not as previously to mail.srv.domain.tld