### PR TITLE
Fixed SQL Error due missing fullchain

### DIFF
--- a/scripts/jobs/cron_letsencrypt.php
+++ b/scripts/jobs/cron_letsencrypt.php
@@ -260,6 +260,7 @@ foreach ($certrows as $certrow) {
 				'ca' => $return['chain'],
 				'chain' => $return['chain'],
 				'csr' => $return['csr'],
+				'fullchain' => $return['fullchain'],
 				'expirationdate' => date('Y-m-d H:i:s', $newcert['validTo_time_t'])
 			));
 


### PR DESCRIPTION
Hey,
the last commit has introduced a sql error when requesting a letsencrypt cert. This pr adds the missing fullchain parameter.

```
froxlor[602]: SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens
froxlor[602]: --- DEBUG: #0 /var/www/lib/classes/database/class.Database.php(72): PDOStatement->execute(Array) #1 /var/www/scripts/jobs/cron_letsencrypt.php(263): Database::pexecute(Object(PDOStatement), Array) #2 /var/www/scripts/froxlor_master_cronjob.php(80): require_once('/var/www/script...') #3 {main}
```