### PR TITLE
Let's Encrypt: Always regenerate a new account-key, if staging

### DIFF
--- a/lib/classes/ssl/class.lescript.php
+++ b/lib/classes/ssl/class.lescript.php
@@ -50,7 +50,7 @@ class lescript
     {
         // Let's see if we have the private accountkey
         $this->accountKey = $certrow['leprivatekey'];
-        if (!$this->accountKey || $this->accountKey == 'unset') {
+        if (!$this->accountKey || $this->accountKey == 'unset' || Settings::Get('system.letsencryptca') != 'production') {
 
             // generate and save new private key for account
             // ---------------------------------------------


### PR DESCRIPTION
The generated account-key is already set to NOT be saved when not using the production environment of LE (since keys are not saved on staging at LE and should be regenerated on every request), but new account-key generation is not triggered when not in production.

So if you have a account-key generated in production (which seems to be the default) and switch to staging afterwards, it'll try to use the production-key, which will fail.

Solution: Simple addition to the if-check.