### PR TITLE
BUGFIX: Cleaninstall fails due syntax error in froxlor.sql 

### DIFF
--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -191,7 +191,7 @@ CREATE TABLE `panel_customers` (
   `pop3` tinyint(1) NOT NULL default '1',
   `imap` tinyint(1) NOT NULL default '1',
   `perlenabled` tinyint(1) NOT NULL default '0',
-  `dnsenabled` tinyint(1) NOT NULL default '0'
+  `dnsenabled` tinyint(1) NOT NULL default '0',
   `theme` varchar(255) NOT NULL default 'Sparkle',
   `custom_notes` text,
   `custom_notes_show` tinyint(1) NOT NULL default '0',


### PR DESCRIPTION
Missing comma after dnsenabled