### PR TITLE
Ability to add custom config to PHPFPM version

### DIFF
--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -848,7 +848,7 @@ CREATE TABLE `panel_fpmdaemons` (
   `max_requests` int(4) NOT NULL DEFAULT '0',
   `idle_timeout` int(4) NOT NULL DEFAULT '30',
   `limit_extensions` varchar(255) NOT NULL default '.php',
-  `custom_config` text NOT NULL DEFAULT '',
+  `custom_config` text,
   PRIMARY KEY  (`id`),
   UNIQUE KEY `reload` (`reload_cmd`),
   UNIQUE KEY `config` (`config_dir`)

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -703,7 +703,7 @@ opcache.interned_strings_buffer'),
 	('panel', 'customer_hide_options', ''),
 	('panel', 'is_configured', '0'),
 	('panel', 'version', '0.10.10'),
-	('panel', 'db_version', '201912310');
+	('panel', 'db_version', '201912311');
 
 
 DROP TABLE IF EXISTS `panel_tasks`;

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -848,6 +848,7 @@ CREATE TABLE `panel_fpmdaemons` (
   `max_requests` int(4) NOT NULL DEFAULT '0',
   `idle_timeout` int(4) NOT NULL DEFAULT '30',
   `limit_extensions` varchar(255) NOT NULL default '.php',
+  `custom_config` text NOT NULL DEFAULT '',
   PRIMARY KEY  (`id`),
   UNIQUE KEY `reload` (`reload_cmd`),
   UNIQUE KEY `config` (`config_dir`)

--- a/install/updates/froxlor/0.10/update_0.10.inc.php
+++ b/install/updates/froxlor/0.10/update_0.10.inc.php
@@ -523,3 +523,10 @@ if (\Froxlor\Froxlor::isFroxlorVersion('0.10.9')) {
 	showUpdateStep("Updating from 0.10.9 to 0.10.10", false);
 	\Froxlor\Froxlor::updateToVersion('0.10.10');
 }
+
+if (\Froxlor\Froxlor::isDatabaseVersion('201912100')) {
+	showUpdateStep("Adding custom phpfpm configuration field");
+	Database::query("ALTER TABLE `" . TABLE_PANEL_PHPDAEMONS . "` ADD `custom_config` text NOT NULL DEFAULT '' AFTER `limit_extensions`;");
+	lastStepStatus(0);
+	\Froxlor\Froxlor::updateToDbVersion('201912310');
+}

--- a/install/updates/froxlor/0.10/update_0.10.inc.php
+++ b/install/updates/froxlor/0.10/update_0.10.inc.php
@@ -525,10 +525,15 @@ if (\Froxlor\Froxlor::isFroxlorVersion('0.10.9')) {
 }
 
 if (\Froxlor\Froxlor::isDatabaseVersion('201912100')) {
-	showUpdateStep("Adding custom phpfpm configuration field");
-	Database::query("ALTER TABLE `" . TABLE_PANEL_PHPDAEMONS . "` ADD `custom_config` text AFTER `limit_extensions`;");
 	showUpdateStep("Adding option to disable SSL sessiontickets for older systems");
 	Settings::AddNew("system.sessionticketsenabled", '1');
 	lastStepStatus(0);
 	\Froxlor\Froxlor::updateToDbVersion('201912310');
+}
+
+if (\Froxlor\Froxlor::isDatabaseVersion('201912310')) {
+	showUpdateStep("Adding custom phpfpm pool configuration field");
+	Database::query("ALTER TABLE `" . TABLE_PANEL_PHPDAEMONS . "` ADD `custom_config` text AFTER `limit_extensions`;");
+	lastStepStatus(0);
+	\Froxlor\Froxlor::updateToDbVersion('201912311');
 }

--- a/install/updates/froxlor/0.10/update_0.10.inc.php
+++ b/install/updates/froxlor/0.10/update_0.10.inc.php
@@ -526,7 +526,7 @@ if (\Froxlor\Froxlor::isFroxlorVersion('0.10.9')) {
 
 if (\Froxlor\Froxlor::isDatabaseVersion('201912100')) {
 	showUpdateStep("Adding custom phpfpm configuration field");
-	Database::query("ALTER TABLE `" . TABLE_PANEL_PHPDAEMONS . "` ADD `custom_config` text NOT NULL DEFAULT '' AFTER `limit_extensions`;");
+	Database::query("ALTER TABLE `" . TABLE_PANEL_PHPDAEMONS . "` ADD `custom_config` text AFTER `limit_extensions`;");
 	lastStepStatus(0);
 	\Froxlor\Froxlor::updateToDbVersion('201912310');
 }

--- a/lib/Froxlor/Api/Commands/FpmDaemons.php
+++ b/lib/Froxlor/Api/Commands/FpmDaemons.php
@@ -151,7 +151,7 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 	 * @param string $limit_extensions
 	 *        	optional, limit execution to the following extensions, default '.php'
 	 * @param string $custom_config
-	 *        	optional, custom settings appended to phpfpm configuration
+	 *        	optional, custom settings appended to phpfpm pool configuration
 	 *        	
 	 * @access admin
 	 * @throws \Exception
@@ -267,7 +267,7 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 	 * @param string $limit_extensions
 	 *        	optional, limit execution to the following extensions, default '.php'
 	 * @param string $custom_config
-	 *        	optional, custom settings appended to phpfpm configuration
+	 *        	optional, custom settings appended to phpfpm pool configuration
 	 *        	
 	 * @access admin
 	 * @throws \Exception

--- a/lib/Froxlor/Api/Commands/FpmDaemons.php
+++ b/lib/Froxlor/Api/Commands/FpmDaemons.php
@@ -150,6 +150,8 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 	 *        	optional, default 0
 	 * @param string $limit_extensions
 	 *        	optional, limit execution to the following extensions, default '.php'
+	 * @param string $custom_config
+	 *        	optional, custom settings appended to phpfpm configuration
 	 *        	
 	 * @access admin
 	 * @throws \Exception
@@ -173,6 +175,7 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 			$max_requests = $this->getParam('max_requests', true, 0);
 			$idle_timeout = $this->getParam('idle_timeout', true, 0);
 			$limit_extensions = $this->getParam('limit_extensions', true, '.php');
+			$custom_config = $this->getParam('custom_config', true, '');
 
 			// validation
 			$description = \Froxlor\Validate\Validate::validate($description, 'description', '', '', array(), true);
@@ -206,7 +209,8 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 				`max_spare_servers` = :max_spare_servers,
 				`max_requests` = :max_requests,
 				`idle_timeout` = :idle_timeout,
-				`limit_extensions` = :limit_extensions
+				`limit_extensions` = :limit_extensions,
+				`custom_config` = :custom_config
 			");
 			$ins_data = array(
 				'desc' => $description,
@@ -219,7 +223,8 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 				'max_spare_servers' => $max_spare_servers,
 				'max_requests' => $max_requests,
 				'idle_timeout' => $idle_timeout,
-				'limit_extensions' => $limit_extensions
+				'limit_extensions' => $limit_extensions,
+				'custom_config' => $custom_config
 			);
 			Database::pexecute($ins_stmt, $ins_data);
 			$id = Database::lastInsertId();
@@ -261,6 +266,8 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 	 *        	optional, default 0
 	 * @param string $limit_extensions
 	 *        	optional, limit execution to the following extensions, default '.php'
+	 * @param string $custom_config
+	 *        	optional, custom settings appended to phpfpm configuration
 	 *        	
 	 * @access admin
 	 * @throws \Exception
@@ -289,6 +296,7 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 			$max_requests = $this->getParam('max_requests', true, $result['max_requests']);
 			$idle_timeout = $this->getParam('idle_timeout', true, $result['idle_timeout']);
 			$limit_extensions = $this->getParam('limit_extensions', true, $result['limit_extensions']);
+			$custom_config = $this->getParam('custom_config', true, $result['custom_config']);
 
 			// validation
 			$description = \Froxlor\Validate\Validate::validate($description, 'description', '', '', array(), true);
@@ -322,7 +330,8 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 				`max_spare_servers` = :max_spare_servers,
 				`max_requests` = :max_requests,
 				`idle_timeout` = :idle_timeout,
-				`limit_extensions` = :limit_extensions
+				`limit_extensions` = :limit_extensions,
+				`custom_config` = :custom_config
 				WHERE `id` = :id
 			");
 			$upd_data = array(
@@ -337,6 +346,7 @@ class FpmDaemons extends \Froxlor\Api\ApiCommand implements \Froxlor\Api\Resourc
 				'max_requests' => $max_requests,
 				'idle_timeout' => $idle_timeout,
 				'limit_extensions' => $limit_extensions,
+				'custom_config' => $custom_config,
 				'id' => $id
 			);
 			Database::pexecute($upd_stmt, $upd_data, true, true);

--- a/lib/Froxlor/Cron/Http/Php/Fpm.php
+++ b/lib/Froxlor/Cron/Http/Php/Fpm.php
@@ -115,6 +115,7 @@ class Fpm
 			$fpm_requests = (int) $this->fpm_cfg['max_requests'];
 			$fpm_process_idle_timeout = (int) $this->fpm_cfg['idle_timeout'];
 			$fpm_limit_extensions = $this->fpm_cfg['limit_extensions'];
+			$fpm_custom_config = $this->fpm_cfg['custom_config'];
 
 			if ($fpm_children == 0) {
 				$fpm_children = 1;
@@ -258,6 +259,12 @@ class Fpm
 			// if not we use our fallback-default as usual
 			if (strpos($fpm_config, 'php_admin_value[sendmail_path]') === false) {
 				$fpm_config .= 'php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f ' . $this->domain['email'] . "\n";
+			}
+
+			// append custom phpfpm configuration
+			if (! empty($fpm_custom_config)) {
+				$fpm_config .= "\n; Custom Configuration\n";
+				$fpm_config .= \Froxlor\PhpHelper::replaceVariables($fpm_custom_config, $php_ini_variables);
 			}
 
 			fwrite($fh, $fpm_config, strlen($fpm_config));

--- a/lib/Froxlor/Froxlor.php
+++ b/lib/Froxlor/Froxlor.php
@@ -10,7 +10,7 @@ final class Froxlor
 	const VERSION = '0.10.10';
 
 	// Database version (YYYYMMDDC where C is a daily counter)
-	const DBVERSION = '201912310';
+	const DBVERSION = '201912311';
 
 	// Distribution branding-tag (used for Debian etc.)
 	const BRANDING = '';

--- a/lib/formfields/admin/phpconfig/formfield.fpmconfig_add.php
+++ b/lib/formfields/admin/phpconfig/formfield.fpmconfig_add.php
@@ -86,6 +86,13 @@ return array(
 						'desc' => $lng['serversettings']['phpfpm_settings']['limit_extensions']['description'],
 						'type' => 'text',
 						'value' => '.php'
+					),
+					'custom_config' => array(
+						'label' => $lng['serversettings']['phpfpm_settings']['custom_config']['title'],
+						'desc' => $lng['serversettings']['phpfpm_settings']['custom_config']['description'],
+						'type' => 'textarea',
+						'cols' => 50,
+						'rows' => 7
 					)
 				)
 			)

--- a/lib/formfields/admin/phpconfig/formfield.fpmconfig_edit.php
+++ b/lib/formfields/admin/phpconfig/formfield.fpmconfig_edit.php
@@ -87,6 +87,14 @@ return array(
 						'desc' => $lng['serversettings']['phpfpm_settings']['limit_extensions']['description'],
 						'type' => 'text',
 						'value' => $result['limit_extensions']
+					),
+					'custom_config' => array(
+						'label' => $lng['serversettings']['phpfpm_settings']['custom_config']['title'],
+						'desc' => $lng['serversettings']['phpfpm_settings']['custom_config']['description'],
+						'type' => 'textarea',
+						'cols' => 50,
+						'rows' => 7,
+						'value' => $result['custom_config']
 					)
 				)
 			)

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2085,3 +2085,6 @@ $lng['serversettings']['apply_phpconfigs_default']['title'] = 'Default value for
 $lng['admin']['domain_sslenabled'] = 'Enable usage of SSL';
 $lng['admin']['domain_honorcipherorder'] = 'Honor the (server) cipher order, default <strong>no</strong>';
 $lng['admin']['domain_sessiontickets'] = 'Enable TLS sessiontickets (RFC 5077), default <strong>yes</strong>';
