### PR TITLE
Add 2FA GA secret output for software TOTP

### DIFF
--- a/2fa.php
+++ b/2fa.php
@@ -86,5 +86,6 @@ if ($userinfo['type_2fa'] == '0') {
 } elseif ($userinfo['type_2fa'] == '2') {
 	// authenticator 2fa enabled
 	$ga_qrcode = $tfa->getQRCodeImageAsDataUri($userinfo['loginname'], $userinfo['data_2fa']);
+        $ga_secret = &$userinfo['data_2fa'];
 }
 eval("echo \"" . \Froxlor\UI\Template::getTemplate("2fa/overview", true) . "\";");

--- a/templates/Sparkle/2fa/overview.tpl
+++ b/templates/Sparkle/2fa/overview.tpl
@@ -32,6 +32,7 @@ $header
 			action="{$linker->getLink(array('section' => 'index', 'page' => $page, 'action' => 'delete'))}">
 			<p>{$lng['2fa']['2fa_ga_desc']}</p>
 			<br> <img src="{$ga_qrcode}" alt="QRCode" /><br>
+      <br> <p>Secret: <strong>{$ga_secret}</strong> </p>
 			<br> <input type="submit" class="cancel"
 				value="{$lng['2fa']['2fa_delete']}" name="delete" />
 		</form>


### PR DESCRIPTION
# Description

For 2FA TOTP Software users its use full to know the 2FA secret. Therefore this pull request adds a textual representation of the 2FA secret below the 2FA QR code.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code