### PR TITLE
* Make ftp quota related to used traffic instead of used disk space

### DIFF
--- a/lib/Froxlor/Cron/Traffic/TrafficCron.php
+++ b/lib/Froxlor/Cron/Traffic/TrafficCron.php
@@ -477,7 +477,7 @@ class TrafficCron extends \Froxlor\Cron\FroxlorCron
 			 * Proftpd Quota
 			 */
 			$upd_data = array(
-				'biu' => ($current_diskspace['all'] * 1024),
+				'biu' => ($sum_month_traffic['all'] * 1024),
 				'loginname' => $row['loginname'],
 				'loginnamelike' => $row['loginname'] . Settings::Get('customer.ftpprefix') . "%"
 			);
@@ -511,7 +511,7 @@ class TrafficCron extends \Froxlor\Cron\FroxlorCron
 				while ($row_quota = $result_quota_stmt->fetch(\PDO::FETCH_ASSOC)) {
 					$quotafile = "" . $row_quota['homedir'] . ".ftpquota";
 					$fh = fopen($quotafile, 'w');
-					$stringdata = "0 " . $current_diskspace['all'] * 1024 . "";
+					$stringdata = "0 " . $sum_month_traffic['all'] * 1024 . "";
 					fwrite($fh, $stringdata);
 					fclose($fh);
 					\Froxlor\FileDir::safe_exec('chown ' . $user . ':' . $group . ' ' . escapeshellarg($quotafile) . '');


### PR DESCRIPTION
# Description

Currently Froxlor calculates FTP quota based on disk space usage which is wrong. If we setup traffic (bandwidth) limit lower than disk space in current state then this prevents user from FTP usage. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Checking working instance after few days and current system calculation manually.

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* Distribution:
* Webserver:
* PHP:
* etc.etc.:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

