### PR TITLE
WIP: SSL OCSP Stapling

### DIFF
--- a/actions/admin/settings/131.ssl.php
+++ b/actions/admin/settings/131.ssl.php
@@ -153,6 +153,23 @@ return array(
 					'type' => 'bool',
 					'default' => false,
 					'save_method' => 'storeSettingField'
+				),
+				'system_ssl_use_stapling' => array(
+					'label' => $lng['serversettings']['ssl']['use_stapling'],
+					'settinggroup' => 'system',
+					'varname' => 'ssl_use_stapling',
+					'type' => 'bool',
+					'default' => true,
+					'save_method' => 'storeSettingField'
+				),
+				'system_ssl_stapling_cache' => array(
+					'label' => $lng['serversettings']['ssl']['stapling_cache'],
+					'settinggroup' => 'system',
+					'varname' => 'ssl_stapling_cache',
+					'type' => 'string',
+					'string_emptyallowed' => false,
+					'default' => '/var/run/ocsp',
+					'save_method' => 'storeSettingField'
 				)
 			)
 		)

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -470,6 +470,8 @@ INSERT INTO `panel_settings` (`settinggroup`, `varname`, `value`) VALUES
 	('system', 'mod_fcgid_maxrequests', '250'),
 	('system', 'ssl_key_file','/etc/apache2/apache2.key'),
 	('system', 'ssl_ca_file', ''),
+	('system', 'ssl_use_stapling', '0'),
+	('system', 'ssl_stapling_cache', '/var/run/ocsp'),
 	('system', 'debug_cron', '0'),
 	('system', 'store_index_file_subs', '1'),
 	('system', 'stdsubdomain', ''),

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2065,3 +2065,8 @@ $lng['admin']['domain_hsts_preload']['description'] = 'If you would like this do
 
 $lng['serversettings']['nginx_http2_support']['title'] = 'Nginx HTTP2 Support';
 $lng['serversettings']['nginx_http2_support']['description'] = 'enable http2 support for ssl. ENABLE ONLY IF YOUR Nginx SUPPORT THIS FEATURE. (version 1.9.5+)';
+
+$lng['serversettings']['ssl']['use_stapling']['title'] = 'Use OCSP stapling';
+$lng['serversettings']['ssl']['use_stapling']['description'] = 'Accelerates the client check for revoked server certificates.';
+$lng['serversettings']['ssl']['stapling_cache']['title'] = 'OCSP stapling cache';
+$lng['serversettings']['ssl']['stapling_cache']['description'] = 'Local path for server-side cache.';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1713,3 +1713,8 @@ $lng['admin']['domain_hsts_incsub']['title'] = 'Inkludiere HSTS für jede Subdom
 $lng['admin']['domain_hsts_incsub']['description'] = 'Die optionale "includeSubDomains" Direktive, wenn vorhanden, signalisiert dem UA, dass die HSTS Regel für diese Domain und auch jede Subdomain dieser gilt.';
 $lng['admin']['domain_hsts_preload']['title'] = 'Füge Domain in die <a href="https://hstspreload.appspot.com/" target="_blank">HSTS preload Liste</a> hinzu';
 $lng['admin']['domain_hsts_preload']['description'] = 'Wenn die Domain in die HSTS preload Liste, verwaltet von Chrome (und genutzt von Firefox und Safari), hinzugefügt werden soll, dann aktiviere diese Einstellung.<br>Die preload-Direktive zu senden kann PERMANTENTE KONSEQUENZEN haben und dazu führen, dass Benutzer auf diese Domain und auch Subdomains nicht zugreifen können.<br>Beachte Details unter <a href="https://hstspreload.appspot.com/#removal" target="_blank">hstspreload.appspot.com/#removal</a> bevor ein Header mit "preload" gesendet wird.';
+
+$lng['serversettings']['ssl']['use_stapling']['title'] = 'OCSP Stapling verwenden';
+$lng['serversettings']['ssl']['use_stapling']['description'] = 'Beschleunigt die Client-Prüfung auf zurückgezogene Zertifikate.';
+$lng['serversettings']['ssl']['stapling_cache']['title'] = 'OCSP Stapling Cache';
+$lng['serversettings']['ssl']['stapling_cache']['description'] = 'Lokaler Pfad für den serverseitigen Cache.';

--- a/scripts/jobs/cron_tasks.inc.http.10.apache.php
+++ b/scripts/jobs/cron_tasks.inc.http.10.apache.php
@@ -430,6 +430,14 @@ class apache extends HttpConfigBase
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLVerifyDepth 10' . "\n";
 							$this->virtualhosts_data[$vhosts_filename] .= ' SSLCertificateFile ' . makeCorrectFile($domain['ssl_cert_file']) . "\n";
 
+							# OCSP Stapling
+							if ((int) Settings::Get('system.ssl_use_stapling') === 1) {
+								$this->virtualhosts_data[$vhosts_filename] .= ' SSLUseStapling on' . "\n";
+								$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingResponderTimeout 5' . "\n";
+								$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingReturnResponderErrors Off' . "\n";
+								$this->virtualhosts_data[$vhosts_filename] .= ' SSLStaplingCache shmcb:' . Settings::Get('system.ssl_stapling_cache')  . '(128000)' . "\n";
+							}
+
 							if ($domain['ssl_key_file'] != '') {
 								// check for existence, #1485
 								if (! file_exists($domain['ssl_key_file'])) {


### PR DESCRIPTION
"Allow client software using SSL to communicate with the server to efficiently check that the server certificate has not been revoked."

Source:
https://wiki.apache.org/httpd/OCSPStapling

- [x] Configuration settings (defaults to off, because cache path may be system dependent)
- [x] Output in vhosts configuration
- [ ] Installation / update scripts
  - [x] Database fields for installation
  - [ ] Update script
- [ ] Translations
  - [ ] Dutch
  - [x] English
  - [ ] French   
  - [x] German
  - [ ] Italian
  - [ ] Portugues
  - [ ] Swedish