### PR TITLE
Added nscd -i passwd to clear user

### DIFF
--- a/scripts/froxlor_master_cronjob.php
+++ b/scripts/froxlor_master_cronjob.php
@@ -91,6 +91,7 @@ if (count($jobs_to_run) > 0) {
 		// clear NSCD cache if using fcgid or fpm, #1570
 		if (Settings::Get('system.mod_fcgid') == 1 || (int)Settings::Get('phpfpm.enabled') == 1) {
 			$false_val = false;
+			safe_exec('nscd -i passwd 1> /dev/null', $false_val, array('>'));
 			safe_exec('nscd -i group 1> /dev/null', $false_val, array('>'));
 		}
 	}

--- a/scripts/jobs/cron_tasks.php
+++ b/scripts/jobs/cron_tasks.php
@@ -178,6 +178,7 @@ while ($row = $result_tasks_stmt->fetch(PDO::FETCH_ASSOC)) {
 			// clear NSCD cache if using fcgid or fpm, #1570
 			if (Settings::Get('system.mod_fcgid') == 1 || (int)Settings::Get('phpfpm.enabled') == 1) {
 				$false_val = false;
+				safe_exec('nscd -i passwd 1> /dev/null', $false_val, array('>'));
 				safe_exec('nscd -i group 1> /dev/null', $false_val, array('>'));
 			}
 		}


### PR DESCRIPTION
If you use libnss-extrausers and create a new customer apache complains about a bad user and fails to restart. You have to clear the users from nscd.
