### PR TITLE
Fix website not loading in current Firefox ESR 45 and tweak webserver config file according to Mozillas recommendations

### DIFF
--- a/actions/admin/settings/131.ssl.php
+++ b/actions/admin/settings/131.ssl.php
@@ -36,7 +36,7 @@ return array(
 					'varname' => 'ssl_cipher_list',
 					'type' => 'string',
 					'string_emptyallowed' => false,
-					'default' => 'ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128',
+					'default' => 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256',
 					'save_method' => 'storeSettingField'
 				),
 				'system_ssl_cert_file' => array(

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -497,7 +497,7 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('system', 'mod_fcgid_defaultini_ownvhost', '2'),
 	('system', 'awstats_icons', '/usr/share/awstats/icon/'),
 	('system', 'ssl_cert_chainfile', ''),
-	('system', 'ssl_cipher_list', 'ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128'),
+	('system', 'ssl_cipher_list', 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'),
 	('system', 'nginx_php_backend', '127.0.0.1:8888'),
 	('system', 'nginx_http2_support', '0'),
 	('system', 'perl_server', 'unix:/var/run/nginx/cgiwrap-dispatch.sock'),

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -1735,7 +1735,7 @@ $lng['domains']['serveraliasoption_www'] = 'WWW (www.domain.tld)';
 $lng['domains']['serveraliasoption_none'] = 'No alias';
 $lng['error']['givendirnotallowed'] = 'The given directory in field %s is not allowed.';
 $lng['serversettings']['ssl']['ssl_cipher_list']['title'] = 'Configure the allowed SSL ciphers';
-$lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'This is a list of ciphers that you want (or don\'t want) to use when talking SSL. For a list of ciphers and how to include/exclude them, see sections "CIPHER LIST FORMAT" and "CIPHER STRINGS" on <a href="http://openssl.org/docs/apps/ciphers.html">the man-page for ciphers</a>.<br /><br /><b>Default value is:</b><pre>ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128</pre>';
+$lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'This is a list of ciphers that you want (or don\'t want) to use when talking SSL. For a list of ciphers and how to include/exclude them, see sections "CIPHER LIST FORMAT" and "CIPHER STRINGS" on <a href="http://openssl.org/docs/apps/ciphers.html">the man-page for ciphers</a>.<br /><br /><b>Default value is:</b><pre>ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256</pre>';
 
 // Added in Froxlor 0.9.31
 $lng['panel']['dashboard'] = 'Dashboard';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1460,7 +1460,7 @@ $lng['domains']['serveraliasoption_www'] = 'www (www.domain.tld)';
 $lng['domains']['serveraliasoption_none'] = 'Kein Alias';
 $lng['error']['givendirnotallowed'] = 'Das angegebene Verzeichnis im Feld %s ist nicht erlaubt.';
 $lng['serversettings']['ssl']['ssl_cipher_list']['title'] = 'Erlaubte SSL Ciphers festlegen';
-$lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'Dies ist eine Liste von Ciphers, die genutzt werden sollen (oder auch nicht genutzt werden sollen), wenn eine SSL Verbindung besteht. Eine Liste aller Ciphers und wie diese hinzugefügt/ausgeschlossen werden ist in den Abschnitten "CIPHER LIST FORMAT" und "CIPHER STRINGS" in <a href="http://openssl.org/docs/apps/ciphers.html">der man-page für Ciphers</a> zu finden.<br /><br /><b>Standard-Wert ist:</b><pre>ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128</pre>';
+$lng['serversettings']['ssl']['ssl_cipher_list']['description'] = 'Dies ist eine Liste von Ciphers, die genutzt werden sollen (oder auch nicht genutzt werden sollen), wenn eine SSL Verbindung besteht. Eine Liste aller Ciphers und wie diese hinzugefügt/ausgeschlossen werden ist in den Abschnitten "CIPHER LIST FORMAT" und "CIPHER STRINGS" in <a href="http://openssl.org/docs/apps/ciphers.html">der man-page für Ciphers</a> zu finden.<br /><br /><b>Standard-Wert ist:</b><pre>ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256</pre>';
 
 // Added in Froxlor 0.9.31
 $lng['panel']['dashboard'] = 'Dashboard';

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -419,7 +419,7 @@ class apache extends HttpConfigBase
 						if (! file_exists($domain['ssl_cert_file'])) {
 							$this->logger->logAction(CRON_ACTION, LOG_ERR, $ipport . ' :: certificate file "' . $domain['ssl_cert_file'] . '" does not exist! Cannot create ssl-directives');
 						} else {
-							// 
+
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLEngine On' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1' . "\n";
 							// this makes it more secure, thx to Marcel (08/2013), updated 12/2016

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -419,14 +419,21 @@ class apache extends HttpConfigBase
 						if (! file_exists($domain['ssl_cert_file'])) {
 							$this->logger->logAction(CRON_ACTION, LOG_ERR, $ipport . ' :: certificate file "' . $domain['ssl_cert_file'] . '" does not exist! Cannot create ssl-directives');
 						} else {
-
+							// 
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLEngine On' . "\n";
-							$this->virtualhosts_data[$vhosts_filename] .= ' SSLProtocol -ALL +TLSv1 +TLSv1.2' . "\n";
-							// this makes it more secure, thx to Marcel (08/2013)
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1' . "\n";
+							// this makes it more secure, thx to Marcel (08/2013), updated 12/2016
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLHonorCipherOrder On' . "\n";
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCompression Off' . "\n";
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLSessionTickets Off' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCipherSuite ' . Settings::Get('system.ssl_cipher_list') . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLVerifyDepth 10' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCertificateFile ' . makeCorrectFile($domain['ssl_cert_file']) . "\n";
+							// OCSP
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLUseStapling On' . "\n";
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingResponderTimeout 5' . "\n";
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingReturnResponderErrors Off' . "\n";
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingCache shmcb:/var/run/ocsp(128000)' . "\n";
 
 							if ($domain['ssl_key_file'] != '') {
 								// check for existence, #1485

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -429,11 +429,6 @@ class apache extends HttpConfigBase
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCipherSuite ' . Settings::Get('system.ssl_cipher_list') . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLVerifyDepth 10' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCertificateFile ' . makeCorrectFile($domain['ssl_cert_file']) . "\n";
-							// OCSP
-							$this->virtualhosts_data[$vhosts_filename] .= ' SSLUseStapling On' . "\n";
-							$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingResponderTimeout 5' . "\n";
-							$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingReturnResponderErrors Off' . "\n";
-							$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingCache shmcb:/var/run/ocsp(128000)' . "\n";
 
 							if ($domain['ssl_key_file'] != '') {
 								// check for existence, #1485

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -617,7 +617,7 @@ class nginx extends HttpConfigBase
 				$sslsettings .= "\t" . 'ssl_ecdh_curve secp384r1;' . "\n";
 				$sslsettings .= "\t" . 'ssl_prefer_server_ciphers on;' . "\n";
 				$sslsettings .= "\t" . 'ssl_certificate ' . makeCorrectFile($domain_or_ip['ssl_cert_file']) . ';' . "\n";
-				
+
 				if ($domain_or_ip['ssl_key_file'] != '') {
 					// check for existence, #1485
 					if (! file_exists($domain_or_ip['ssl_key_file'])) {

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -609,12 +609,15 @@ class nginx extends HttpConfigBase
 			} else {
 				// obsolete: ssl on now belongs to the listen block as 'ssl' at the end
 				// $sslsettings .= "\t" . 'ssl on;' . "\n";
-				$sslsettings .= "\t" . 'ssl_protocols TLSv1 TLSv1.2;' . "\n";
+				$sslsettings .= "\t" . 'ssl_session_timeout 1d;' . "\n";
+				$sslsettings .= "\t" . 'ssl_session_cache shared:SSL:50m;' . "\n";
+				$sslsettings .= "\t" . 'ssl_session_tickets off;' . "\n";
+				$sslsettings .= "\t" . 'ssl_protocols TLSv1.2;' . "\n";
 				$sslsettings .= "\t" . 'ssl_ciphers ' . Settings::Get('system.ssl_cipher_list') . ';' . "\n";
 				$sslsettings .= "\t" . 'ssl_ecdh_curve secp384r1;' . "\n";
 				$sslsettings .= "\t" . 'ssl_prefer_server_ciphers on;' . "\n";
 				$sslsettings .= "\t" . 'ssl_certificate ' . makeCorrectFile($domain_or_ip['ssl_cert_file']) . ';' . "\n";
-
+				
 				if ($domain_or_ip['ssl_key_file'] != '') {
 					// check for existence, #1485
 					if (! file_exists($domain_or_ip['ssl_key_file'])) {
@@ -623,6 +626,10 @@ class nginx extends HttpConfigBase
 						$sslsettings .= "\t" . 'ssl_certificate_key ' . makeCorrectFile($domain_or_ip['ssl_key_file']) . ';' . "\n";
 					}
 				}
+				
+				// OCSP
+				$sslsettings .= "\t" . 'ssl_stapling on;' . "\n";
+				$sslsettings .= "\t" . 'ssl_stapling_verify on;' . "\n";
 
 				if (isset($domain_or_ip['hsts']) && $domain_or_ip['hsts'] >= 0) {
 					$sslsettings .= 'add_header Strict-Transport-Security "max-age=' . $domain_or_ip['hsts'];

--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -626,10 +626,6 @@ class nginx extends HttpConfigBase
 						$sslsettings .= "\t" . 'ssl_certificate_key ' . makeCorrectFile($domain_or_ip['ssl_key_file']) . ';' . "\n";
 					}
 				}
-				
-				// OCSP
-				$sslsettings .= "\t" . 'ssl_stapling on;' . "\n";
-				$sslsettings .= "\t" . 'ssl_stapling_verify on;' . "\n";
 
 				if (isset($domain_or_ip['hsts']) && $domain_or_ip['hsts'] >= 0) {
 					$sslsettings .= 'add_header Strict-Transport-Security "max-age=' . $domain_or_ip['hsts'];


### PR DESCRIPTION
See: https://wiki.mozilla.org/Security/Server_Side_TLS

With the old cipher suite (ECDH+AESGCM:ECDH+AES256:!aNULL:!MD5:!DSS:!DH:!AES128), Firefox ESR 45 will stop loading the page and the window will stay blank (tested with nginx).
The config files for apache and nginx were updated as per Mozilla's recommendation, the lighttpd config is still good.
This will improve the SSLLabs score as well.