### PR TITLE
htpasswd only on configured paths

### DIFF
--- a/lib/Froxlor/Cron/Http/Nginx.php
+++ b/lib/Froxlor/Cron/Http/Nginx.php
@@ -849,6 +849,7 @@ class Nginx extends HttpConfigBase
 			FROM `" . TABLE_PANEL_HTPASSWDS . "` AS a
 			JOIN `" . TABLE_PANEL_DOMAINS . "` AS b USING (`customerid`)
 			WHERE b.customerid = :customerid AND b.domain = :domain
+			AND path LIKE CONCAT(b.documentroot, '%')
 		");
 		Database::pexecute($result_stmt, array(
 			'customerid' => $domain['customerid'],


### PR DESCRIPTION
Only apply htpasswd rules to (sub)domains if the rule's path begins with the domain's document root.