### PR TITLE
Fix renewal of ECC/ECDSA certificates.

### DIFF
--- a/lib/Froxlor/Cron/Http/LetsEncrypt/AcmeSh.php
+++ b/lib/Froxlor/Cron/Http/LetsEncrypt/AcmeSh.php
@@ -327,6 +327,9 @@ class AcmeSh extends \Froxlor\Cron\FroxlorCron
 			}
 			if (Settings::Get('system.leecc') > 0) {
 				$acmesh_cmd .= " --keylength ec-" . Settings::Get('system.leecc');
+				if ($cert_mode != 'issue') {
+					$acmesh_cmd .= " --ecc";
+				}
 			} else {
 				$acmesh_cmd .= " --keylength " . Settings::Get('system.letsencryptkeysize');
 			}


### PR DESCRIPTION
# Description

The ACME v2 implementation uses separate directoies for ECC and on-ECC
certificates. The renew command for a domain checks if an ECC directory
exists (having a "_ecc" suffix) and refuses the command unless the
"--ecc" flag was specified.

Confusingly, this flag is only required to *renew* an ECC certificate,
but not to issue it.

Fixes https://github.com/Froxlor/Froxlor/issues/820.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] I ran the cronjob which successfully renewed my previously expired ECC certificates.

**Test Configuration**:

* Distribution: Debian GNU/Linux 10 (buster)
* Web server: apache2
* ACME: 2.8.6

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
