### PR TITLE
Support for multi homed DNS servers

### DIFF
--- a/scripts/jobs/cron_tasks.inc.dns.10.bind.php
+++ b/scripts/jobs/cron_tasks.inc.dns.10.bind.php
@@ -35,14 +35,17 @@ class bind {
 			foreach ($nameservers as $nameserver) {
 				// DNS servers might be multi homed; allow transfer from all ip
 				// addresses of the DNS server
-                $nameserver_ips = gethostbynamel(trim($nameserver));
-				if (substr($nameserver, -1, 1) != '.') {
-					$nameserver.= '.';
+				$nameserver_ips = gethostbynamel(trim($nameserver));
+				// ignore invalid responses
+				if (is_array($nameserver_ips)) {
+					if (substr($nameserver, -1, 1) != '.') {
+						$nameserver.= '.';
+					}
+					$this->nameservers[] = array(
+						'hostname' => trim($nameserver),
+						'ips' => $nameserver_ips
+					);
 				}
-				$this->nameservers[] = array(
-					'hostname' => trim($nameserver),
-                    'ips' => $nameserver_ips
-				);
 			}
 		}
 
@@ -235,9 +238,9 @@ class bind {
 			// put nameservers in allow-transfer
 			if (count($this->nameservers) > 0) {
 				foreach ($this->nameservers as $ns) {
-                    foreach($ns["ips"] as $ip) {
-                        $bindconf_file.= '		' . $ip . ";\n";
-                    }
+					foreach($ns["ips"] as $ip) {
+						$bindconf_file.= '		' . $ip . ";\n";
+					}
 				}
 			}
 			// AXFR server #100

--- a/scripts/jobs/cron_tasks.inc.dns.10.bind.php
+++ b/scripts/jobs/cron_tasks.inc.dns.10.bind.php
@@ -33,13 +33,15 @@ class bind {
 		if (Settings::Get('system.nameservers') != '') {
 			$nameservers = explode(',', Settings::Get('system.nameservers'));
 			foreach ($nameservers as $nameserver) {
-				$nameserver_ip = gethostbyname(trim($nameserver));
+				// DNS servers might be multi homed; allow transfer from all ip
+				// addresses of the DNS server
+                $nameserver_ips = gethostbynamel(trim($nameserver));
 				if (substr($nameserver, -1, 1) != '.') {
 					$nameserver.= '.';
 				}
 				$this->nameservers[] = array(
 					'hostname' => trim($nameserver),
-					'ip' => trim($nameserver_ip)
+                    'ips' => $nameserver_ips
 				);
 			}
 		}
@@ -233,7 +235,9 @@ class bind {
 			// put nameservers in allow-transfer
 			if (count($this->nameservers) > 0) {
 				foreach ($this->nameservers as $ns) {
-					$bindconf_file.= '		' . $ns['ip'] . ';' . "\n";
+                    foreach($ns["ips"] as $ip) {
+                        $bindconf_file.= '		' . $ip . ";\n";
+                    }
 				}
 			}
 			// AXFR server #100


### PR DESCRIPTION
Hi,

the secondary DNS servers might have multiple IP addresses and the transfer requests might be issued from any of the IP addresses; therefore all IP addresses of the secodnary DNS servers should be allowed to transfer zones. I had this fix added to my old syscp installation for some years. 

As I plan to upgrade to a recent Froxlor version I decided to share some of my modifications with you.

Regards

Kay Zumbusch