### PR TITLE
fixed parsing due to changes in dovecots default mail_log_prefix

### DIFF
--- a/lib/Froxlor/MailLogParser.php
+++ b/lib/Froxlor/MailLogParser.php
@@ -209,12 +209,12 @@ class MailLogParser
 
 			$timestamp = $this->getLogTimestamp($line);
 			if ($this->startTime < $timestamp) {
-				if (preg_match("/dovecot.*(?::|\]) imap\(.*@([a-z0-9\.\-]+)\):.*(?:in=(\d+) out=(\d+)|bytes=(\d+)\/(\d+))/i", $line, $matches)) {
+				if (preg_match("/dovecot.*(?::|\]) imap\(.*@([a-z0-9\.\-]+)\)(<\d+><[a-z0-9+\/=]+>)?:.*(?:in=(\d+) out=(\d+)|bytes=(\d+)\/(\d+))/i", $line, $matches)) {
 					// Dovecot IMAP
-					$this->addDomainTraffic($matches[1], (int) $matches[2] + (int) $matches[3], $timestamp);
-				} elseif (preg_match("/dovecot.*(?::|\]) pop3\(.*@([a-z0-9\.\-]+)\):.*in=(\d+).*out=(\d+)/i", $line, $matches)) {
+					$this->addDomainTraffic($matches[1], (int) $matches[3] + (int) $matches[4], $timestamp);
+				} elseif (preg_match("/dovecot.*(?::|\]) pop3\(.*@([a-z0-9\.\-]+)\)(<\d+><[a-z0-9+\/=]+>)?:.*in=(\d+).*out=(\d+)/i", $line, $matches)) {
 					// Dovecot POP3
-					$this->addDomainTraffic($matches[1], (int) $matches[2] + (int) $matches[3], $timestamp);
+					$this->addDomainTraffic($matches[1], (int) $matches[3] + (int) $matches[4], $timestamp);
 				}
 			}
 		}


### PR DESCRIPTION
Fixed parsing due to changes in dovecots default mail_log_prefix since version 2.3
Regex supports old and new default format now
See https://wiki2.dovecot.org/Upgrading/2.3 for changes in mail_log_prefix default settings

# Description

Dovecot traffic was not counted anymore, since dovecot changed the default log prefix

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)