### PR TITLE
Changed SOA refresh intervall to be within recommended values

### DIFF
--- a/lib/functions/dns/function.createDomainZone.php
+++ b/lib/functions/dns/function.createDomainZone.php
@@ -279,7 +279,7 @@ function createDomainZone($domain_id, $froxlorhostname = false, $isMainButSubTo 
 		$soa_content = $primary_ns . " " . escapeSoaAdminMail(Settings::Get('panel.adminmail')) . " ";
 		$soa_content .= $domain['bindserial'] . " ";
 		// TODO for now, dummy time-periods
-		$soa_content .= "1800 900 604800 1200";
+		$soa_content .= "3600 900 604800 1200";
 
 		$soa_record = new DnsEntry('@', 'SOA', $soa_content);
 		array_unshift($zonerecords, $soa_record);


### PR DESCRIPTION
See: https://www.denic.de/fileadmin/public/documentation/DENIC-23p.pdf

The recommended values according to DENIC are:
refresh: 3600 - 86400
retry: 900 - 28800
expire: 604800 - 3600000
negTTL: 180 - 86400