### PR TITLE
Change redirect host from main domain name to requested domain name

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -808,7 +808,7 @@ class apache extends HttpConfigBase
 				$_sslport = ":" . $ssldestport['port'];
 			}
 
-			$domain['documentroot'] = 'https://' . $domain['domain'] . $_sslport . '/';
+			$domain['documentroot'] = 'https://%{HTTP_HOST}' . $_sslport . '/';
 		}
 
 		if ($ssl_vhost === true && $domain['ssl'] == '1' && Settings::Get('system.use_ssl') == '1') {

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -424,7 +424,7 @@ class lighttpd extends HttpConfigBase
 				$_sslport = ":" . $ssldestport['port'];
 			}
 
-			$domain['documentroot'] = 'https://' . $domain['domain'] . $_sslport . '/';
+			$domain['documentroot'] = 'https://%1' . $_sslport . '/';
 		}
 
 		// avoid using any whitespaces
@@ -435,11 +435,13 @@ class lighttpd extends HttpConfigBase
 
 			// Get domain's redirect code
 			$code = getDomainRedirectCode($domain['id'], '301');
-
-			$vhost_content .= '  url.redirect-code = ' . $code. "\n";
-			$vhost_content .= '  url.redirect = (' . "\n";
-			$vhost_content .= '     "^/(.*)$" => "' . $uri . '$1"' . "\n";
-			$vhost_content .= '  )' . "\n";
+            
+            $vhost_content .= '  $HTTP["host"] =~ "^(.*)$" {'. "\n";
+			$vhost_content .= '    url.redirect-code = ' . $code. "\n";
+			$vhost_content .= '    url.redirect = (' . "\n";
+			$vhost_content .= '       "^/(.*)$" => "' . $uri . '$1"' . "\n";
+			$vhost_content .= '    )' . "\n";
+			$vhost_content .= '  }' . "\n";
 		} else {
 
 			mkDirWithCorrectOwnership($domain['customerroot'], $domain['documentroot'], $domain['guid'], $domain['guid'], true, true);

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -435,13 +435,11 @@ class lighttpd extends HttpConfigBase
 
 			// Get domain's redirect code
 			$code = getDomainRedirectCode($domain['id'], '301');
-            
-            $vhost_content .= '  $HTTP["host"] =~ "^(.*)$" {'. "\n";
-			$vhost_content .= '    url.redirect-code = ' . $code. "\n";
-			$vhost_content .= '    url.redirect = (' . "\n";
-			$vhost_content .= '       "^/(.*)$" => "' . $uri . '$1"' . "\n";
-			$vhost_content .= '    )' . "\n";
-			$vhost_content .= '  }' . "\n";
+
+			$vhost_content .= '  url.redirect-code = ' . $code. "\n";
+			$vhost_content .= '  url.redirect = (' . "\n";
+			$vhost_content .= '     "^/(.*)$" => "' . $uri . '$1"' . "\n";
+			$vhost_content .= '  )' . "\n";
 		} else {
 
 			mkDirWithCorrectOwnership($domain['customerroot'], $domain['documentroot'], $domain['guid'], $domain['guid'], true, true);

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -447,7 +447,7 @@ class nginx extends HttpConfigBase
 				$_sslport = ":" . $ssldestport['port'];
 			}
 
-			$domain['documentroot'] = 'https://' . $domain['domain'] . $_sslport . '/';
+			$domain['documentroot'] = 'https://$host' . $_sslport . '/';
 		}
 
 		// avoid using any whitespaces


### PR DESCRIPTION
When you have enabled "SSL redirect" and have alias domain(s) always redirected to the main https domain: http://maindomain.com -> https://maindomain.com and http://aliasdomain.com -> https://maindomain.com

I think the required operation is to redirect to the requested domain: http://maindomain.com -> https://maindomain.com and http://aliasdomain.com -> https://aliasdomain.com

I tested with nginx, I edited an apache config file with the generated text, but I don't have lighthttpd.