### PR TITLE
Option to add a prefix to systems users/groups needed for fcgid+suexec

### DIFF
--- a/actions/admin/settings/135.fcgid.php
+++ b/actions/admin/settings/135.fcgid.php
@@ -105,6 +105,14 @@ return array(
 					'default' => 30,
 					'save_method' => 'storeSettingField'
 					),
+				'system_mod_fcgid_system_prefix' => array(
+					'label' => $lng['serversettings']['mod_fcgid']['username_prefix'],
+					'settinggroup' => 'system',
+					'varname' => 'mod_fcgid_system_prefix',
+					'type' => 'string',
+					'default' => '',
+					'save_method' => 'storeSettingField'
+					),
 				)
 			)
 		)

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -450,6 +450,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('system', 'last_archive_run', '000000'),
 	('system', 'mod_fcgid_configdir', '/var/www/php-fcgi-scripts'),
 	('system', 'mod_fcgid_tmpdir', '/var/customers/tmp'),
+	('system', 'mod_fcgid_system_prefix', ''),
 	('system', 'ssl_cert_file', '/etc/apache2/apache2.pem'),
 	('system', 'use_ssl', '0'),
 	('system', 'default_vhostconf', ''),

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3502,6 +3502,14 @@ if (isDatabaseVersion('201609240')) {
 	updateToDbVersion('201610070');
 }
 