+
+$lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Custom Configuration';
+$lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Add custom configuration to each PHP-FPM version instance, for example <i>pm.status_path = /status</i> for monitoring. Variables below can be used here.';

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2086,5 +2086,6 @@ $lng['admin']['domain_sslenabled'] = 'Enable usage of SSL';
 $lng['admin']['domain_honorcipherorder'] = 'Honor the (server) cipher order, default <strong>no</strong>';
 $lng['admin']['domain_sessiontickets'] = 'Enable TLS sessiontickets (RFC 5077), default <strong>yes</strong>';
 
-$lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Custom Configuration';
-$lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Add custom configuration to each PHP-FPM version instance, for example <i>pm.status_path = /status</i> for monitoring. Variables below can be used here.';
+$lng['serversettings']['phpfpm_settings']['restart_note'] = 'Attention: The config won\'t be checked for any errors. If it contains errors, PHP-FPM might not start again!';
+$lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Custom configuration';
+$lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Add custom configuration to each PHP-FPM version instance, for example <i>pm.status_path = /status</i> for monitoring. Variables below can be used here. ' . ' <strong>' . $lng['serversettings']['phpfpm_settings']['restart_note'] . '</strong>';

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2086,9 +2086,9 @@ $lng['admin']['domain_sslenabled'] = 'Enable usage of SSL';
 $lng['admin']['domain_honorcipherorder'] = 'Honor the (server) cipher order, default <strong>no</strong>';
 $lng['admin']['domain_sessiontickets'] = 'Enable TLS sessiontickets (RFC 5077), default <strong>yes</strong>';
 
