### PR TITLE
Link domains to HTTPS in certificate list

### DIFF
--- a/templates/Sparkle/ssl_certificates/certs_cert.tpl
+++ b/templates/Sparkle/ssl_certificates/certs_cert.tpl
@@ -1,6 +1,6 @@
 <tr <if !$isValid>class="domain-expired"</if>>
 	<td>
-		<a href="http://{$row['domain']}" target="_blank">{$row['domain']}</a>
+		<a href="https://{$row['domain']}" target="_blank">{$row['domain']}</a>
 		{$adminCustomerLink}
 	</td>
 	<td>


### PR DESCRIPTION
As an admin I want to check if the certificate of a website is working.
Therefore I click on the domain in the SSL certificate list and have to prepend "https" to the URL later.
In this case I'd link the domain to HTTPS initially.