### PR TITLE
Prevent Chromes password autofill in

### DIFF
--- a/templates/Sparkle/admin/customers/customers_edit.tpl
+++ b/templates/Sparkle/admin/customers/customers_edit.tpl
@@ -15,6 +15,7 @@ $header
 				<input type="hidden" name="action" value="$action" />
 				<input type="hidden" name="id" value="$id" />
 				<input type="hidden" name="send" value="send" />
+				<input type="password" name="fakepwd" class="input-fake" />
 			
 				<table class="full">
 					{$customer_edit_form}

--- a/templates/Sparkle/assets/css/main.css
+++ b/templates/Sparkle/assets/css/main.css
@@ -1513,3 +1513,9 @@ fieldset.file {
 table.hl tbody tr.domain-hostname:hover {
 	background-color: rgb(64, 150, 238);
 }
+.input-fake{
+  visibility:hidden;
+  position:absolute;
+  width:0;
+  height:0;
+}


### PR DESCRIPTION
If editing a customers in Chrome-Browser a saved password is automatically filled in the password field.
If not manually emptied the auto-filled-in-password gets the new customer-password.
This patch inserts a hidden password-field that gets auto-filled-in by chrome so the froxlor password-field keeps empty until filled manually.