### PR TITLE
fix group by clause to be be compliant with mysql 5.7

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -393,6 +393,9 @@ if ($page == 'domains' || $page == 'overview') {
 					'0',
 					''
 				));
+				if ($registration_date == '0000-00-00') {
+					$registration_date = null;
+				}
 
 				$termination_date = trim($_POST['termination_date']);
 				$termination_date = validate($termination_date, 'termination_date', '/^(19|20)\d\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$/', '', array(
@@ -400,6 +403,9 @@ if ($page == 'domains' || $page == 'overview') {
 					'0',
 					''
 				));
+				if ($termination_date == '0000-00-00') {
+					$termination_date = null;
+				}
 
 				if ($userinfo['change_serversettings'] == '1') {
 
@@ -1206,12 +1212,18 @@ if ($page == 'domains' || $page == 'overview') {
 					'0',
 					''
 				));
+				if ($registration_date == '0000-00-00') {
+					$registration_date = null;
+				}
 				$termination_date = trim($_POST['termination_date']);
 				$termination_date = validate($termination_date, 'termination_date', '/^(19|20)\d\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01])$/', '', array(
 					'0000-00-00',
 					'0',
 					''
 				));
+				if ($termination_date == '0000-00-00') {
+					$termination_date = null;
+				}
 
 				$isemaildomain = 0;
 				if (isset($_POST['isemaildomain'])) {

--- a/customer_domains.php
+++ b/customer_domains.php
@@ -730,7 +730,7 @@ if ($page == 'overview') {
 					AND `dip`.`id_ipandports`
 					IN (SELECT `id_ipandports` FROM `".TABLE_DOMAINTOIP."`
 						WHERE `id_domain` = :id)
-					GROUP BY `d`.`domain`
+					GROUP BY `d`.`id`, `d`.`domain`
 					ORDER BY `d`.`domain` ASC"
 				);
 				Database::pexecute($domains_stmt, array("id" => $result['id'], "customerid" => $userinfo['customerid']));

--- a/customer_traffic.php
+++ b/customer_traffic.php
@@ -115,8 +115,7 @@ if (!is_null($month) && !is_null($year)) {
 	$result_stmt = Database::prepare("SELECT `month`, `year`, SUM(`http`) AS http, SUM(`ftp_up`) AS ftp_up, SUM(`ftp_down`) AS ftp_down, SUM(`mail`) AS mail
 		FROM `" . TABLE_PANEL_TRAFFIC . "`
 		WHERE `customerid` = :customerid
-		GROUP BY CONCAT(`year`,`month`)
-		ORDER BY CONCAT(`year`,`month`) DESC
+		GROUP BY `year` DESC, `month` DESC
 		LIMIT 12"
 	);
 	Database::pexecute($result_stmt, array("customerid" => $userinfo['customerid']));

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -66,7 +66,7 @@ CREATE TABLE `mail_virtual` (
   `id` int(11) NOT NULL auto_increment,
   `email` varchar(255) NOT NULL default '',
   `email_full` varchar(255) NOT NULL default '',
-  `destination` text NOT NULL,
+  `destination` text NOT NULL default '',
   `domainid` int(11) NOT NULL default '0',
   `customerid` int(11) NOT NULL default '0',
   `popaccountid` int(11) NOT NULL default '0',
@@ -245,8 +245,8 @@ CREATE TABLE `panel_domains` (
   `deactivated` tinyint(1) NOT NULL default '0',
   `bindserial` varchar(10) NOT NULL default '2000010100',
   `add_date` int( 11 ) NOT NULL default '0',
-  `registration_date` date NOT NULL,
-  `termination_date` date NOT NULL,
+  `registration_date` date DEFAULT NULL,
+  `termination_date` date DEFAULT NULL,
   `phpsettingid` INT( 11 ) UNSIGNED NOT NULL DEFAULT '1',
   `mod_fcgid_starter` int(4) default '-1',
   `mod_fcgid_maxrequests` int(4) default '-1',
@@ -573,7 +573,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('panel', 'password_special_char_required', '0'),
 	('panel', 'password_special_char', '!?<>§$%+#=@'),
 	('panel', 'version', '0.9.37'),
-	('panel', 'db_version', '201609200');
+	('panel', 'db_version', '201609240');
 
 
 DROP TABLE IF EXISTS `panel_tasks`;

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3475,3 +3475,14 @@ if (isDatabaseVersion('201609120')) {
 
 	updateToDbVersion('201609200');
 }
+
+if (isDatabaseVersion('201609200')) {
+
+    showUpdateStep("Changing tables to be more mysql strict-mode compatible");
+    Database::query("ALTER TABLE `".TABLE_MAIL_VIRTUAL."` CHANGE `destination` `destination` TEXT NOT NULL DEFAULT '';");
+    Database::query("ALTER TABLE `".TABLE_PANEL_DOMAINS."` CHANGE `registration_date` `registration_date` DATE NULL DEFAULT NULL;");
+    Database::query("ALTER TABLE `".TABLE_PANEL_DOMAINS."` CHANGE `termination_date` `termination_date` DATE NULL DEFAULT NULL;");
+    lastStepStatus(0);
+
+    updateToDbVersion('201609240');
+}

--- a/lib/version.inc.php
+++ b/lib/version.inc.php
@@ -19,7 +19,7 @@
 $version = '0.9.37';
 
 // Database version (YYYYMMDDC where C is a daily counter)
-$dbversion = '201609200';
+$dbversion = '201609240';
 
 // Distribution branding-tag (used for Debian etc.)
 $branding = '';


### PR DESCRIPTION
In mysql 5.7 only_full_group_by is enabled by default.