### PR TITLE
Don't suggest php5 during update as default

### DIFF
--- a/install/updates/preconfig/0.9/preconfig_0.9.inc.php
+++ b/install/updates/preconfig/0.9/preconfig_0.9.inc.php
@@ -600,8 +600,8 @@ function parseAndOutputPreconfig(&$has_preconfig, &$return, $current_version, $c
 	if (versionInUpdate($current_version, '0.9.32-rc2')) {
 		$has_preconfig = true;
 		$description = 'To customize the command which executes the cronjob (php - basically) change the path below according to your system.<br /><br />';
-		$question = '<strong>Please specify the command to execute cronscripts</strong> (default: "/usr/bin/nice -n 5 /usr/bin/php5 -q")<br />';
-		$question .= '<input type="text" class="text" name="croncmdline" value="/usr/bin/nice -n 5 /usr/bin/php5 -q" /><br />';
+		$question = '<strong>Please specify the command to execute cronscripts</strong> (default: "/usr/bin/nice -n 5 /usr/bin/php -q")<br />';
+		$question .= '<input type="text" class="text" name="croncmdline" value="/usr/bin/nice -n 5 /usr/bin/php -q" /><br />';
 		eval("\$return.=\"" . \Froxlor\UI\Template::getTemplate("update/preconfigitem") . "\";");
 	}
 


### PR DESCRIPTION
# Description

During update there is a default suggestion of php5, which is not needed, usually `/etc/alternatives/php` points to the right installed php version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

untested

