### PR TITLE
fix "undefined index" warnings

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -369,6 +369,7 @@ class apache extends HttpConfigBase {
 						'adminid' => 1, /* first admin-user (superadmin) */
 						'loginname' => 'froxlor.panel',
 						'documentroot' => $mypath,
+						'parentdomainid' => 0,
 					);
 
 					// override corresponding array values

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -174,7 +174,8 @@ class lighttpd extends HttpConfigBase
 					'domain' => Settings::Get('system.hostname'),
 					'adminid' => 1, /* first admin-user (superadmin) */
 					'loginname' => 'froxlor.panel',
-					'documentroot' => $mypath
+					'documentroot' => $mypath,
+					'parentdomainid' => 0,
 				);
 
 				// override corresponding array values

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -156,7 +156,8 @@ class nginx extends HttpConfigBase {
 						'domain' => Settings::Get('system.hostname'),
 						'adminid' => 1, /* first admin-user (superadmin) */
 						'loginname' => 'froxlor.panel',
-						'documentroot' => $mypath
+						'documentroot' => $mypath,
+						'parentdomainid' => 0,
 					);
 
 					// override corresponding array values


### PR DESCRIPTION
PHP Notice:  Undefined index: parentdomainid in
[…]/froxlor/lib/classes/webserver/class.DomainSSL.php on line 49