### PR TITLE
Add support for http2 option to nginx

### DIFF
--- a/actions/admin/settings/130.webserver.php
+++ b/actions/admin/settings/130.webserver.php
@@ -179,6 +179,17 @@ return array(
 						'nginx'
 					)
 				),
+				'system_nginx_http2_support' => array(
+					'label' => $lng['serversettings']['nginx_http2_support'],
+					'settinggroup' => 'system',
+					'varname' => 'nginx_http2_support',
+					'type' => 'bool',
+					'default' => false,
+					'save_method' => 'storeSettingField',
+					'websrv_avail' => array(
+						'nginx'
+					)
+				),
 				'system_nginx_php_backend' => array(
 					'label' => $lng['serversettings']['nginx_php_backend'],
 					'settinggroup' => 'system',

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -496,6 +496,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('system', 'ssl_cert_chainfile', ''),
 	('system', 'ssl_cipher_list', 'ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128'),
 	('system', 'nginx_php_backend', '127.0.0.1:8888'),
+        ('system', 'nginx_http2_support', '0'),
 	('system', 'perl_server', 'unix:/var/run/nginx/cgiwrap-dispatch.sock'),
 	('system', 'phpreload_command', ''),
 	('system', 'apache24', '0'),

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3513,3 +3513,13 @@ if (isFroxlorVersion('0.9.38-rc1')) {
 	showUpdateStep("Updating from 0.9.38-rc1 to 0.9.38-rc2", false);
 	updateToVersion('0.9.38-rc2');
 }
+/*
+if (isDatabaseVersion('201610070')) {
+
+	showUpdateStep("Add Nginx http2 setting");
+    Settings::AddNew("system.nginx_http2_support", 0);
+    lastStepStatus(0);
+
+	updateToDbVersion('201610270');
+}
+ */

--- a/install/updates/froxlor/0.9/update_0.9.inc.php
+++ b/install/updates/froxlor/0.9/update_0.9.inc.php
@@ -3513,13 +3513,12 @@ if (isFroxlorVersion('0.9.38-rc1')) {
 	showUpdateStep("Updating from 0.9.38-rc1 to 0.9.38-rc2", false);
 	updateToVersion('0.9.38-rc2');
 }
-/*
+
 if (isDatabaseVersion('201610070')) {
 
 	showUpdateStep("Add Nginx http2 setting");
     Settings::AddNew("system.nginx_http2_support", 0);
     lastStepStatus(0);
 
-	updateToDbVersion('201610270');
+	updateToDbVersion('201611180');
 }
- */

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2062,3 +2062,6 @@ $lng['admin']['domain_hsts_incsub']['title'] = 'Include HSTS for any subdomain';
 $lng['admin']['domain_hsts_incsub']['description'] = 'The optional "includeSubDomains" directive, if present, signals the UA that the HSTS Policy applies to this HSTS Host as well as any subdomains of the host\'s domain name.';
 $lng['admin']['domain_hsts_preload']['title'] = 'Include domain in <a href="https://hstspreload.appspot.com/" target="_blank">HSTS preload list</a>';
 $lng['admin']['domain_hsts_preload']['description'] = 'If you would like this domain to be included in the HSTS preload list maintained by Chrome (and used by Firefox and Safari), then use activate this.<br>Sending the preload directive from your site can have PERMANENT CONSEQUENCES and prevent users from accessing your site and any of its subdomains.<br>Please read the details at <a href="hstspreload.appspot.com/#removal" target="_blank">hstspreload.appspot.com/#removal</a> before sending the header with "preload".';
+
+$lng['serversettings']['nginx_http2_support']['title'] = 'Nginx HTTP2 Support';
+$lng['serversettings']['nginx_http2_support']['description'] = 'enable http2 support for ssl. ENABLE ONLY IF YOUR Nginx SUPPORT THIS FEATURE. (version 1.9.5+)';

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -196,10 +196,12 @@ class nginx extends HttpConfigBase
 					}
 				}
 
+                $http2 = $ssl_vhost == true && Settings::Get('system.nginx_http2_support') == '1';
+                
 				/**
 				 * this HAS to be set for the default host in nginx or else no vhost will work
 				 */
-				$this->nginx_data[$vhost_filename] .= "\t" . 'listen    ' . $ip . ':' . $port . ' default_server' . ($ssl_vhost == true ? ' ssl' : '') . ';' . "\n";
+                $this->nginx_data[$vhost_filename] .= "\t" . 'listen    ' . $ip . ':' . $port . ' default_server' . ($ssl_vhost == true ? ' ssl' : '') . ($http2 == true ? ' http2' : '') . ';' . "\n";
 
 				$this->nginx_data[$vhost_filename] .= "\t" . '# Froxlor default vhost' . "\n";
 				$this->nginx_data[$vhost_filename] .= "\t" . 'server_name    ' . Settings::Get('system.hostname') . ';' . "\n";
@@ -411,7 +413,9 @@ class nginx extends HttpConfigBase
 				$_vhost_content .= $this->processSpecialConfigTemplate($ipandport['default_vhostconf_domain'], $domain, $domain['ip'], $domain['port'], $ssl_vhost) . "\n";
 			}
 
-			$vhost_content .= "\t" . 'listen ' . $ipport . ($ssl_vhost == true ? ' ssl' : '') . ';' . "\n";
+            $http2 = $ssl_vhost == true && Settings::Get('system.nginx_http2_support') == '1';
+
+            $vhost_content .= "\t" . 'listen ' . $ipport . ($ssl_vhost == true ? ' ssl' : '') . ($http2 == true ? ' http2' : '') . ';' . "\n";
 		}
 
 		// get all server-names


### PR DESCRIPTION
I tested this modification and works great. 
I added the setting manually to my panel_settings table. I know nothing how to make the database update in update_0.9.inc.php file, so it commented out the code what I believe to correct.