### PR TITLE
Remove unnecessary slash for SSL redirect

### DIFF
--- a/lib/Froxlor/Cron/Http/Nginx.php
+++ b/lib/Froxlor/Cron/Http/Nginx.php
@@ -244,7 +244,7 @@ class Nginx extends HttpConfigBase
 						$is_redirect = false;
 					} else {
 						$_sslport = $this->checkAlternativeSslPort();
-						$mypath = 'https://' . Settings::Get('system.hostname') . $_sslport . '/';
+						$mypath = 'https://' . Settings::Get('system.hostname') . $_sslport;
 						$this->nginx_data[$vhost_filename] .= "\t" . 'location / {' . "\n";
 						$this->nginx_data[$vhost_filename] .= "\t\t" . 'return 301 ' . $mypath . '$request_uri;' . "\n";
 						$this->nginx_data[$vhost_filename] .= "\t" . '}' . "\n";


### PR DESCRIPTION
Remove slash after hostname since requests directly to the hostname do not require a slash at the end and all other content goes to `$request_uri` which starts with shlash, hence no longer doubleslashes on hostname only queries.