### PR TITLE
Add the posibility to create new mailboxes with first- and lastname

### DIFF
--- a/actions/admin/settings/150.mail.php
+++ b/actions/admin/settings/150.mail.php
@@ -61,6 +61,14 @@ return array(
 					'string_emptyallowed' => true,
 					'save_method' => 'storeSettingField',
 					),
+				'panel_mailacc_with_name' => array(
+					'label' => $lng['serversettings']['mailacc_with_name'],
+					'settinggroup' => 'panel',
+					'varname' => 'mailacc_with_name',
+					'type' => 'bool',
+					'default' => false,
+					'save_method' => 'storeSettingField',
+					),
 				'panel_sendalternativemail' => array(
 					'label' => $lng['serversettings']['sendalternativemail'],
 					'settinggroup' => 'panel',

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3171,3 +3171,16 @@ if (isDatabaseVersion('201603070')) {
 
 	updateToDbVersion('201603150');
 }
+
+if (isDatabaseVersion('201603150')) {
+
+        showUpdateStep("Adding new mailacc_with_name setting to table panel_settings");
+	Database::query("INSERT INTO `" . TABLE_PANEL_SETTINGS . "` SET `settinggroup` = 'panel', `varname` = 'mailacc_with_name', `value` = '';");
+        lastStepStatus(0);
+	
+        showUpdateStep("Alter table mail_users to be able to hold first and lastname for a mailbox");
+	Database::query("ALTER TABLE `" . TABLE_MAIL_USERS ."` ADD COLUMN `firstname` VARCHAR(128) NOT NULL AFTER `username`, ADD COLUMN `lastname` VARCHAR(128) NOT NULL AFTER `firstname`;");
+        lastStepStatus(0);
+
+        updateToDbVersion('201603270');
+}

--- a/lib/formfields/customer/email/formfield.emails_accountchangename.php
+++ b/lib/formfields/customer/email/formfield.emails_accountchangename.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the Froxlor project.
+ * Copyright (c) 2010 the Froxlor Team (see authors).
+ *
+ * For the full copyright and license information, please view the COPYING
+ * file that was distributed with this source code. You can also view the
+ * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
+ *
+ * @copyright  (c) the authors
+ * @author     Froxlor team <team@froxlor.org> (2010-)
+ * @license    GPLv2 http://files.froxlor.org/misc/COPYING.txt
+ * @package    Formfields
+ *
+ */
+
+return array(
+	'emails_accountchangename' => array(
+		'title' => $lng['menue']['main']['changepassword'],
+		'image' => 'icons/email_edit.png',
+		'sections' => array(
+			'section_a' => array(
+				'title' => $lng['menue']['main']['changepassword'],
+				'image' => 'icons/email_edit.png',
+				'fields' => array(
+					'email_full' => array(
+						'label' => $lng['emails']['emailaddress'],
+						'type' => 'label',
+						'value' => $result['email_full']
+					),
+					'owner_lastname' => array(
+						'label' => $lng['customer']['name'],
+						'type'  => 'text',
+						'value' => $result['lastname'],
+					),
+					'owner_firstname' => array(
+						'label' => $lng['customer']['firstname'], 
+						'type' => 'text',
+						'value' => $result['firstname'],
+					),
+				)
+			)
+		)
+	)
+);

--- a/lib/formfields/customer/email/formfield.emails_addaccount.php
+++ b/lib/formfields/customer/email/formfield.emails_addaccount.php
@@ -29,6 +29,16 @@ return array(
 						'type' => 'label',
 						'value' => $result['email_full']
 					),
+					'owner_lastname' => array(
+						'visible' => (Settings::Get('panel.mailacc_with_name') == '1' ? true : false),
+                                                'label'   => $lng['customer']['name'],
+                                                'type'    => 'text',
+                                        ),
+					'owner_firstname' => array(
+						'visible' => (Settings::Get('panel.mailacc_with_name') == '1' ? true : false),
+                                                'label'   => $lng['customer']['firstname'],
+                                                'type'    => 'text',
+                                        ),
 					'email_password' => array(
 						'label' => $lng['login']['password'],
 						'type' => 'password',

--- a/lib/formfields/customer/email/formfield.emails_edit.php
+++ b/lib/formfields/customer/email/formfield.emails_edit.php
@@ -30,6 +30,12 @@ return array(
 						'type' => 'label',
 						'value' => $result['email_full']
 					),
+					'owner_name' => array(
+						'visible' => ($result['popaccountid'] != 0 ? true : false) && (Settings::Get('panel.mailacc_with_name') == '1' ? true : false),
+						'label' => $lng['customer']['name'],
+						'type' => 'label',
+						'value' => $result['firstname']." ".$result['lastname'].'&nbsp;[<a href="'.$filename.'?page=accounts&amp;action=changename&amp;id='.$result['id'].'&amp;s='.$s.'">'.$lng['menue']['main']['changename'].'</a>]'
+					),
 					'account_yes' => array(
 						'visible' => ($result['popaccountid'] != 0 ? true : false),
 						'label' => $lng['emails']['account'],

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1975,3 +1975,8 @@ $lng['domains']['termination_date_overview'] = 'canceled until ';
 $lng['panel']['set'] = 'Apply';
 $lng['customer']['selectserveralias_addinfo'] = 'This option can be set when editing the domain. Its initial value is inherited from the parent-domain.';
 $lng['error']['mailaccistobedeleted'] = "Another account with the same name (%s) is currently being deleted and can therefore not be added at this moment.";
+
+// Added for mailbox with first- and lastname
+$lng['menue']['main']['changenamv'] = 'Change name';
+$lng['serversettings']['mailacc_with_name']['title'] = 'Create mailboxes with first- and lastname';
+$lng['serversettings']['mailacc_with_name']['description'] = 'When you create new mailboxes it is possible to add a first- and lastname of the owner of that mailbox.';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1628,3 +1628,8 @@ $lng['domains']['termination_date_overview'] = 'gekündigt zum ';
 $lng['panel']['set'] = 'Setzen';
 $lng['customer']['selectserveralias_addinfo'] = 'Diese Option steht beim Bearbeiten der Domain zur Verfügung. Als Initial-Wert wird die Einstellung der Hauptdomain vererbt.';
 $lng['error']['mailaccistobedeleted'] = "Ein vorheriges Konto mit dem gleichen Namen (%s) wird aktuell noch gelöscht und kann daher derzeit nicht angelegt werden";
+
+// Added for 'Mail Account with Name'
+$lng['menue']['main']['changename'] = 'Name ändern';
+$lng['serversettings']['mailacc_with_name']['title'] = "Emailkonten mit Vor- und Nachname erstellen";
+$lng['serversettings']['mailacc_with_name']['description'] = 'Beim Anlegen eines neuen Email-Kontos kann ein Name für den Eigentümer des Kontos hinterlegt werden.';

--- a/templates/Sparkle/customer/email/account_changename.tpl
+++ b/templates/Sparkle/customer/email/account_changename.tpl
@@ -1,0 +1,26 @@
+$header
+	<article>
+		<header>
+			<h2>
+				<img src="templates/{$theme}/assets/img/icons/email_edit_big.png" alt="{$title}" />&nbsp;
+				{$title}
+			</h2>
+		</header>
+
+		<section>
+			<form action="{$linker->getLink(array('section' => 'email'))}" method="post" enctype="application/x-www-form-urlencoded">
+				<input type="hidden" name="s" value="$s" />
+				<input type="hidden" name="page" value="$page" />
+				<input type="hidden" name="action" value="$action" />
+				<input type="hidden" name="id" value="$id" />
+				<input type="hidden" name="send" value="send" />
+
+				<table class="full">
+					{$account_changename_form}
+				</table>
+			</form>
+
+		</section>
+
+	</article>
+$footer

--- a/templates/Sparkle/customer/email/emails_edit.tpl
+++ b/templates/Sparkle/customer/email/emails_edit.tpl
@@ -8,7 +8,6 @@ $header
 	</header>
 
 	<section>
-
 		<form action="{$linker->getLink(array('section' => 'email'))}" method="post" enctype="application/x-www-form-urlencoded">
 			<table class="full">
 				<thead>


### PR DESCRIPTION
This patch provides the positbility to create a new mailbox with a firstname and a
lastname. This is very useful if you want to connect these mailboxes with a groupware.
For the case that the feature is not wanted: There was added a setting for this feature.
Default status of this feature is disabled.
