### PR TITLE
nginx: add index directive to path options for secured directories

### DIFF
--- a/scripts/jobs/cron_tasks.inc.http.30.nginx.php
+++ b/scripts/jobs/cron_tasks.inc.http.30.nginx.php
@@ -719,6 +719,11 @@ class nginx extends HttpConfigBase
 								if ($single['path'] == '/') {
 									$path_options .= "\t\t" . 'auth_basic            "' . $single['authname'] . '";' . "\n";
 									$path_options .= "\t\t" . 'auth_basic_user_file  ' . makeCorrectFile($single['usrf']) . ';' . "\n";
+									if ($domain['phpenabled_customer'] == 1 && $domain['phpenabled_vhost'] == '1') {
+										$path_options .= "\t\t" . 'index    index.php index.html index.htm;' . "\n";
+									} else {
+										$path_options .= "\t\t" . 'index    index.html index.htm;' . "\n";
+									}
 									$path_options .= "\t\t" . 'location ~ ^(.+?\.php)(/.*)?$ {' . "\n";
 									$path_options .= "\t\t\t" . 'try_files ' . $domain['nonexistinguri'] . ' @php;' . "\n";
 									$path_options .= "\t\t" . '}' . "\n";
@@ -776,6 +781,11 @@ class nginx extends HttpConfigBase
 						$path_options .= "\t" . 'location ' . makeCorrectDir($single['path']) . ' {' . "\n";
 						$path_options .= "\t\t" . 'auth_basic            "' . $single['authname'] . '";' . "\n";
 						$path_options .= "\t\t" . 'auth_basic_user_file  ' . makeCorrectFile($single['usrf']) . ';' . "\n";
+						if ($domain['phpenabled_customer'] == 1 && $domain['phpenabled_vhost'] == '1') {
+							$path_options .= "\t\t" . 'index    index.php index.html index.htm;' . "\n";
+						} else {
+							$path_options .= "\t\t" . 'index    index.html index.htm;' . "\n";
+						}
 						$path_options .= "\t\t" . 'location ~ ^(.+?\.php)(/.*)?$ {' . "\n";
 						$path_options .= "\t\t\t" . 'try_files ' . $domain['nonexistinguri'] . ' @php;' . "\n";
 						$path_options .= "\t\t" . '}' . "\n";


### PR DESCRIPTION
`index` directives are now created for secured directory locations, closes #449 