### PR TITLE
enabled autofocus for 2fa_code

### DIFF
--- a/templates/Sparkle/2fa/entercode.tpl
+++ b/templates/Sparkle/2fa/entercode.tpl
@@ -9,7 +9,7 @@ $header
 					<legend>Froxlor&nbsp;-&nbsp;{$lng['login']['2fa']}</legend>
 					<p>
 						<label for="2fa_code">{$lng['login']['2facode']}:</label>&nbsp;
-						<input type="text" name="2fa_code" id="2fa_code" value="" required/>
+						<input type="text" name="2fa_code" id="2fa_code" value="" autofocus required/>
 					</p>
 					<p class="submit">
 						<input type="hidden" name="action" value="2fa_verify" />


### PR DESCRIPTION
# Description

added autofocus for 2fa_code

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Yes, Chrome, Edge, Firefox, Opera all accepted the tag.

- [x] tested, it's a valid HTML5 tag at the right position

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

