### PR TITLE
TLSv1 is deprecated

### DIFF
--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -265,7 +265,6 @@ return array(
 						'desc' => $lng['serversettings']['ssl']['ssl_protocols']['description'],
 						'type' => 'checkbox',
 						'value' => array(
-							'TLSv1',
 							'TLSv1.2'
 						),
 						'values' => array(


### PR DESCRIPTION
TLSv1 is deprecated, I believe it should not be enabled for new domains by default. Will be great to enable TLSv1.3 by default but it might be not available on the older distributions.