### PR TITLE
Fix fastcgi_split_path_info

### DIFF
--- a/lib/Froxlor/Cron/Http/Nginx.php
+++ b/lib/Froxlor/Cron/Http/Nginx.php
@@ -285,7 +285,7 @@ class Nginx extends HttpConfigBase
 
 				if (! $is_redirect) {
 					$this->nginx_data[$vhost_filename] .= "\tlocation ~ \.php {\n";
-					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_split_path_info ^(.+\.php)(/.+)\$;\n";
+					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_split_path_info ^(.+?\.php)(/.*)$;\n";
 					$this->nginx_data[$vhost_filename] .= "\t\tinclude " . Settings::Get('nginx.fastcgiparams') . ";\n";
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param SCRIPT_FILENAME \$request_filename;\n";
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param PATH_INFO \$fastcgi_path_info;\n";
@@ -955,7 +955,7 @@ class Nginx extends HttpConfigBase
 			$phpopts .= "\t" . '}' . "\n\n";
 
 			$phpopts .= "\tlocation @php {\n";
-			$phpopts .= "\t\tfastcgi_split_path_info ^(.+\.php)(/.+)\$;\n";
+			$phpopts .= "\t\tfastcgi_split_path_info ^(.+?\.php)(/.*)$;\n";
 			$phpopts .= "\t\tinclude " . Settings::Get('nginx.fastcgiparams') . ";\n";
 			$phpopts .= "\t\tfastcgi_param SCRIPT_FILENAME \$request_filename;\n";
 			$phpopts .= "\t\tfastcgi_param PATH_INFO \$fastcgi_path_info;\n";

--- a/lib/Froxlor/Cron/Http/NginxFcgi.php
+++ b/lib/Froxlor/Cron/Http/NginxFcgi.php
@@ -37,7 +37,7 @@ class NginxFcgi extends Nginx
 			$php_options_text .= "\t" . 'location @php {' . "\n";
 			$php_options_text .= "\t\t" . 'try_files $1 =404;' . "\n\n";
 			$php_options_text .= "\t\t" . 'include ' . Settings::Get('nginx.fastcgiparams') . ";\n";
-			$php_options_text .= "\t\t" . 'fastcgi_split_path_info ^(.+\.php)(/.+)$;' . "\n";
+			$php_options_text .= "\t\t" . 'fastcgi_split_path_info ^(.+?\.php)(/.*)$;' . "\n";
 			$php_options_text .= "\t\t" . 'fastcgi_param SCRIPT_FILENAME $request_filename;' . "\n";
 			$php_options_text .= "\t\t" . 'fastcgi_param PATH_INFO $2;' . "\n";
 			if ($domain['ssl'] == '1' && $ssl_vhost) {

--- a/lib/Froxlor/Cron/Http/NginxFcgi.php
+++ b/lib/Froxlor/Cron/Http/NginxFcgi.php
@@ -37,7 +37,7 @@ class NginxFcgi extends Nginx
 			$php_options_text .= "\t" . 'location @php {' . "\n";
 			$php_options_text .= "\t\t" . 'try_files $1 =404;' . "\n\n";
 			$php_options_text .= "\t\t" . 'include ' . Settings::Get('nginx.fastcgiparams') . ";\n";
-			$php_options_text .= "\t\t" . 'fastcgi_split_path_info ^(.+\.php)(/.+)\$;' . "\n";
+			$php_options_text .= "\t\t" . 'fastcgi_split_path_info ^(.+\.php)(/.+)$;' . "\n";
 			$php_options_text .= "\t\t" . 'fastcgi_param SCRIPT_FILENAME $request_filename;' . "\n";
 			$php_options_text .= "\t\t" . 'fastcgi_param PATH_INFO $2;' . "\n";
 			if ($domain['ssl'] == '1' && $ssl_vhost) {


### PR DESCRIPTION
With Nginx+PHP fpm the fastcgi_split_path_info parameter is generated wrong:
`                fastcgi_split_path_info ^(.+\.php)(/.+)\$;`
instead of:
`                fastcgi_split_path_info ^(.+\.php)(/.+)$;`

(i.e.: https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/ )

