### PR TITLE
Internal IP and port

### DIFF
--- a/admin_ipsandports.php
+++ b/admin_ipsandports.php
@@ -149,6 +149,8 @@ if ($page == 'ipsandports'
 
 			$ip = validate_ip($_POST['ip']);
 			$port = validate($_POST['port'], 'port', '/^(([1-9])|([1-9][0-9])|([1-9][0-9][0-9])|([1-9][0-9][0-9][0-9])|([1-5][0-9][0-9][0-9][0-9])|(6[0-4][0-9][0-9][0-9])|(65[0-4][0-9][0-9])|(655[0-2][0-9])|(6553[0-5]))$/Di', array('stringisempty', 'myport'));
+			$internalip = validate_ip($_POST['internalip']);
+			$internalport = validate($_POST['internalport'], 'port', '/^(([1-9])|([1-9][0-9])|([1-9][0-9][0-9])|([1-9][0-9][0-9][0-9])|([1-5][0-9][0-9][0-9][0-9])|(6[0-4][0-9][0-9][0-9])|(65[0-4][0-9][0-9])|(655[0-2][0-9])|(6553[0-5]))$/Di', array('stringisempty', 'myport'));
 			$listen_statement = isset($_POST['listen_statement']) ? 1 : 0;
 			$namevirtualhost_statement = isset($_POST['namevirtualhost_statement']) ? 1 : 0;
 			$vhostcontainer = isset($_POST['vhostcontainer']) ? 1 : 0;
@@ -225,8 +227,9 @@ if ($page == 'ipsandports'
 				$ins_stmt = Database::prepare("
 					INSERT INTO `" . TABLE_PANEL_IPSANDPORTS . "`
 					SET
-						`ip` = :ip, `port` = :port, `listen_statement` = :ls,
-						`namevirtualhost_statement` = :nvhs, `vhostcontainer` = :vhc,
+						`ip` = :ip, `port` = :port, `internalip` = :internalip, 
+						`internalport` = :internalport,	`listen_statement` = :ls, 
+						`namevirtualhost_statement` = :nvhs, `vhostcontainer` = :vhc, 
 						`vhostcontainer_servername_statement` = :vhcss,
 						`specialsettings` = :ss, `ssl` = :ssl,
 						`ssl_cert_file` = :ssl_cert, `ssl_key_file` = :ssl_key,
@@ -236,6 +239,8 @@ if ($page == 'ipsandports'
 				$ins_data = array(
 					'ip' => $ip,
 					'port' => $port,
+					'internalip' => $internalip,
+					'internalport' => $internalport,
 					'ls' => $listen_statement,
 					'nvhs' => $namevirtualhost_statement,
 					'vhc' => $vhostcontainer,
@@ -289,6 +294,8 @@ if ($page == 'ipsandports'
 
 				$ip = validate_ip($_POST['ip']);
 				$port = validate($_POST['port'], 'port', '/^(([1-9])|([1-9][0-9])|([1-9][0-9][0-9])|([1-9][0-9][0-9][0-9])|([1-5][0-9][0-9][0-9][0-9])|(6[0-4][0-9][0-9][0-9])|(65[0-4][0-9][0-9])|(655[0-2][0-9])|(6553[0-5]))$/Di', array('stringisempty', 'myport'));
+				$internalip = validate_ip($_POST['internalip']);
+				$internalport = validate($_POST['internalport'], 'port', '/^(([1-9])|([1-9][0-9])|([1-9][0-9][0-9])|([1-9][0-9][0-9][0-9])|([1-5][0-9][0-9][0-9][0-9])|(6[0-4][0-9][0-9][0-9])|(65[0-4][0-9][0-9])|(655[0-2][0-9])|(6553[0-5]))$/Di', array('stringisempty', 'myport'));
 				$listen_statement = isset($_POST['listen_statement']) ? 1 : 0;
 				$namevirtualhost_statement = isset($_POST['namevirtualhost_statement']) ? 1 : 0;
 				$vhostcontainer = isset($_POST['vhostcontainer']) ? 1 : 0;
@@ -384,7 +391,8 @@ if ($page == 'ipsandports'
 					$upd_stmt = Database::prepare("
 						UPDATE `" . TABLE_PANEL_IPSANDPORTS . "`
 						SET
-							`ip` = :ip, `port` = :port, `listen_statement` = :ls,
+							`ip` = :ip, `port` = :port, `internalip` = :internalip, 
+							`internalport` = :internalport,	`listen_statement` = :ls, 
 							`namevirtualhost_statement` = :nvhs, `vhostcontainer` = :vhc,
 							`vhostcontainer_servername_statement` = :vhcss,
 							`specialsettings` = :ss, `ssl` = :ssl,
@@ -396,6 +404,8 @@ if ($page == 'ipsandports'
 					$upd_data = array(
 						'ip' => $ip,
 						'port' => $port,
+						'internalip' => $internalip,
+						'internalport' => $internalport,
 						'ls' => $listen_statement,
 						'nvhs' => $namevirtualhost_statement,
 						'vhc' => $vhostcontainer,

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -270,6 +270,8 @@ CREATE TABLE `panel_ipsandports` (
   `id` int(11) unsigned NOT NULL auto_increment,
   `ip` varchar(39) NOT NULL default '',
   `port` int(5) NOT NULL default '80',
+  `internalip` varchar(39) NOT NULL default '',
+  `internalport` int(5) NOT NULL default '0',
   `listen_statement` tinyint(1) NOT NULL default '0',
   `namevirtualhost_statement` tinyint(1) NOT NULL default '0',
   `vhostcontainer` tinyint(1) NOT NULL default '0',

--- a/lib/formfields/admin/ipsandports/formfield.ipsandports_add.php
+++ b/lib/formfields/admin/ipsandports/formfield.ipsandports_add.php
@@ -32,6 +32,17 @@ return array(
 						'label' => $lng['admin']['ipsandports']['port'],
 						'type' => 'text',
 						'size' => 5
+					),
+					'internalip' => array(
+						'label' => $lng['admin']['ipsandports']['internalip']['title'],
+						'desc' => $lng['admin']['ipsandports']['internalip']['description'],
+						'type' => 'text'
+					),
+					'internalport' => array(
+						'label' => $lng['admin']['ipsandports']['internalport']['title'],
+						'desc' => $lng['admin']['ipsandports']['internalport']['description'],
+						'type' => 'text',
+						'size' => 5
 					)
 				)
 			),

--- a/lib/formfields/admin/ipsandports/formfield.ipsandports_edit.php
+++ b/lib/formfields/admin/ipsandports/formfield.ipsandports_edit.php
@@ -34,6 +34,19 @@ return array(
 						'type' => 'text',
 						'value' => $result['port'],
 						'size' => 5
+					),
+					'internalip' => array(
+						'label' => $lng['admin']['ipsandports']['internalip']['title'],
+						'desc' => $lng['admin']['ipsandports']['internalip']['description'],
+						'type' => 'text',
+						'value' => $result['internalip']
+					),
+					'internalport' => array(
+						'label' => $lng['admin']['ipsandports']['internalport']['title'],
+						'desc' => $lng['admin']['ipsandports']['internalport']['description'],
+						'type' => 'text',
+						'value' => $result['internalport'],
+						'size' => 5
 					)
 				)
 			),

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2067,3 +2067,8 @@ $lng['serversettings']['nginx_http2_support']['title'] = 'Nginx HTTP2 Support';
 $lng['serversettings']['nginx_http2_support']['description'] = 'enable http2 support for ssl. ENABLE ONLY IF YOUR Nginx SUPPORT THIS FEATURE. (version 1.9.5+)';
 
 $lng['error']['noipportgiven'] = 'No IP/port given';
+
+$lng['admin']['ipsandports']['internalip']['title'] = 'Internal IP';
+$lng['admin']['ipsandports']['internalip']['description'] = 'If the server is behind a NAT / firewall / proxy, you can set a different IP for webserver binding';
+$lng['admin']['ipsandports']['internalport']['title'] = 'Internal port';
+$lng['admin']['ipsandports']['internalport']['description'] = 'If the server is behind a NAT / firewall / proxy, you can set a different port for webserver binding';

--- a/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
+++ b/scripts/jobs/cron_tasks.inc.http.20.lighttpd.php
@@ -73,10 +73,17 @@ class lighttpd extends HttpConfigBase
 			if (filter_var($row_ipsandports['ip'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
 				$ip = '[' . $row_ipsandports['ip'] . ']';
 				$port = $row_ipsandports['port'];
-				$ipv6 = 'server.use-ipv6 = "enable"' . "\n";
 			} else {
 				$ip = $row_ipsandports['ip'];
 				$port = $row_ipsandports['port'];
+			}
+
+			$internalip = $row_ipsandports['internalip'] ? $row_ipsandports['internalip'] : $row_ipsandports['ip'];
+			$internalport = $row_ipsandports['internalport'] ? $row_ipsandports['internalport'] : $row_ipsandports['port'];
+			if (filter_var($internalip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+				$internalip = '[' . $internalip . ']';
+				$ipv6 = 'server.use-ipv6 = "enable"' . "\n";
+			} else {
 				$ipv6 = '';
 			}
 
@@ -87,11 +94,11 @@ class lighttpd extends HttpConfigBase
 				$this->lighttpd_data[$vhost_filename] = '';
 			}
 
-			$this->lighttpd_data[$vhost_filename] .= '$SERVER["socket"] == "' . $ip . ':' . $port . '" {' . "\n";
+			$this->lighttpd_data[$vhost_filename] .= '$SERVER["socket"] == "' . $internalip . ':' . $internalport . '" {' . "\n";
 
 			if ($row_ipsandports['listen_statement'] == '1') {
-				$this->lighttpd_data[$vhost_filename] .= 'server.port = ' . $port . "\n";
-				$this->lighttpd_data[$vhost_filename] .= 'server.bind = "' . $ip . '"' . "\n";
+				$this->lighttpd_data[$vhost_filename] .= 'server.port = ' . $internalport . "\n";
+				$this->lighttpd_data[$vhost_filename] .= 'server.bind = "' . $internalip . '"' . "\n";
 				$this->lighttpd_data[$vhost_filename] .= $ipv6;
 			}
 
@@ -485,6 +492,8 @@ class lighttpd extends HttpConfigBase
 
 					$domain['ip'] = $ipandport['ip'];
 					$domain['port'] = $ipandport['port'];
+					$domain['internalip'] = $ipandport['internalip'] ? $ipandport['internalip'] : $ipandport['ip'];
+					$domain['internalport'] = $ipandport['internalport'] ? $ipandport['internalport'] : $ipandport['port'];
 					$domain['ssl_cert_file'] = $ipandport['ssl_cert_file'];
 					$domain['ssl_key_file'] = $ipandport['ssl_key_file'];
 					$domain['ssl_ca_file'] = $ipandport['ssl_ca_file'];


### PR DESCRIPTION
Add internal IP/Port config option, useful when the public server IP (used by nameserver) is different than the webserver IP (e.g. ```<VirtualHost 0.0.0.0:80>```). This is useful when using AWS Elastic IP or DO floating IP, or when the server is behind a proxy.