### PR TITLE
Sensible default for domain alias

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -291,7 +291,7 @@ if ($page == 'domains' || $page == 'overview') {
 			// create serveralias options
 			$serveraliasoptions = "";
 			$serveraliasoptions .= \Froxlor\UI\HTML::makeoption($lng['domains']['serveraliasoption_wildcard'], '0', '0', true, true);
-			$serveraliasoptions .= \Froxlor\UI\HTML::makeoption($lng['domains']['serveraliasoption_www'], '1', '0', true, true);
+			$serveraliasoptions .= \Froxlor\UI\HTML::makeoption($lng['domains']['serveraliasoption_www'], '1', '1', true, true);
 			$serveraliasoptions .= \Froxlor\UI\HTML::makeoption($lng['domains']['serveraliasoption_none'], '2', '0', true, true);
 
 			$subcanemaildomain = \Froxlor\UI\HTML::makeoption($lng['admin']['subcanemaildomain']['never'], '0', '0', true, true);


### PR DESCRIPTION
I believe in 99% of cases www alias is what people want. At the moment the default selection is wildcard, if overlooked by admin it often creates a problem with Letsencrypt certificate issuance.