### PR TITLE
Make path to acme.conf configurable

### DIFF
--- a/actions/admin/settings/131.ssl.php
+++ b/actions/admin/settings/131.ssl.php
@@ -105,6 +105,15 @@ return array(
 								'default' => false,
 								'save_method' => 'storeSettingField'
 							),
+							'system_letsencryptacmeconf' => array(
+									'label' => $lng['serversettings']['letsencryptacmeconf'],
+									'settinggroup' => 'system',
+									'varname' => 'letsencryptacmeconf',
+									'type' => 'string',
+									'string_emptyallowed' => false,
+									'default' => '/etc/acme.conf',
+									'save_method' => 'storeSettingField',
+							),
 							'system_letsencryptca' => array(
 									'label' => $lng['serversettings']['letsencryptca'],
 									'settinggroup' => 'system',

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1952,6 +1952,8 @@ $lng['serversettings']['letsencryptkeysize']['title'] = "Key size for new Let's 
 $lng['serversettings']['letsencryptkeysize']['description'] = "Size of the key in Bits for new Let's Encrypt certificates.<br><strong class=\"red\">ATTENTION:</strong> Let's Encrypt is still in beta</strong>";
 $lng['serversettings']['letsencryptreuseold']['title'] = "Re-use Let's Encrypt key";
 $lng['serversettings']['letsencryptreuseold']['description'] = "If activated, the same key will be used for every renew, otherwise a new key will be generated every time.<br><strong class=\"red\">ATTENTION:</strong> Let's Encrypt is still in beta</strong>";
+$lng['serversettings']['letsencryptacmeconf']['title'] = "Path to the acme.conf snippet";
+$lng['serversettings']['letsencryptacmeconf']['description'] = "File name of the config snippet which allows the web server to serve the acme challenge.<br><strong class=\"red\">ATTENTION:</strong> Let's Encrypt is still in beta.";
 $lng['serversettings']['leenabled']['title'] = "Enable Let's Encrypt";
 $lng['serversettings']['leenabled']['description'] = "If activated, customers are able to let froxlor automatically generate and renew Let's Encrypt ssl-certificates for domains with a ssl IP/port.<br /><br />Please remember that you need to go through the webserver-configuration when eabled because this feature needs a special configuration.";
 $lng['domains']['ssl_redirect_temporarilydisabled'] = "<br>The SSL redirect is temporarily deactivated while a new Let's Encrypt certificate is generated. It will be activated again after the certificate was generated.";

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1606,6 +1606,8 @@ $lng['serversettings']['letsencryptkeysize']['title'] = "Schlüsselgröße für 
 $lng['serversettings']['letsencryptkeysize']['description'] = "Größe des Schlüssels in Bit für neue Let's Encrypt Zertifikate.<br><strong class=\"red\">ACHTUNG:</strong> Let's Encrypt befindet sich noch im Test";
 $lng['serversettings']['letsencryptreuseold']['title'] = "Let's Encrypt Schlüssel wiederverwenden";
 $lng['serversettings']['letsencryptreuseold']['description'] = "Wenn dies aktiviert ist, wird der alte Schlüssel bei jeder Verlängerung verwendet, andernfalls wird ein neues Paar generiert.<br><strong class=\"red\">ACHTUNG:</strong> Let's Encrypt befindet sich noch im Test";
+$lng['serversettings']['letsencryptacmeconf']['title'] = "Pfad zu acme.conf";
+$lng['serversettings']['letsencryptacmeconf']['description'] = "Dateiname der Konfiguration, die dem Webserver erlaubt, die ACME-Challenges zu bedienen.<br><strong class=\"red\">ACHTUNG:</strong> Let's Encrypt befindet sich noch im Test.";
 $lng['serversettings']['leenabled']['title'] = "Let's Encrypt verwenden";
 $lng['serversettings']['leenabled']['description'] = "Wenn dies aktiviert ist, können Kunden durch Froxlor automatisch generierte und verlängerbare Let's Encrypt SSL-Zertifikate für Domains mit SSL IP/port nutzen.<br /><br />Bitte die Webserver-Konfiguration beachten wenn aktiviert, da dieses Feature eine spezielle Konfiguration benötigt.";
 $lng['domains']['ssl_redirect_temporarilydisabled'] = "<br>Die SSL-Umleitung ist, während ein neues Let's Encrypt - Zertifikat erstellt wird, temporär deaktiviert. Die Umleitung wird nach der Zertifikatserstellung wieder aktiviert.";

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -457,7 +457,8 @@ class nginx extends HttpConfigBase {
 
 		if (Settings::Get('system.use_ssl') == '1' && Settings::Get('system.leenabled') == '1')
 		{
-			$vhost_content.= "\t".'include /etc/nginx/acme.conf;'."\n";
+			$acmeConfFilename = Settings::Get('system.letsencryptacmeconf');
+			$vhost_content.= "\t".'include "' . $acmeConfFilename . '";'."\n";
 		}
 
 		// if the documentroot is an URL we just redirect


### PR DESCRIPTION
When using FreeBSD -- as I do --, trees /usr and /etc are for the "base system", and additionally installed software goes into /usr/local/. A suiting path for the acme.conf file therefore is /usr/local/etc/nginx/acme.conf (and not /etc/nginx/acme.conf). In order to make this possible, make the path to this acme.conf file configurable in Settings/SSL Settings.

As a workaround, I have used a symlink up to now.

I suspect the (/usr/local/) /etc/nginx/acme.conf file is only used whit nginx as the web server; as far as I have been able to see, these configuration settings are stored differently when using Apache for instance.

Also, an update script is missing from this pull request because I have no idea how and if at all I should add one. A new configuration entry "system.letsencryptacmeconf" would have to be entered into panel_settings.