### PR TITLE
Fix db param null

### DIFF
--- a/lib/Froxlor/Database/Manager/DbManagerMySQL.php
+++ b/lib/Froxlor/Database/Manager/DbManagerMySQL.php
@@ -58,8 +58,14 @@ class DbManagerMySQL
 	 *
 	 * @param string $dbname
 	 */
-	public function createDatabase($dbname = null)
+	public function createDatabase($dbname)
 	{
+        if (!is_string($dbname)) {
+            throw new \InvalidArgumentException('Parameter must be of type string.', 1557449868);
+        }
+	    if (is_string($dbname) && empty(trim($dbname))) {
+            throw new \InvalidArgumentException('Databasename cannot be empty.', 1557444946);
+        }
 		Database::query("CREATE DATABASE `" . $dbname . "`");
 	}
 


### PR DESCRIPTION
# Description

Via PR #680 I've seen the method \Froxlor\Database\Manager\DbManagerMySQL::createDatabase. But it allowed "NULL" as parameter value and it will crash the following query (CREATE DATABASE ...). 
Therefore I've added checks to prevent that behaviour and instead throw a exception.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

