### PR TITLE
fix triggering an LE CSR when changing www on a main domain

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -1124,7 +1124,6 @@ if ($page == 'domains' || $page == 'overview') {
 			}
 		}
 	} elseif ($action == 'edit' && $id != 0) {
-
 		$result_stmt = Database::prepare("
 			SELECT `d`.*, `c`.`customerid`
 			FROM `" . TABLE_PANEL_DOMAINS . "` `d`
@@ -2250,12 +2249,12 @@ if ($page == 'domains' || $page == 'overview') {
 			}
 		}
 	} elseif ($action == 'jqGetCustomerPHPConfigs') {
-		
+
 		$customerid = intval($_POST['customerid']);
 		$allowed_phpconfigs = getCustomerDetail($customerid, 'allowed_phpconfigs');
 		echo !empty($allowed_phpconfigs) ? $allowed_phpconfigs : json_encode(array());
 		exit;
-		
+
 	} elseif ($action == 'import') {
 
 		if (isset($_POST['send']) && $_POST['send'] == 'send') {

--- a/admin_domains.php
+++ b/admin_domains.php
@@ -2027,7 +2027,15 @@ if ($page == 'domains' || $page == 'overview') {
 				} else
 					if ($result['wwwserveralias'] != $wwwserveralias || $result['letsencrypt'] != $letsencrypt) {
 						// or when wwwserveralias or letsencrypt was changed
+
 						triggerLetsEncryptCSRForAliasDestinationDomain($aliasdomain, $log);
+
+						if ($aliasdomain === 0) {
+							// in case the wwwserveralias is set on a main domain, $aliasdomain is 0
+							// --> the call just above to triggerLetsEncryptCSRForAliasDestinationDomain
+							//     is a noop...let's repeat it with the domain id of the main domain
+							triggerLetsEncryptCSRForAliasDestinationDomain($id, $log);
+						}
 					}
 
 				$log->logAction(ADM_ACTION, LOG_INFO, "edited domain #" . $id);

--- a/customer_domains.php
+++ b/customer_domains.php
@@ -773,7 +773,15 @@ if ($page == 'overview') {
 							triggerLetsEncryptCSRForAliasDestinationDomain($aliasdomain, $log);
 						} elseif ($result['wwwserveralias'] != $wwwserveralias || $result['letsencrypt'] != $letsencrypt) {
 							// or when wwwserveralias or letsencrypt was changed
+
 							triggerLetsEncryptCSRForAliasDestinationDomain($aliasdomain, $log);
+
+							if ($aliasdomain === 0) {
+								// in case the wwwserveralias is set on a main domain, $aliasdomain is 0
+								// --> the call just above to triggerLetsEncryptCSRForAliasDestinationDomain
+								//     is a noop...let's repeat it with the domain id of the main domain
+								triggerLetsEncryptCSRForAliasDestinationDomain($id, $log);
+							}
 						}
 
 						// check whether LE has been disabled, so we remove the certificate


### PR DESCRIPTION
Prior to this, LE CSRs were triggered only when the wwwserveralias was
changed on alias domains, but not on main domains.

Fixes #526