### PR TITLE
Fixed MySQL Warning while creating a new user

### DIFF
--- a/admin_customers.php
+++ b/admin_customers.php
@@ -910,7 +910,7 @@ if ($page == 'customers'
 							'customerid' => $customerid,
 							'adminid' => $userinfo['adminid'],
 							'docroot' => $documentroot,
-							'adddate' => date('Y-m-d'),
+							'adddate' => time(),
 							'phpenabled' => $phpenabled
 						);
 						$ins_stmt = Database::prepare("
@@ -1283,7 +1283,7 @@ if ($page == 'customers'
 								'customerid' => $result['customerid'],
 								'adminid' => $userinfo['adminid'],
 								'docroot' => $result['documentroot'],
-								'adddate' => date('Y-m-d')
+								'adddate' => time()
 						);
 						$ins_stmt = Database::prepare("
 							INSERT INTO `" . TABLE_PANEL_DOMAINS . "` SET


### PR DESCRIPTION
adddate is a integer column it throws any time a mysql warning.
A database error occurred SQLSTATE[01000]: Warning: 1265 Data truncated for column 'add_date' at row 1