### PR TITLE
Fix buggy error-reporting for wildcarddomains with letsencrypt V2

### DIFF
--- a/customer_domains.php
+++ b/customer_domains.php
@@ -687,7 +687,7 @@ if ($page == 'overview') {
 				}
 				// if using acme-v2 we cannot issue wildcard-certificates
 				// because they currently only support the dns-01 challenge
-				if ($iswildcarddomain == '0' && $letsencrypt == '1' && Settings::Get('system.leapiversion') == '2') {
+				if ($iswildcarddomain == '1' && $letsencrypt == '1' && Settings::Get('system.leapiversion') == '2') {
 					standard_error('nowildcardwithletsencryptv2');
 				}
 


### PR DESCRIPTION
# Description

At the moment the error for "nowildcardwithletsencryptv2" is thrown if it's NOT a wildcard domain but it should be the opposite

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a new domain / subdomain with activated "Let's encrypt V2 (Admin Settings)" and change the ServerAlias field within this (Sub)Domain to "www" or "none" - the error will be shown.

**Test Configuration**:

* Distribution: Debian 9
* Webserver: apache2
* PHP: 7.0

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

