### PR TITLE
Fixed class.lescript_v2.php to work with ACMEv2

### DIFF
--- a/lib/classes/ssl/class.lescript_v2.php
+++ b/lib/classes/ssl/class.lescript_v2.php
@@ -495,8 +495,8 @@ class Client
 	private function curl($method, $url, $data = null)
 	{
 		$headers = array(
-			'Accept: application/json',
-			'Content-Type: application/json'
+			'Accept: application/jose+json',
+			'Content-Type: application/jose+json'
 		);
 		$handle = curl_init();
 		curl_setopt($handle, CURLOPT_URL, preg_match('~^http~', $url) ? $url : $this->base . $url);
@@ -550,7 +550,7 @@ class Client
 			return trim($matches[1]);
 		}
 		
-		$this->curl('GET', '/directory');
+		$this->curl('GET', '/acme/new-nonce');
 		return $this->getLastNonce();
 	}
 


### PR DESCRIPTION
As GET /document never returns any Reply-Nonce Header, getLastNonce() caused an infinite loop.
The Content-Type for v2 must be application/jose+json.