### PR TITLE
ssl_cert_chainfile should only contain the intermediate certificate

### DIFF
--- a/scripts/jobs/cron_letsencrypt.php
+++ b/scripts/jobs/cron_letsencrypt.php
@@ -28,7 +28,7 @@ $certificates_stmt = Database::query("
 ");
 
 $updcert_stmt = Database::prepare("
-	REPLACE INTO `".TABLE_PANEL_DOMAIN_SSL_SETTINGS."` SET `id` = :id, `domainid` = :domainid, `ssl_cert_file` = :crt, `ssl_key_file` = :key, `ssl_ca_file` = :ca, `ssl_cert_chainfile` = :fullchain, `ssl_csr_file` = :csr, expirationdate = :expirationdate
+	REPLACE INTO `".TABLE_PANEL_DOMAIN_SSL_SETTINGS."` SET `id` = :id, `domainid` = :domainid, `ssl_cert_file` = :crt, `ssl_key_file` = :key, `ssl_ca_file` = :ca, `ssl_cert_chainfile` = :chain, `ssl_csr_file` = :csr, expirationdate = :expirationdate
 ");
 
 $upddom_stmt = Database::prepare("
@@ -86,7 +86,7 @@ while ($certrow = $certificates_stmt->fetch(PDO::FETCH_ASSOC)) {
 					'crt' => $return['crt'],
 					'key' => $return['key'],
 					'ca' => $return['chain'],
-					'fullchain' => $return['fullchain'],
+					'chain' => $return['chain'],
 					'csr' => $return['csr'],
 					'expirationdate' => date('Y-m-d H:i:s', $newcert['validTo_time_t'])
 				)


### PR DESCRIPTION
The column ssl_cert_chainfile in the domain_ssl_settings tablet should only contain the intermediate certificate. Using the fullcert from let's encrypt leads on using nginx to a certificate file like this:

[Certificate]
[Certificate]
[Intermediate Certificate]

Not a real problem but the check on ssllabs.com shows a error message:

[https://community.qualys.com/docs/DOC-1931](url)
