### PR TITLE
Fixes #682 - mail log parsing regex character group

### DIFF
--- a/lib/Froxlor/MailLogParser.php
+++ b/lib/Froxlor/MailLogParser.php
@@ -101,13 +101,13 @@ class MailLogParser
 
 			$timestamp = $this->getLogTimestamp($line);
 			if ($this->startTime < $timestamp) {
-				if (preg_match("/postfix\/qmgr.*(?::|\])\s([A-Z\d]+).*from=<?(?:.*\@([a-z\A-Z\d\.\-]+))?>?, size=(\d+),/", $line, $matches)) {
+				if (preg_match("/postfix\/qmgr.*(?::|\])\s([A-Z\d]+).*from=<?(?:.*\@([a-zA-Z\d\.\-]+))?>?, size=(\d+),/", $line, $matches)) {
 					// Postfix from
 					$this->mails[$matches[1]] = array(
 						"domainFrom" => strtolower($matches[2]),
 						"size" => $matches[3]
 					);
-				} elseif (preg_match("/postfix\/(?:pipe|smtp).*(?::|\])\s([A-Z\d]+).*to=<?(?:.*\@([a-z\A-Z\d\.\-]+))?>?,/", $line, $matches)) {
+				} elseif (preg_match("/postfix\/(?:pipe|smtp).*(?::|\])\s([A-Z\d]+).*to=<?(?:.*\@([a-zA-Z\d\.\-]+))?>?,/", $line, $matches)) {
 					// Postfix to
 					if (array_key_exists($matches[1], $this->mails)) {
 						$this->mails[$matches[1]]["domainTo"] = strtolower($matches[2]);


### PR DESCRIPTION
# Description

The mail log parsing regex was incorrectly using a character group of `\A`

Fixes #682

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Hand validation via `php -r '...'`

**Test Configuration**:

* Distribution: debian
* Webserver: N/A
* PHP: 7.3.5-1+0\~20190503093914.38+buster\~1.gbp60a41b

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

