### PR TITLE
Letsencrypt: Don't redirect .well-known

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -851,10 +851,16 @@ class apache extends HttpConfigBase {
 			if (!$ssl_vhost) {
 				$vhost_content .= '    RewriteCond %{HTTPS} off' . "\n";
 			}
+			if ($domain['letsencrypt']) {
+				$vhost_content .= '    RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/' . "\n";
+			}
 			$vhost_content .= '    RewriteRule ^/(.*) '. $corrected_docroot.'$1' . $modrew_red . "\n";
 			$vhost_content .= '  </IfModule>' . "\n";
 
-			$vhost_content .= '  Redirect '.$code.' / ' . $this->idnaConvert->encode($domain['documentroot']) . "\n";
+			if (!$domain['letsencrypt']) {
+				// With lets'encryp we can't support redirects without mod_rewrite
+				$vhost_content .= '  Redirect ' . $code . ' / ' . $this->idnaConvert->encode($domain['documentroot']) . "\n";
+			}
 
 		} else {
 


### PR DESCRIPTION
A redirect to foreign Domains or (not yet signed) https prevents letsencrypt-verification. So we should exclude .well-known/acme-challenge from redirects.