### PR TITLE
Skip views when altering table charsets

### DIFF
--- a/lib/classes/integrity/class.IntegrityCheck.php
+++ b/lib/classes/integrity/class.IntegrityCheck.php
@@ -85,11 +85,10 @@ class IntegrityCheck {
 				// fix database
 				Database::query('ALTER DATABASE `' . Database::getDbName() . '` CHARACTER SET utf8 COLLATE utf8_general_ci');
 				// fix all tables
-				$handle = Database::query('SHOW TABLES');
-				while ($row = $handle->fetch(PDO::FETCH_ASSOC)) {
-					foreach ($row as $table) {
-						Database::query('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;');
-					}
+				$handle = Database::query('SHOW FULL TABLES WHERE Table_type != "VIEW"');
+				while ($row = $handle->fetch(PDO::FETCH_BOTH)) {
+					$table = $row[0];
+					Database::query('ALTER TABLE `' . $table . '` CONVERT TO CHARACTER SET utf8 COLLATE utf8_general_ci;');
 				}
 				$this->_log->logAction(ADM_ACTION, LOG_WARNING, "database charset was different from UTF-8, integrity-check fixed that");
 			} else {


### PR DESCRIPTION
"ALTER TABLE ... CONVERT TO CHARACTER SET" fails on VIEWs with error like

ERROR 1347 (HY000): 'froxlor.view_xxx' is not BASE TABLE

Views can be created for third-party extensions and API to Froxlor database (see for example opendkim support).