### PR TITLE
do not die after token self check

### DIFF
--- a/lib/classes/ssl/class.lescript.php
+++ b/lib/classes/ssl/class.lescript.php
@@ -189,7 +189,7 @@ class lescript
 					$errmsg = "";
 				}
 				@unlink($tokenPath);
-				throw new \RuntimeException("Please check $uri - token not available" . $errmsg);
+				$cronlog->logAction(CRON_ACTION, LOG_ERR,"letsencrypt Please check $uri - token not available" . $errmsg);
 			}
 
 			$this->log("Sending request to challenge");


### PR DESCRIPTION
We have to finish the challenge request so that the auth does not linger in state "pending", but goes to "invalid". See https://forum.froxlor.org/index.php/topic/13463-lets-encrypt-zertifikate-werden-nicht-erneuert/#entry32895