### PR TITLE
fix MysqlHandler user field

### DIFF
--- a/lib/Froxlor/System/MysqlHandler.php
+++ b/lib/Froxlor/System/MysqlHandler.php
@@ -57,7 +57,7 @@ class MysqlHandler extends AbstractProcessingHandler
 	{
 		$this->insert([
 			':message' => $record['message'],
-			':contextUser' => (isset($record['context']['loginname']) ? $record['context']['loginname'] : 'unknown'),
+			':contextUser' => (isset($record['context']['user']) ? $record['context']['user'] : 'unknown'),
 			':contextAction' => (isset($record['context']['action']) ? $record['context']['action'] : '0'),
 			':level' => self::$froxlorLevels[$record['level']],
 			':datetime' => $record['datetime']->format('U')


### PR DESCRIPTION
# Description

I noticed the System Log in the panel would only show "unkown" as the user. Upon digging into the code, I noticed that the context field is called `user`, not `loginname`. See https://github.com/Froxlor/Froxlor/blob/master/lib/Froxlor/FroxlorLogger.php#L162

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Log page now shows users.

**Test Configuration**:

Distribution: Debian Buster
Webserver: Apache/2.4.38
PHP: PHP 7.3.9-1~deb10u1

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

