### PR TITLE
fix non-persistent XSS due inproper content escaping

### DIFF
--- a/index.php
+++ b/index.php
@@ -302,7 +302,7 @@ if ($action == 'login') {
 		}
 		$lastqrystr = "";
 		if (isset($_REQUEST['qrystr']) && $_REQUEST['qrystr'] != "") {
-			$lastqrystr = strip_tags($_REQUEST['qrystr']);
+			$lastqrystr = htmlspecialchars($_REQUEST['qrystr'], ENT_QUOTES);
 		}
 
 		eval("echo \"" . getTemplate('login') . "\";");


### PR DESCRIPTION
This commit fixes non-persistent Cross-site scripting (XSS) vulnerability due improper content escaping. Variable `qrystr` is used in template in html attribute content, but it's escaped in generic content (strip_tags).

Vulnerability was found during penetration testing.