### PR TITLE
mysql 5.7, Remove unsupported default value in text column

### DIFF
--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -66,7 +66,7 @@ CREATE TABLE `mail_virtual` (
   `id` int(11) NOT NULL auto_increment,
   `email` varchar(255) NOT NULL default '',
   `email_full` varchar(255) NOT NULL default '',
-  `destination` text NOT NULL default '',
+  `destination` text NOT NULL,
   `domainid` int(11) NOT NULL default '0',
   `customerid` int(11) NOT NULL default '0',
   `popaccountid` int(11) NOT NULL default '0',


### PR DESCRIPTION
For fixing installation on mysql 5.7 & php 7, I have to remove default value from text field otherwise table is not getting created.
https://dev.mysql.com/doc/refman/5.7/en/blob.html
BLOB and TEXT columns cannot have DEFAULT values.