+$lng['admin']['domain_sessionticketsenabled']['title'] = 'Enable usage of TLS sessiontickets globally';
+$lng['admin']['domain_sessionticketsenabled']['description'] = 'Default <strong>yes</strong><br>Requires apache-2.4.11+ or nginx-1.5.9+';
+
 $lng['serversettings']['phpfpm_settings']['restart_note'] = 'Attention: The config won\'t be checked for any errors. If it contains errors, PHP-FPM might not start again!';
 $lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Custom configuration';
 $lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Add custom configuration to each PHP-FPM version instance, for example <i>pm.status_path = /status</i> for monitoring. Variables below can be used here. ' . ' <strong>' . $lng['serversettings']['phpfpm_settings']['restart_note'] . '</strong>';
-
-$lng['admin']['domain_sessionticketsenabled']['title'] = 'Enable usage of TLS sessiontickets globally';
-$lng['admin']['domain_sessionticketsenabled']['description'] = 'Default <strong>yes</strong><br>Requires apache-2.4.11+ or nginx-1.5.9+';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1733,9 +1733,9 @@ $lng['admin']['domain_sslenabled'] = 'Aktiviere Nutzung von SSL';
 $lng['admin']['domain_honorcipherorder'] = 'Bevorzuge die serverseitige Cipher Reihenfolge, Standardwert <strong>nein</strong>';
 $lng['admin']['domain_sessiontickets'] = 'Aktiviere TLS Sessiontickets (RFC 5077), Standardwert <strong>ja</strong>';
 
