### PR TITLE
Enable Plaintext Authentification

### DIFF
--- a/lib/configfiles/jessie.xml
+++ b/lib/configfiles/jessie.xml
@@ -2731,7 +2731,7 @@ password_query = SELECT username AS user, password_enc AS password, CONCAT(homed
 # matches the local IP (ie. you're connecting from the same computer), the
 # connection is considered secure and plaintext authentication is allowed.
 # See also ssl=required setting.
-#disable_plaintext_auth = yes
+disable_plaintext_auth = no
 
 # Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
 # bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.

--- a/lib/configfiles/precise.xml
+++ b/lib/configfiles/precise.xml
@@ -886,7 +886,7 @@ service auth {
 # SSL/TLS is used (LOGINDISABLED capability). Note that if the remote IP
 # matches the local IP (ie. you're connecting from the same computer), the
 # connection is considered secure and plaintext authentication is allowed.
-#disable_plaintext_auth = yes
+disable_plaintext_auth = no
 
 # Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
 # bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -907,7 +907,7 @@ service auth {
 # SSL/TLS is used (LOGINDISABLED capability). Note that if the remote IP
 # matches the local IP (ie. you're connecting from the same computer), the
 # connection is considered secure and plaintext authentication is allowed.
-#disable_plaintext_auth = yes
+disable_plaintext_auth = no
 
 # Authentication cache size (e.g. 10M). 0 means it's disabled. Note that
 # bsdauth, PAM and vpopmail require cache_key to be set for caching to be used.


### PR DESCRIPTION
Sice we have no other authentification method enabled, or SSL setup, we can´t connect to the MDA without enabling plaintext authentification.
