### PR TITLE
proftp requires epel, awstats needs install and awstats cron moved

### DIFF
--- a/lib/configfiles/centos7.xml
+++ b/lib/configfiles/centos7.xml
@@ -1871,6 +1871,7 @@ iterate_query = SELECT username AS user FROM mail_users
 				<!-- Proftpd -->
 				<daemon name="proftpd" version="1.3" title="ProFTPd"
 					default="true">
+          <install><![CDATA[yum --enablerepo=extras install epel-release]]></install>
 					<install><![CDATA[yum install proftpd proftpd-mysql]]></install>
 					<file name="/etc/proftpd.conf" chown="root:0"
 						chmod="0600" backup="true">
@@ -2341,9 +2342,10 @@ ControlsLog			/var/log/proftpd/controls.log
 				<!-- AWstats -->
 				<daemon name="awstats"
 					title="Awstats (webalizer alternative)">
+          <install><![CDATA[yum install awstats]]></install>
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
-					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/cron.hourly/awstats]]></command>
 				</daemon>
 				<!-- libnss-mysql -->
 				<daemon name="libnss"


### PR DESCRIPTION
# Description
    proftpd requires epel repository to be enabled first
    missing create directory for http passwd files
    awstats cron file is placed in a different directory

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Tested installation on clean minimal install centos 7 machine

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