+$lng['admin']['domain_sessionticketsenabled']['title'] = 'Aktiviere Nutzung von TLS Sessiontickets systemweit';
+$lng['admin']['domain_sessionticketsenabled']['description'] = 'Standardwert <strong>yes</strong><br>Erfordert apache-2.4.11+ oder nginx-1.5.9+';
+
 $lng['serversettings']['phpfpm_settings']['restart_note'] = 'Achtung: Der Code wird nicht auf Fehler geprüft. Etwaige Fehler werden also auch übernommen. Der Webserver könnte nicht mehr starten!';
 $lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Benutzerdefinierte Konfiguration';
 $lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Füge eine benutzerdefinierte Einstellungen zur PHP-FPM Instanz hinzu, beispielsweise <i>pm.status_path = /status</i> für Monitoring. Unten ersichtliche Variablen können verwendet werden.' . ' <strong>' . $lng['serversettings']['phpfpm_settings']['restart_note'] . '</strong>';
-
-$lng['admin']['domain_sessionticketsenabled']['title'] = 'Aktiviere Nutzung von TLS Sessiontickets systemweit';
-$lng['admin']['domain_sessionticketsenabled']['description'] = 'Standardwert <strong>yes</strong><br>Erfordert apache-2.4.11+ oder nginx-1.5.9+';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1732,3 +1732,6 @@ $lng['serversettings']['apply_phpconfigs_default']['title'] = 'Standardwert für
 $lng['admin']['domain_sslenabled'] = 'Aktiviere Nutzung von SSL';
 $lng['admin']['domain_honorcipherorder'] = 'Bevorzuge die serverseitige Cipher Reihenfolge, Standardwert <strong>nein</strong>';
 $lng['admin']['domain_sessiontickets'] = 'Aktiviere TLS Sessiontickets (RFC 5077), Standardwert <strong>ja</strong>';
