### PR TITLE
Fixed the case that the spf record is not inserted with it's quotes, …

### DIFF
--- a/lib/Froxlor/Dns/Dns.php
+++ b/lib/Froxlor/Dns/Dns.php
@@ -160,7 +160,7 @@ class Dns
 				// unset special CAA required-entry
 				unset($required_entries[$entry['type']][md5("@CAA@")]);
 			}
-			if (Settings::Get('spf.use_spf') == '1' && $entry['type'] == 'TXT' && $entry['record'] == '@' && strtolower(substr($entry['content'], 0, 7)) == '"v=spf1') {
+			if (Settings::Get('spf.use_spf') == '1' && $entry['type'] == 'TXT' && $entry['record'] == '@' && (strtolower(substr($entry['content'], 0, 7)) == '"v=spf1' || strtolower(substr($entry['content'], 0, 6)) == 'v=spf1') ) {
 				// unset special spf required-entry
 				unset($required_entries[$entry['type']][md5("@SPF@")]);
 			}


### PR DESCRIPTION
…and so the condition fails and 2 spf records are inserted in the domain

# Description
Whe adding manual dns records, specifically an spf record, the ["content"] key of the array contains the spf record without the quotes, and so the condition fails, leaving the default spf record alongside the newly created one

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a custom spf record, and checked the default record was removed
Deleted the custom spf record, and checked that the default record was there again

**Test Configuration**:

* Distribution: Ubuntu 18.04
* Webserver: Apache 2.4
* PHP: 7.2 fpm
* DNS daemon: PowerDNS
