### PR TITLE
fix missing namespaces in PowerDNS cron

### DIFF
--- a/lib/Froxlor/Cron/Dns/PowerDNS.php
+++ b/lib/Froxlor/Cron/Dns/PowerDNS.php
@@ -111,7 +111,7 @@ class PowerDNS extends DnsBase
 
 	private function insertZone($domainname, $serial = 0)
 	{
-		$ins_stmt = PowerDNS::getDB()->prepare("
+		$ins_stmt = \Froxlor\Dns\PowerDNS::getDB()->prepare("
 			INSERT INTO domains set `name` = :domainname, `notified_serial` = :serial, `type` = 'NATIVE'
 		");
 		$ins_stmt->execute(array(
@@ -124,7 +124,7 @@ class PowerDNS extends DnsBase
 
 	private function insertRecords($domainid = 0, $records = array(), $origin = "")
 	{
-		$ins_stmt = PowerDNS::getDB()->prepare("
+		$ins_stmt = \Froxlor\Dns\PowerDNS::getDB()->prepare("
 			INSERT INTO records set
 			`domain_id` = :did,
 			`name` = :rec,
@@ -161,7 +161,7 @@ class PowerDNS extends DnsBase
 
 	private function insertAllowedTransfers($domainid)
 	{
-		$ins_stmt = PowerDNS::getDB()->prepare("
+		$ins_stmt = \Froxlor\Dns\PowerDNS::getDB()->prepare("
 			INSERT INTO domainmetadata set `domain_id` = :did, `kind` = 'ALLOW-AXFR-FROM', `content` = :value
 		");
 


### PR DESCRIPTION
## Description
Some getDB calls were missing the `\Froxlor\Dns\` prefix

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Cron threw an error during initial run:

`PHP Fatal error:  Uncaught Error: Call to undefined method Froxlor\Cron\Dns\PowerDNS::getDB() in /var/www/froxlor/lib/Froxlor/Cron/Dns/PowerDNS.php:115
Stack trace:
#0 /var/www/froxlor/lib/Froxlor/Cron/Dns/PowerDNS.php(72): Froxlor\Cron\Dns\PowerDNS->insertZone('test.froxlor.on...', 2019092201)
#1 /var/www/froxlor/lib/Froxlor/Cron/Dns/PowerDNS.php(41): Froxlor\Cron\Dns\PowerDNS->walkDomainList(Array, Array)
#2 /var/www/froxlor/lib/Froxlor/Cron/System/TasksCron.php(257): Froxlor\Cron\Dns\PowerDNS->writeConfigs()
#3 /var/www/froxlor/lib/Froxlor/Cron/System/TasksCron.php(62): Froxlor\Cron\System\TasksCron::rebuildDnsConfigs()
#4 /var/www/froxlor/lib/Froxlor/Cron/MasterCron.php(101): Froxlor\Cron\System\TasksCron::run()
#5 /var/www/froxlor/scripts/froxlor_master_cronjob.php(20): Froxlor\Cron\MasterCron::run()
#6 {main}
  thrown in /var/www/froxlor/lib/Froxlor/Cron/Dns/PowerDNS.php on line 115`

After adding the namespaces, the cronjob ran without problems.

**Test Configuration**:

* Distribution: Debian Buster
* Webserver: Apache
* PHP: 7.3.9-1~deb10u1
* PowerDNS: 4.1.6

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

