### PR TITLE
Fix apache24_ocsp_cache_path definition

### DIFF
--- a/actions/admin/settings/131.ssl.php
+++ b/actions/admin/settings/131.ssl.php
@@ -86,7 +86,7 @@ return array(
 					'type' => 'string',
 					'string_type' => 'string',
 					'string_emptyallowed' => false,
-					'default' => '',
+					'default' => 'shmcb:/var/run/apache2/ocsp-stapling.cache(131072)',
 					'visible' => Settings::Get('system.webserver') == "apache2" &&
 							Settings::Get('system.apache24') == 1,
 					'save_method' => 'storeSettingField'


### PR DESCRIPTION
Add default value for apache24_ocsp_cache_path, otherwise saving
SSL settings for !apache24 fails on apache24_ocsp_cache_path validation.