### PR TITLE
display system hostname and some memory info on dashboard

### DIFF
--- a/admin_index.php
+++ b/admin_index.php
@@ -144,6 +144,15 @@ if ($page == 'overview') {
 	$cron_last_runs = getCronjobsLastRun();
 	$outstanding_tasks = getOutstandingTasks();
 
+	$system_hostname = gethostname();
+	$meminfo= explode("\n", @file_get_contents("/proc/meminfo"));
+	$memory = "";
+	for ($i = 0; $i < sizeof($meminfo); ++$i) {
+		if (substr($meminfo[$i], 0, 3) === "Mem") {
+			$memory.= $meminfo[$i] . PHP_EOL;
+		}
+	}
+
 	if (function_exists('sys_getloadavg')) {
 		$loadArray = sys_getloadavg();
 		$load = number_format($loadArray[0], 2, '.', '') . " / " . number_format($loadArray[1], 2, '.', '') . " / " . number_format($loadArray[2], 2, '.', '');

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2041,3 +2041,7 @@ $lng['serversettings']['option_unavailable_websrv'] = '<br><em class="red">Avail
 $lng['serversettings']['option_unavailable'] = '<br><em class="red">Option not availble due to other settings.</em>';
 $lng['serversettings']['letsencryptacmeconf']['title'] = "Path to the acme.conf snippet";
 $lng['serversettings']['letsencryptacmeconf']['description'] = "File name of the config snippet which allows the web server to serve the acme challenge.";
+
+// Added in froxlor 0.9.38
+$lng['admin']['hostname'] = 'Hostname';
+$lng['admin']['memory'] = 'Memory usage';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1693,3 +1693,7 @@ $lng['serversettings']['option_unavailable_websrv'] = '<br><em class="red">Nur v
 $lng['serversettings']['option_unavailable'] = '<br><em class="red">Option aufgrund anderer Einstellungen nicht verfügbar.</em>';
 $lng['serversettings']['letsencryptacmeconf']['title'] = "Pfad zu acme.conf";
 $lng['serversettings']['letsencryptacmeconf']['description'] = "Dateiname der Konfiguration, die dem Webserver erlaubt, die ACME-Challenges zu bedienen.";
+
+// Added in froxlor 0.9.38
+$lng['admin']['hostname'] = 'Hostname';
+$lng['admin']['memory'] = 'Speicherauslastung';

--- a/templates/Sparkle/admin/index/index.tpl
+++ b/templates/Sparkle/admin/index/index.tpl
@@ -212,6 +212,10 @@ $header
 					</thead>
 					<tbody>
 						<tr>
+							<td>{$lng['admin']['hostname']}:</td>
+							<td>{$system_hostname}</td>
+						</tr>
+						<tr>
 							<td>{$lng['admin']['serversoftware']}:</td>
 							<td>{$_SERVER['SERVER_SOFTWARE']}</td>
 						</tr>
@@ -226,6 +230,10 @@ $header
 						<tr>
 							<td>{$lng['admin']['webserverinterface']}:</td>
 							<td>$webserverinterface</td>
+						</tr>
+						<tr>
+							<td>{$lng['admin']['memory']}:</td>
+							<td><pre>$memory</pre></td>
 						</tr>
 						<tr>
 							<td>{$lng['admin']['sysload']}:</td>


### PR DESCRIPTION
hostname may be useful in situations where several froxlors are
reverse-proxied on a single webserver