+if (isDatabaseVersion('201610070')) {
+	showUpdateStep("Add fcgid special system prefix option for vhosts");
+	Settings::AddNew("system.mod_fcgid_system_prefix", "");
+	lastStepStatus(0);
+
+	updateToDbVersion('201611060');
+}
+
 if (isFroxlorVersion('0.9.37')) {
 
 	showUpdateStep("Updating from 0.9.37 to 0.9.38-rc1", false);

--- a/lib/configfiles/gentoo.xml
+++ b/lib/configfiles/gentoo.xml
@@ -3702,37 +3702,37 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 					<file name="/etc/libnss-mysql.cfg" chown="root:root" chmod="0600"
 						backup="true">
 						<content><![CDATA[
-getpwnam    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwuid    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwuid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
             WHERE uid='%1$u' \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getspnam    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwent    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users
-getspent    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users
-getgrnam    SELECT groupname,'x',gid \
+getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname='%1$s' \
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
             LIMIT 1
-getgrgid    SELECT groupname,'x',gid \
+getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
             WHERE gid='%1$u' \
             LIMIT 1
-getgrent    SELECT groupname,'x',gid \
+getgrent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups
 memsbygid   SELECT members \
             FROM ftp_groups \

--- a/lib/configfiles/gentoo.xml
+++ b/lib/configfiles/gentoo.xml
@@ -3726,7 +3726,7 @@ getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup =
             FROM ftp_users
 getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             LIMIT 1
 getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \

--- a/lib/configfiles/jessie.xml
+++ b/lib/configfiles/jessie.xml
@@ -4474,37 +4474,37 @@ rm libnss-mysql-bg_1.5-4_`dpkg --print-architecture`.deb
 					<file name="/etc/libnss-mysql.cfg" chown="root:root" chmod="0600"
 						backup="true">
 						<content><![CDATA[
-getpwnam    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwuid    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwuid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
             WHERE uid='%1$u' \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getspnam    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwent    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users
-getspent    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users
-getgrnam    SELECT groupname,'x',gid \
+getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname='%1$s' \
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
             LIMIT 1
-getgrgid    SELECT groupname,'x',gid \
+getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
             WHERE gid='%1$u' \
             LIMIT 1
-getgrent    SELECT groupname,'x',gid \
+getgrent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups
 memsbygid   SELECT members \
             FROM ftp_groups \

--- a/lib/configfiles/jessie.xml
+++ b/lib/configfiles/jessie.xml
@@ -4498,7 +4498,7 @@ getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup =
             FROM ftp_users
 getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             LIMIT 1
 getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \

--- a/lib/configfiles/precise.xml
+++ b/lib/configfiles/precise.xml
@@ -1542,37 +1542,37 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 					<file name="/etc/libnss-mysql.cfg" chown="root:root" chmod="0600"
 						backup="true">
 						<content><![CDATA[
-getpwnam    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwuid    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwuid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
             WHERE uid='%1$u' \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getspnam    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwent    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users
-getspent    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users
-getgrnam    SELECT groupname,'x',gid \
+getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname='%1$s' \
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
             LIMIT 1
-getgrgid    SELECT groupname,'x',gid \
+getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
             WHERE gid='%1$u' \
             LIMIT 1
-getgrent    SELECT groupname,'x',gid \
+getgrent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups
 memsbygid   SELECT members \
             FROM ftp_groups \

--- a/lib/configfiles/precise.xml
+++ b/lib/configfiles/precise.xml
@@ -1566,7 +1566,7 @@ getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup =
             FROM ftp_users
 getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             LIMIT 1
 getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \

--- a/lib/configfiles/rhel_centos.xml
+++ b/lib/configfiles/rhel_centos.xml
@@ -2315,37 +2315,37 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 					<file name="/etc/libnss-mysql.cfg" chown="root:root" chmod="0600"
 						backup="true">
 						<content><![CDATA[
-getpwnam    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwuid    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwuid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
             WHERE uid='%1$u' \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getspnam    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwent    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users
-getspent    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users
-getgrnam    SELECT groupname,'x',gid \
+getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname='%1$s' \
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
             LIMIT 1
-getgrgid    SELECT groupname,'x',gid \
+getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
             WHERE gid='%1$u' \
             LIMIT 1
-getgrent    SELECT groupname,'x',gid \
+getgrent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups
 memsbygid   SELECT members \
             FROM ftp_groups \

--- a/lib/configfiles/rhel_centos.xml
+++ b/lib/configfiles/rhel_centos.xml
@@ -2339,7 +2339,7 @@ getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup =
             FROM ftp_users
 getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             LIMIT 1
 getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -1574,7 +1574,7 @@ getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup =
             FROM ftp_users
 getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             LIMIT 1
 getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \

--- a/lib/configfiles/trusty.xml
+++ b/lib/configfiles/trusty.xml
@@ -1550,37 +1550,37 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 					<file name="/etc/libnss-mysql.cfg" chown="root:root" chmod="0600"
 						backup="true">
 						<content><![CDATA[
-getpwnam    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwuid    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwuid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
             WHERE uid='%1$u' \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getspnam    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwent    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users
-getspent    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users
-getgrnam    SELECT groupname,'x',gid \
+getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname='%1$s' \
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
             LIMIT 1
-getgrgid    SELECT groupname,'x',gid \
+getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
             WHERE gid='%1$u' \
             LIMIT 1
-getgrent    SELECT groupname,'x',gid \
+getgrent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups
 memsbygid   SELECT members \
             FROM ftp_groups \

--- a/lib/configfiles/wheezy.xml
+++ b/lib/configfiles/wheezy.xml
@@ -5372,7 +5372,7 @@ getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup =
             FROM ftp_users
 getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             LIMIT 1
 getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \

--- a/lib/configfiles/wheezy.xml
+++ b/lib/configfiles/wheezy.xml
@@ -5348,37 +5348,37 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 					<file name="/etc/libnss-mysql.cfg" chown="root:root" chmod="0600"
 						backup="true">
 						<content><![CDATA[
-getpwnam    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwuid    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwuid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users \
             WHERE uid='%1$u' \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getspnam    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users \
-            WHERE username='%1$s' \
+            WHERE username=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1))) \
             AND login_enabled = 'Y' \
             ORDER BY LENGTH(username) \
             LIMIT 1
-getpwent    SELECT username,'x',uid,gid,'Froxlor Customer',homedir,shell \
+getpwent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),'x',uid,gid,'Froxlor Customer',homedir,shell \
             FROM ftp_users
-getspent    SELECT username,password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
+getspent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), username),password,FLOOR(UNIX_TIMESTAMP()/86400-1),'1','99999','7','-1','-1','0' \
             FROM ftp_users
-getgrnam    SELECT groupname,'x',gid \
+getgrnam    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
-            WHERE groupname='%1$s' \
+            WHERE groupname=substring('%1$s', 1+CHARACTER_LENGTH((SELECT value FROM panel_settings WHERE settinggroup = 'system' AND varname = 'mod_fcgid_system_prefix' LIMIT 1)))
             LIMIT 1
-getgrgid    SELECT groupname,'x',gid \
+getgrgid    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups \
             WHERE gid='%1$u' \
             LIMIT 1
-getgrent    SELECT groupname,'x',gid \
+getgrent    SELECT CONCAT((SELECT value FROM panel_settings WHERE settinggroup = 'system' and varname = 'mod_fcgid_system_prefix' LIMIT 1), groupname),'x',gid \
             FROM ftp_groups
 memsbygid   SELECT members \
             FROM ftp_groups \

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2062,6 +2062,7 @@ $lng['admin']['domain_hsts_incsub']['title'] = 'Include HSTS for any subdomain';
 $lng['admin']['domain_hsts_incsub']['description'] = 'The optional "includeSubDomains" directive, if present, signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host\'s domain name.';
 $lng['admin']['domain_hsts_preload']['title'] = 'Include domain in <a href="https://hstspreload.appspot.com/" target="_blank">HSTS preload list</a>';
 $lng['admin']['domain_hsts_preload']['description'] = 'If you would like this domain to be included in the HSTS preload list maintained by Chrome (and used by Firefox and Safari), then use activate this.<br>Sending the preload directive from your site can have PERMANENT CONSEQUENCES and prevent users from accessing your site and any of its subdomains.<br>Please read the details at <a href="hstspreload.appspot.com/#removal" target="_blank">hstspreload.appspot.com/#removal</a> before sending the header with "preload".';
-
 $lng['serversettings']['nginx_http2_support']['title'] = 'Nginx HTTP2 Support';
 $lng['serversettings']['nginx_http2_support']['description'] = 'enable http2 support for ssl. ENABLE ONLY IF YOUR Nginx SUPPORT THIS FEATURE. (version 1.9.5+)';
+$lng['serversettings']['mod_fcgid']['username_prefix']['title'] = 'Prefix added to the username';
+$lng['serversettings']['mod_fcgid']['username_prefix']['description'] = 'This setting avoids username collisions.';

--- a/scripts/jobs/cron_tasks.inc.http.15.apache_fcgid.php
+++ b/scripts/jobs/cron_tasks.inc.http.15.apache_fcgid.php
@@ -37,7 +37,7 @@ class apache_fcgid extends apache
 				// #1317 - perl is executed via apache and therefore, when using fpm, does not know the user
 				// which perl is supposed to run as, hence the need for Suexec need
 				if (customerHasPerlEnabled($domain['customerid'])) {
-					$php_options_text.= '  SuexecUserGroup "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '" "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '"' . "\n";
+					$php_options_text.= '  SuexecUserGroup "' . Settings::Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '" "' . Settings::Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '"' . "\n";
 				}
 				
 				// mod_proxy stuff for apache-2.4
@@ -87,7 +87,7 @@ class apache_fcgid extends apache
 			else
 			{
 				$php_options_text.= '  FcgidIdleTimeout ' . Settings::Get('system.mod_fcgid_idle_timeout') . "\n";
-				$php_options_text.= '  SuexecUserGroup "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '" "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '"' . "\n";
+				$php_options_text.= '  SuexecUserGroup "' . Settings::Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '" "' . Settings::Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '"' . "\n";
 
 				if((int)Settings::Get('system.mod_fcgid_wrapper') == 0)
 				{

--- a/scripts/jobs/cron_tasks.inc.http.15.apache_fcgid.php
+++ b/scripts/jobs/cron_tasks.inc.http.15.apache_fcgid.php
@@ -37,7 +37,7 @@ class apache_fcgid extends apache
 				// #1317 - perl is executed via apache and therefore, when using fpm, does not know the user
 				// which perl is supposed to run as, hence the need for Suexec need
 				if (customerHasPerlEnabled($domain['customerid'])) {
-					$php_options_text.= '  SuexecUserGroup "' . $domain['loginname'] . '" "' . $domain['loginname'] . '"' . "\n";
+					$php_options_text.= '  SuexecUserGroup "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '" "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '"' . "\n";
 				}
 				
 				// mod_proxy stuff for apache-2.4
@@ -87,14 +87,15 @@ class apache_fcgid extends apache
 			else
 			{
 				$php_options_text.= '  FcgidIdleTimeout ' . Settings::Get('system.mod_fcgid_idle_timeout') . "\n";
+				$php_options_text.= '  SuexecUserGroup "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '" "' . Settings.Get('system.mod_fcgid_system_prefix') . $domain['loginname'] . '"' . "\n";
+
 				if((int)Settings::Get('system.mod_fcgid_wrapper') == 0)
 				{
-					$php_options_text.= '  SuexecUserGroup "' . $domain['loginname'] . '" "' . $domain['loginname'] . '"' . "\n";
+
 					$php_options_text.= '  ScriptAlias /php/ ' . $php->getInterface()->getConfigDir() . "\n";
 				}
 				else
 				{
-					$php_options_text.= '  SuexecUserGroup "' . $domain['loginname'] . '" "' . $domain['loginname'] . '"' . "\n";
 					$php_options_text.= '  <Directory "' . makeCorrectDir($domain['documentroot']) . '">' . "\n";
 					$file_extensions = explode(' ', $phpconfig['file_extensions']);
 					$php_options_text.= '    <FilesMatch "\.(' . implode('|', $file_extensions) . ')$">' . "\n";


### PR DESCRIPTION
Accidental username& group collisions of froxlor administered users and shell users can be avoided using this feature.

