### PR TITLE
Get mailbox size with maildirsize file

### DIFF
--- a/lib/Froxlor/Cron/System/MailboxsizeCron.php
+++ b/lib/Froxlor/Cron/System/MailboxsizeCron.php
@@ -38,16 +38,24 @@ class MailboxsizeCron extends \Froxlor\Cron\FroxlorCron
 			$_maildir = \Froxlor\FileDir::makeCorrectDir($maildir['maildirpath']);
 
 			if (file_exists($_maildir) && is_dir($_maildir)) {
-				// 1. Check if maildirsize exists (usually when quota is enabled)
-				$maildirsize = $_maildir.'maildirsize';
-				if (file_exists($maildirsize)) {
+				$maildirsize = \Froxlor\FileDir::makeCorrectFile($_maildir . '/maildirsize');
+				
+				// When quota is enabled and maildirsize file exists, use that to calculate size
+				if (\Froxlor\Settings::Get('system.mail_quota_enabled') == 1 && file_exists($maildirsize)) {
 					\Froxlor\FroxlorLogger::getInstanceOf()->logAction(\Froxlor\FroxlorLogger::CRON_ACTION, LOG_NOTICE, 'found maildirsize file in ' . $_maildir);
 					$file = file($maildirsize, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-					if (!empty($file[1])) {
-						$emailusage = floatval(explode(' ', $file[1])[0]);
+					// Remove header
+					array_shift($file);
+					$emailusage = 0;
+					// Sum up all the changes (line 2 -> end)
+					foreach ($file as $line) {
+						$parts = explode(' ', $line);
+						if (!empty($parts[0])) {
+							$emailusage += floatval($parts[0]);
+						}
 					}
 				} else {
-					// 2. If maildirsize file does not exist, compute with du
+					// if quota is disabled or maildirsize file does not exist, compute with du
 					// mail-address allows many special characters, see http://en.wikipedia.org/wiki/Email_address#Local_part
 					$return = false;
 					$back = \Froxlor\FileDir::safe_exec('du -sk ' . escapeshellarg($_maildir), $return, array(


### PR DESCRIPTION
# Description

When quota is enabled, dovecot generates a [maildirsize file](https://wiki2.dovecot.org/Quota/Maildir#Maildirsize_file). This file can be used to get the current Maildir size. This is quicker & easier than using du. When quota is not enabled, the file is missing & du is used as usual.

Especially when quota integration in Dovecot is actively used, du sometimes reports too big values, leading to confusion why it's different from the value shown in mail clients. The big values come from various files that usually do not count towards maildir size, like index files.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on local configuration with various use-cases (file there, file not there, new user mailbox etc.)

**Test Configuration**:

* Distribution: Debian Buster
* Webserver: Apache/2.4.38
* PHP: PHP 7.3.9-1~deb10u1
* Dovecot: 2.3.4.1 (f79e8e7e4)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

