### PR TITLE
Add validation for special IP 0.0.0.0 and 0.0.0.0/0.0.0.0 + test

### DIFF
--- a/lib/Froxlor/Validate/Validate.php
+++ b/lib/Froxlor/Validate/Validate.php
@@ -161,6 +161,12 @@ class Validate
 			return $ip . $cidr;
 		}
 
+		// special case: 0.0.0.0 and 0.0.0.0/0 are used for 'any ip' but it's filtered out by FILTER_FLAG_NO_RES_RANGE
+		if ($ip == '0.0.0.0' && ($cidr == '' || $cidr == '/0.0.0.0')) {
+			return $ip. $cidr;
+		}
+
+
 		if ($return_bool) {
 			return false;
 		} else {

--- a/tests/Froxlor/ValidateTest.php
+++ b/tests/Froxlor/ValidateTest.php
@@ -67,6 +67,18 @@ class ValidateTest extends TestCase
 		$this->assertFalse($result);
 	}
 
+	public function testValidateAnyIpBool()
+	{
+		$result = Validate::validate_ip2("0.0.0.0", true, 'invalidip', false, false, false, false, true);
+		$this->assertEquals("0.0.0.0",$result);
+	}
+
+	public function testValidateAnyIpWithNetmaskBool()
+	{
+		$result = Validate::validate_ip2("0.0.0.0/0.0.0.0", true, 'invalidip', false, false, true, true, true);
+		$this->assertEquals("0.0.0.0/0.0.0.0",$result);
+	}
+
 	public function testValidateIpCidrNotAllowed()
 	{
 		$this->expectException("Exception");


### PR DESCRIPTION
# Description

IP validation sorts out any "reserved" IP. That's a good thing because we do not want e.g. to DHCP bind to broadcasts IPs. But there are some special cases that are filtered out by FILTER_FLAG_NO_RES_RANGE:

* Using 0.0.0.0 in "Ports and IPs" to create a Port listening on any IP
* Using 0.0.0.0/0.0.0.0 e.g. for MySQL to allow access to any IP

(Personally, I have only use case 1 but since It's quite similar, I added the other too).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have manually tested that creating a port with IP 0.0.0.0 works as expected. I have added Tests into ValidationTests for both use cases.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
-> No idea where to document it exactly, it's just a minor fix/enhancement
- [?] My changes generate no new warnings
-> How to test?
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