+
+$lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Benutzerdefinierte Konfiguration';
+$lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Füge eine benutzerdefinierte Einstellungen zur PHP-FPM Instanz hinzu, beispielsweise <i>pm.status_path = /status</i> für Monitoring. Unten ersichtliche Variablen können verwendet werden.';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1733,5 +1733,6 @@ $lng['admin']['domain_sslenabled'] = 'Aktiviere Nutzung von SSL';
 $lng['admin']['domain_honorcipherorder'] = 'Bevorzuge die serverseitige Cipher Reihenfolge, Standardwert <strong>nein</strong>';
 $lng['admin']['domain_sessiontickets'] = 'Aktiviere TLS Sessiontickets (RFC 5077), Standardwert <strong>ja</strong>';
 
+$lng['serversettings']['phpfpm_settings']['restart_note'] = 'Achtung: Der Code wird nicht auf Fehler geprüft. Etwaige Fehler werden also auch übernommen. Der Webserver könnte nicht mehr starten!';
 $lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Benutzerdefinierte Konfiguration';
-$lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Füge eine benutzerdefinierte Einstellungen zur PHP-FPM Instanz hinzu, beispielsweise <i>pm.status_path = /status</i> für Monitoring. Unten ersichtliche Variablen können verwendet werden.';
+$lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Füge eine benutzerdefinierte Einstellungen zur PHP-FPM Instanz hinzu, beispielsweise <i>pm.status_path = /status</i> für Monitoring. Unten ersichtliche Variablen können verwendet werden.' . ' <strong>' . $lng['serversettings']['phpfpm_settings']['restart_note'] . '</strong>';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1736,6 +1736,6 @@ $lng['admin']['domain_sessiontickets'] = 'Aktiviere TLS Sessiontickets (RFC 5077
 $lng['admin']['domain_sessionticketsenabled']['title'] = 'Aktiviere Nutzung von TLS Sessiontickets systemweit';
 $lng['admin']['domain_sessionticketsenabled']['description'] = 'Standardwert <strong>yes</strong><br>Erfordert apache-2.4.11+ oder nginx-1.5.9+';
 
-$lng['serversettings']['phpfpm_settings']['restart_note'] = 'Achtung: Der Code wird nicht auf Fehler geprüft. Etwaige Fehler werden also auch übernommen. Der Webserver könnte nicht mehr starten!';
+$lng['serversettings']['phpfpm_settings']['restart_note'] = 'Achtung: Der Code wird nicht auf Fehler geprüft. Bei etwaigen Fehlern könnte der PHP-FPM-Prozess nicht mehr starten!';
 $lng['serversettings']['phpfpm_settings']['custom_config']['title'] = 'Benutzerdefinierte Konfiguration';
 $lng['serversettings']['phpfpm_settings']['custom_config']['description'] = 'Füge eine benutzerdefinierte Einstellungen zur PHP-FPM Instanz hinzu, beispielsweise <i>pm.status_path = /status</i> für Monitoring. Unten ersichtliche Variablen können verwendet werden.' . ' <strong>' . $lng['serversettings']['phpfpm_settings']['restart_note'] . '</strong>';

--- a/templates/Sparkle/admin/phpconfig/fpmconfig_add.tpl
+++ b/templates/Sparkle/admin/phpconfig/fpmconfig_add.tpl
@@ -21,4 +21,78 @@ $header
 			</form>
 		</section>
 	</article>
+
+	<br />
+	<article>
+		<header>
+			<h3>
+				{$lng['admin']['templates']['template_replace_vars']}
+			</h3>
+		</header>
+		
+		<section>
+			
+			<table class="full">
+			<thead>
+				<tr>
+					<th>{$lng['panel']['variable']}</th>
+					<th>{$lng['panel']['description']}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><em>{PEAR_DIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['pear_dir']}</td>
+				</tr>
+				<tr>
+					<td><em>{OPEN_BASEDIR_C}</em></td>
+					<td>{$lng['admin']['phpconfig']['open_basedir_c']}</td>
+				</tr>
+				<tr>
+					<td><em>{OPEN_BASEDIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['open_basedir']}</td>
+				</tr>
+				<tr>
+					<td><em>{OPEN_BASEDIR_GLOBAL}</em></td>
+					<td>{$lng['admin']['phpconfig']['open_basedir_global']}</td>
+				</tr>
+				<tr>
+					<td><em>{TMP_DIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['tmp_dir']}</td>
+				</tr>
+				<tr>
+					<td><em>{CUSTOMER_EMAIL}</em></td>
+					<td>{$lng['admin']['phpconfig']['customer_email']}</td>
+				</tr>
+				<tr>
+					<td><em>{ADMIN_EMAIL}</em></td>
+					<td>{$lng['admin']['phpconfig']['admin_email']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOMAIN}</em></td>
+					<td>{$lng['admin']['phpconfig']['domain']}</td>
+				</tr>
+				<tr>
+					<td><em>{CUSTOMER}</em></td>
+					<td>{$lng['admin']['phpconfig']['customer']}</td>
+				</tr>
+				<tr>
+					<td><em>{ADMIN}</em></td>
+					<td>{$lng['admin']['phpconfig']['admin']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOCUMENT_ROOT}</em></td>
+					<td>{$lng['admin']['phpconfig']['docroot']}</td>
+				</tr>
+				<tr>
+					<td><em>{CUSTOMER_HOMEDIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['homedir']}</td>
+				</tr>
+			</tbody>
+			</table>
+
+		</section>
+
+	</article>
+
 $footer

--- a/templates/Sparkle/admin/phpconfig/fpmconfig_edit.tpl
+++ b/templates/Sparkle/admin/phpconfig/fpmconfig_edit.tpl
@@ -22,4 +22,78 @@ $header
 			</form>
 		</section>
 	</article>
+
+	<br />
+	<article>
+		<header>
+			<h3>
+				{$lng['admin']['templates']['template_replace_vars']}
+			</h3>
+		</header>
+		
+		<section>
+			
+			<table class="full">
+			<thead>
+				<tr>
+					<th>{$lng['panel']['variable']}</th>
+					<th>{$lng['panel']['description']}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><em>{PEAR_DIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['pear_dir']}</td>
+				</tr>
+				<tr>
+					<td><em>{OPEN_BASEDIR_C}</em></td>
+					<td>{$lng['admin']['phpconfig']['open_basedir_c']}</td>
+				</tr>
+				<tr>
+					<td><em>{OPEN_BASEDIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['open_basedir']}</td>
+				</tr>
+				<tr>
+					<td><em>{OPEN_BASEDIR_GLOBAL}</em></td>
+					<td>{$lng['admin']['phpconfig']['open_basedir_global']}</td>
+				</tr>
+				<tr>
+					<td><em>{TMP_DIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['tmp_dir']}</td>
+				</tr>
+				<tr>
+					<td><em>{CUSTOMER_EMAIL}</em></td>
+					<td>{$lng['admin']['phpconfig']['customer_email']}</td>
+				</tr>
+				<tr>
+					<td><em>{ADMIN_EMAIL}</em></td>
+					<td>{$lng['admin']['phpconfig']['admin_email']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOMAIN}</em></td>
+					<td>{$lng['admin']['phpconfig']['domain']}</td>
+				</tr>
+				<tr>
+					<td><em>{CUSTOMER}</em></td>
+					<td>{$lng['admin']['phpconfig']['customer']}</td>
+				</tr>
+				<tr>
+					<td><em>{ADMIN}</em></td>
+					<td>{$lng['admin']['phpconfig']['admin']}</td>
+				</tr>
+				<tr>
+					<td><em>{DOCUMENT_ROOT}</em></td>
+					<td>{$lng['admin']['phpconfig']['docroot']}</td>
+				</tr>
+				<tr>
+					<td><em>{CUSTOMER_HOMEDIR}</em></td>
+					<td>{$lng['admin']['phpconfig']['homedir']}</td>
+				</tr>
+			</tbody>
+			</table>
+
+		</section>
+
+	</article>
+
 $footer


### PR DESCRIPTION
# Description

Adds the ability to append custom configuration to PHPFPM pool configuration:
![image](https://user-images.githubusercontent.com/2029878/71610482-b11de480-2b91-11ea-8a24-d5066bc5d026.png)

Addresses #643

## Type of change
 
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Tested on Froxlor 0.10.10 installation
- [X] Also tested variables and checked if configs written correctly

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings