### PR TITLE
Disable SSLCompression (CRIME attack)

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -422,6 +422,8 @@ class apache extends HttpConfigBase
 
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLEngine On' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLProtocol -ALL +TLSv1 +TLSv1.2' . "\n";
+							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCompression Off' . "\n";
+
 							// this makes it more secure, thx to Marcel (08/2013)
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLHonorCipherOrder On' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCipherSuite ' . Settings::Get('system.ssl_cipher_list') . "\n";


### PR DESCRIPTION
Disable `SSLCompression` to mitigate CRIME attack.

Source:
https://raymii.org/s/tutorials/Strong_SSL_Security_On_Apache2.html#SSL_Compression_(CRIME_attack)