### PR TITLE
Data integrity - remove default values from some columns

### DIFF
--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -15,10 +15,10 @@ CREATE TABLE `ftp_groups` (
 DROP TABLE IF EXISTS `ftp_users`;
 CREATE TABLE `ftp_users` (
   `id` int(20) NOT NULL auto_increment,
-  `username` varchar(255) NOT NULL default '',
+  `username` varchar(255) NOT NULL,
   `uid` int(5) NOT NULL default '0',
   `gid` int(5) NOT NULL default '0',
-  `password` varchar(128) NOT NULL default '',
+  `password` varchar(128) NOT NULL,
   `homedir` varchar(255) NOT NULL default '',
   `shell` varchar(255) NOT NULL default '/bin/false',
   `login_enabled` enum('N','Y') NOT NULL default 'N',
@@ -90,8 +90,8 @@ CREATE TABLE `panel_activation` (
 DROP TABLE IF EXISTS `panel_admins`;
 CREATE TABLE `panel_admins` (
   `adminid` int(11) unsigned NOT NULL auto_increment,
-  `loginname` varchar(50) NOT NULL default '',
-  `password` varchar(255) NOT NULL default '',
+  `loginname` varchar(50) NOT NULL,
+  `password` varchar(255) NOT NULL,
   `name` varchar(255) NOT NULL default '',
   `email` varchar(255) NOT NULL default '',
   `def_language` varchar(100) NOT NULL default '',
@@ -142,7 +142,7 @@ CREATE TABLE `panel_admins` (
 DROP TABLE IF EXISTS `panel_customers`;
 CREATE TABLE `panel_customers` (
   `customerid` int(11) unsigned NOT NULL auto_increment,
-  `loginname` varchar(50) NOT NULL default '',
+  `loginname` varchar(50) NOT NULL,
   `password` varchar(255) NOT NULL default '',
   `adminid` int(11) unsigned NOT NULL default '0',
   `name` varchar(255) NOT NULL default '',
@@ -223,7 +223,7 @@ CREATE TABLE `panel_databases` (
 DROP TABLE IF EXISTS `panel_domains`;
 CREATE TABLE `panel_domains` (
   `id` int(11) unsigned NOT NULL auto_increment,
-  `domain` varchar(255) NOT NULL default '',
+  `domain` varchar(255) NOT NULL,
   `domain_ace` varchar(255) NOT NULL default '',
   `adminid` int(11) unsigned NOT NULL default '0',
   `customerid` int(11) unsigned NOT NULL default '0',
@@ -286,7 +286,7 @@ CREATE TABLE `panel_domains` (
 DROP TABLE IF EXISTS `panel_ipsandports`;
 CREATE TABLE `panel_ipsandports` (
   `id` int(11) unsigned NOT NULL auto_increment,
-  `ip` varchar(39) NOT NULL default '',
+  `ip` varchar(39) NOT NULL,
   `port` int(5) NOT NULL default '80',
   `listen_statement` tinyint(1) NOT NULL default '0',
   `namevirtualhost_statement` tinyint(1) NOT NULL default '0',


### PR DESCRIPTION
Data integrity - under no circumstances the empty string is a valid value for these columns.
Probably not worth it to remove these default values from existing DBs.
