### PR TITLE
Letsencrypt alias domains 

### DIFF
--- a/lib/classes/ssl/class.lescript.php
+++ b/lib/classes/ssl/class.lescript.php
@@ -218,7 +218,7 @@ class lescript
 
 		$this->client->getLastLinks();
 
-		if (empty($csrfile) || Settings::Get('system.letsencryptreuseold') == 0) {
+		if (empty($csr) || Settings::Get('system.letsencryptreuseold') == 0) {
 			$csr = $this->generateCSR($privateDomainKey, $domains);
 		}
 


### PR DESCRIPTION
At least for Apache:

ServerAlias is used for ssl alias domains, however the certificate is only for the primary domain.
This patch adds the alias domains as additional san domains.  The primary domain currently is responsible for activating let's encrypt. 

This won't solve the problem that changing wwwalias settings or alias domains won't recreate a proper new certificate request as the old domains will always used.
Technical expire needs to be reset and the csr recreated when csr old domain list != domains.

Patch 2 $csrfile:
Seems like a variable from upstream lescript was not converted to database fields (untested) 