### PR TITLE
Added option in system/ssl-settings to define the desired ssl_protocols to be used

### DIFF
--- a/actions/admin/settings/131.ssl.php
+++ b/actions/admin/settings/131.ssl.php
@@ -31,6 +31,16 @@ return array(
 									'save_method' => 'storeSettingField',
 									'overview_option' => true
 							),
+                                                       'system_ssl_protocols' => array(
+                                                                        'label' => $lng['serversettings']['ssl']['ssl_protocols'],
+                                                                        'settinggroup' => 'system',
+                                                                        'varname' => 'ssl_protocols',
+                                                                        'type' => 'option',
+                                                                        'default' => 'TLSv1,TLSv1.1,TLSv1.2',
+                                                                        'option_mode' => 'multiple',
+                                                                        'option_options' => array('TLSv1' => 'TLSv1', 'TLSv1.1' => 'TLSv1.1', 'TLSv1.2' => 'TLSv1.2'),
+                                                                        'save_method' => 'storeSettingField',
+                                                        ),
 							'system_ssl_cipher_list' => array(
 									'label' => $lng['serversettings']['ssl']['ssl_cipher_list'],
 									'settinggroup' => 'system',

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -493,6 +493,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('system', 'mod_fcgid_defaultini_ownvhost', '2'),
 	('system', 'awstats_icons', '/usr/share/awstats/icon/'),
 	('system', 'ssl_cert_chainfile', ''),
+	('system', 'ssl_protocols', 'TLSv1,TLSv1.1,TLSv1.2'),
 	('system', 'ssl_cipher_list', 'ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128'),
 	('system', 'nginx_php_backend', '127.0.0.1:8888'),
 	('system', 'perl_server', 'unix:/var/run/nginx/cgiwrap-dispatch.sock'),

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -2491,6 +2491,10 @@ if (isFroxlorVersion('0.9.30-rc1')) {
 	Database::query("INSERT INTO `panel_settings` SET `settinggroup` = 'system', `varname` = 'ssl_cipher_list', `value` = 'ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH'");
 	lastStepStatus(0);
 
+        showUpdateStep("Adding ssl-protocols setting");
+        Database::query("INSERT INTO `panel_settings` SET `settinggroup` = 'system', `varname` = 'ssl_protocols', `value` = 'TLSv1,TLSv1.1,TLSv1.2'");
+        lastStepStatus(0);
+
 	updateToVersion('0.9.30');
 }
 

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1730,6 +1730,8 @@ $lng['domains']['serveraliasoption_none'] = 'No alias';
 $lng['error']['givendirnotallowed'] = 'The given directory in field %s is not allowed.';
 $lng['serversettings']['ssl']['ssl_cipher_list']['title'] = 'Configure the allowed SSL ciphers';
 $lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'This is a list of ciphers that you want (or don\'t want) to use when talking SSL. For a list of ciphers and how to include/exclude them, see sections "CIPHER LIST FORMAT" and "CIPHER STRINGS" on <a href="http://openssl.org/docs/apps/ciphers.html">the man-page for ciphers</a>.<br /><br /><b>Default value is:</b><pre>ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128</pre>';
+$lng['serversettings']['ssl']['ssl_protocols']['title'] = 'Configure the TLS protocol version';
+$lng['serversettings']['ssl']['ssl_protocols']['description'] = 'This is a list of ssl protocols that you want (or don\'t want) to use when talking SSL. <b>Notice:</b> Some older browsers may not support the newest protcol versions. <br /><br /><b>Default value is:</b><pre>TLSv1, TLSv1.1, TLSv1.2</pre>';
 
 // Added in Froxlor 0.9.31
 $lng['panel']['dashboard'] = 'Dashboard';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1456,6 +1456,8 @@ $lng['domains']['serveraliasoption_none'] = 'Kein Alias';
 $lng['error']['givendirnotallowed'] = 'Das angegebene Verzeichnis im Feld %s ist nicht erlaubt.';
 $lng['serversettings']['ssl']['ssl_cipher_list']['title'] = 'Erlaubte SSL Ciphers festlegen';
 $lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'Dies ist eine Liste von Ciphers, die genutzt werden sollen (oder auch nicht genutzt werden sollen), wenn eine SSL Verbindung besteht. Eine Liste aller Ciphers und wie diese hinzugefügt/ausgeschlossen werden ist in den Abschnitten "CIPHER LIST FORMAT" und "CIPHER STRINGS" in <a href="http://openssl.org/docs/apps/ciphers.html">der man-page für Ciphers</a> zu finden.<br /><br /><b>Standard-Wert ist:</b><pre>ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128</pre>';
+$lng['serversettings']['ssl']['ssl_protocols']['title'] = 'SSL Version festlegen';
+$lng['serversettings']['ssl']['ssl_protocols']['description'] = 'Dies ist eine Liste von Protokollversionen, die genutzt werden sollen (oder auch nicht genutzt werden sollen), um SSL Verbindungen zu Clients zu initiieren. <b>Hinweis:</b> &Auml;ltere Browser sind m&ouml;glicherweise nicht vollstÃ¤ndig zum neusten Protokoll kompatibel. <br /><br /><b>Standard-Wert ist:</b><pre>TLSv1, TLSv1.1, TLSv1.2</pre>';
 
 // Added in Froxlor 0.9.31
 $lng['panel']['dashboard'] = 'Dashboard';

--- a/lng/italian.lng.php
+++ b/lng/italian.lng.php
@@ -1700,6 +1700,8 @@ $lng['domains']['serveraliasoption_none'] = 'Nessun alias';
 $lng['error']['givendirnotallowed'] = 'La cartella fornita nel campo %s non è permessa.';
 $lng['serversettings']['ssl']['ssl_cipher_list']['title'] = 'Configura le cifrature SSL permesse';
 $lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'Questa è una lista di cifrature che vuoi (o non vuoi) usare nelle communicazioni SSL. Per una lista delle cifrature e come includerle od escluderle, vedi le sezioni "CIPHER LIST FORMAT" e "CIPHER STRINGS" sulla <a href="http://openssl.org/docs/apps/ciphers.html">man-page per le cifrature</a>.<br /><br /><b>Il valore predefinito è:</b><pre>ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH</pre>';
+$lng['serversettings']['ssl']['ssl_protocols']['title'] = 'Configura le cifrature SSL protocollo';
+$lng['serversettings']['ssl']['ssl_protocols']['description'] = 'Questa Ã¨ una lista di protocolli SSL che si desidera (o non vuoi) da utilizzare quando si parla di SSL. <b>Avviso:</b> Alcuni browser piÃ¹ vecchi potrebbero non supportare le versioni piÃ¹ recenti di protocollo. <br /><br /><b>Il valore predefinito Ã¨:</b><pre>TLSv1, TLSv1.1, TLSv1.2</pre>';
 $lng['panel']['dashboard'] = 'Cruscotto';
 $lng['panel']['assigned'] = 'Assegnato';
 $lng['panel']['available'] = 'Disponibile';

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -362,7 +362,7 @@ class apache extends HttpConfigBase {
 						} else {
 
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLEngine On' . "\n";
-							$this->virtualhosts_data[$vhosts_filename] .= ' SSLProtocol ALL -SSLv2 -SSLv3' . "\n";
+                                                        $this->virtualhosts_data[$vhosts_filename] .= ' SSLProtocol -ALL ' . str_replace(","," +",Settings::Get('system.ssl_protocols')) . "\n";
 							// this makes it more secure, thx to Marcel (08/2013)
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLHonorCipherOrder On' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCipherSuite ' . Settings::Get('system.ssl_cipher_list') . "\n";
@@ -796,7 +796,7 @@ class apache extends HttpConfigBase {
 
 			if ($domain['ssl_cert_file'] != '') {
 				$vhost_content .= '  SSLEngine On' . "\n";
-				$vhost_content .= '  SSLProtocol ALL -SSLv2 -SSLv3' . "\n";
+                                $vhost_content .= '  SSLProtocol -ALL ' . str_replace(","," +",Settings::Get('system.ssl_protocols')) . "\n";
 				// this makes it more secure, thx to Marcel (08/2013)
 				$vhost_content .= '  SSLHonorCipherOrder On' . "\n";
 				$vhost_content .= '  SSLCipherSuite ' . Settings::Get('system.ssl_cipher_list') . "\n";

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -172,6 +172,7 @@ class lighttpd extends HttpConfigBase {
 				    } else {
     					$this->lighttpd_data[$vhost_filename].= 'ssl.engine = "enable"' . "\n";
     					$this->lighttpd_data[$vhost_filename].= 'ssl.use-sslv2 = "disable"' . "\n";
+					$this->lighttpd_data[$vhost_filename].= 'ssl.use-sslv3 = "disable"' . "\n";
     					$this->lighttpd_data[$vhost_filename].= 'ssl.cipher-list = "' . Settings::Get('system.ssl_cipher_list') . '"' . "\n";
     					$this->lighttpd_data[$vhost_filename].= 'ssl.honor-cipher-order = "enable"' . "\n";
     					$this->lighttpd_data[$vhost_filename].= 'ssl.pemfile = "' . makeCorrectFile($row_ipsandports['ssl_cert_file']) . '"' . "\n";
@@ -511,6 +512,7 @@ class lighttpd extends HttpConfigBase {
 			    
 				$ssl_settings.= 'ssl.engine = "enable"' . "\n";
 				$ssl_settings.= 'ssl.use-sslv2 = "disable"' . "\n";
+                                $ssl_settings.= 'ssl.use-sslv3 = "disable"' . "\n";
 				$ssl_settings.= 'ssl.cipher-list = "' . Settings::Get('system.ssl_cipher_list') . '"' . "\n";
 				$ssl_settings.= 'ssl.honor-cipher-order = "enable"' . "\n";
 				$ssl_settings.= 'ssl.pemfile = "' . makeCorrectFile($domain['ssl_cert_file']) . '"' . "\n";

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -568,9 +568,7 @@ class nginx extends HttpConfigBase {
 		        $this->logger->logAction(CRON_ACTION, LOG_ERR, $domain_or_ip['domain'] . ' :: certificate file "'.$domain_or_ip['ssl_cert_file'].'" does not exist! Cannot create ssl-directives');
 		        echo $domain_or_ip['domain'] . ' :: certificate file "'.$domain_or_ip['ssl_cert_file'].'" does not exist! Cannot create SSL-directives'."\n";
 		    } else {
-			// obsolete: ssl on now belongs to the listen block as 'ssl' at the end
-    			//$sslsettings .= "\t" . 'ssl on;' . "\n";
-    			$sslsettings .= "\t" . 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2;' . "\n";
+			$sslsettings .= "\t" . 'ssl_protocols ' . str_replace(","," ",Settings::Get('system.ssl_protocols')) . ';' . "\n";
     			$sslsettings .= "\t" . 'ssl_ciphers ' . Settings::Get('system.ssl_cipher_list') . ';' . "\n";
 					$sslsettings .= "\t" . 'ssl_ecdh_curve secp384r1;' . "\n";
     			$sslsettings .= "\t" . 'ssl_prefer_server_ciphers on;' . "\n";


### PR DESCRIPTION
This commit adds the opportunity to choose the desired ssl protocols within System --> SSL Settings.
The available options are TLSv1, TLSv1.1, TLSv1.2  - which can be enabled in combination or single.

Since i could not figure out the Lighttpd config yet, i only added support for Nginx and Apache for now.

! This commit needs further testing !