### PR TITLE
[WIP] Extract mail log parsers into dedicated handler classes

### DIFF
--- a/lib/Froxlor/Cron/Traffic/Mail/AbstractLogHandler.php
+++ b/lib/Froxlor/Cron/Traffic/Mail/AbstractLogHandler.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Froxlor\Cron\Traffic\Mail;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
+
+abstract class AbstractLogHandler
+{
+	/**
+	 * @var TrafficSink
+	 */
+	private $sink;
+
+	/**
+	 * Marker for calculating when a log line originates from last year.
+	 *
+	 * @var DateTimeInterface
+	 */
+	private $tomorrow;
+
+	/**
+	 * Create a new instance.
+	 *
+	 * @param TrafficSink $sink
+	 */
+	public function __construct(TrafficSink $sink, DateTimeInterface $tomorrow)
+	{
+		$this->sink     = $sink;
+		$this->tomorrow = new DateTimeImmutable($tomorrow->format('Y-m-d') . ' 23:59:59.999999');
+	}
+
+	/**
+	 * Parse a log file.
+	 *
+	 * @param string $logFile The absolute path to the log.
+	 *
+	 * @return void
+	 *
+	 * @throws \Exception When the file can not be opened.
+	 */
+	public function handleFile(string $logFile)
+	{
+		// Check if file exists
+		if (! file_exists($logFile)) {
+			return;
+		}
+		// Open the log file
+		$file_handle = fopen($logFile, 'rb');
+		if (! $file_handle) {
+			throw new \Exception('Could not open file ' . $logFile);
+		}
+
+		try {
+			while (!feof($file_handle)) {
+				if (false === $line = fgets($file_handle)) {
+					return;
+				}
+				try {
+					$timestamp = $this->getLogTimestamp($line);
+				} catch (InvalidArgumentException $exception) {
+					// Failed to extract timestamp from log.
+					// FIXME: add warning here?
+					return;
+				}
+
+				// Newer than last run, must have been already processed during last run then.
+				if (!$this->sink->acceptsTime($timestamp)) {
+					return;
+				}
+
+				$this->handle($timestamp, $line);
+			}
+		} finally {
+			fclose($file_handle);
+		}
+	}
+
+	/**
+	 * Process a single log line.
+	 *
+	 * @param DateTimeInterface $timestamp The timestamp the log line was produced at.
+	 * @param string            $line      The line to process.
+	 *
+	 * @return void
+	 */
+	abstract public function handle(DateTimeInterface $timestamp, string $line);
+
+	/**
+	 * Add traffic for a given domain.
+	 *
+	 * @param string            $domain    The domain to record the traffic for.
+	 * @param int               $traffic   The amount of bytes to record.
+	 * @param DateTimeInterface $timestamp The timestamp the traffic was produced.
+	 *
+	 * @return void
+	 */
+	protected function addDomainTraffic(string $domain, int $traffic, DateTimeInterface $timestamp)
+	{
+		$this->sink->addDomainTraffic($domain, $traffic, $timestamp);
+	}
+
+	/**
+	 * Convert a date time string to a DateTimeInterface.
+	 *
+	 * If the date is in the future, we move it to the last year.
+	 */
+	protected function getLogTimestamp(string &$line): DateTimeInterface
+	{
+		$matches = null;
+		if (preg_match('/^((?:[A-Z]{3}\s{1,2}\d{1,2}|\d{4}-\d{2}-\d{2}) \d{2}:\d{2}:\d{2})/i', $line, $matches)) {
+			$timestamp = new DateTimeImmutable($matches[1]);
+			// If timestamp is in future, we encountered a year skip between last run and this run - let's compensate.
+			if ($timestamp > $this->tomorrow) {
+				return $timestamp->modify('-1 year');
+			}
+			return $timestamp;
+		}
+
+		throw new InvalidArgumentException('Could not extract date from: ' . $line);
+	}
+}

--- a/lib/Froxlor/Cron/Traffic/Mail/CourierLogHandler.php
+++ b/lib/Froxlor/Cron/Traffic/Mail/CourierLogHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Froxlor\Cron\Traffic\Mail;
+
+use DateTimeInterface;
+
+/**
+ * Parses the courier imap/pop3 traffic from logfile.
+ */
+final class CourierLogHandler extends AbstractLogHandler
+{
+	public function handle(DateTimeInterface $timestamp, string $line)
+	{
+		// IMAP & POP3
+		if (preg_match('/(?:imapd|pop3d)(?:-ssl)?.*[:\]].*user=.*@([a-z0-9.\-]+),.*rcvd=(\d+), sent=(\d+),/i', $line, $matches)) {
+			$this->addDomainTraffic($matches[1], (int) $matches[2] + (int) $matches[3], $timestamp);
+		}
+	}
+}

--- a/lib/Froxlor/Cron/Traffic/Mail/DovecotLogHandler.php
+++ b/lib/Froxlor/Cron/Traffic/Mail/DovecotLogHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Froxlor\Cron\Traffic\Mail;
+
+use DateTimeInterface;
+
+/**
+ * Parses the dovecot imap/pop3 traffic from logfile.
+ */
+final class DovecotLogHandler extends AbstractLogHandler
+{
+	public function handle(DateTimeInterface $timestamp, string $line)
+	{
+		// IMAP
+		if (preg_match('/dovecot.*[:\]] imap\(.*@([a-z0-9.\-]+)\)(?:<\d+><[a-z0-9+\/=]+>)?:.*(?:in=(\d+) out=(\d+)|bytes=(\d+)\/(\d+))/i', $line, $matches)) {
+			$this->addDomainTraffic($matches[1], (int) $matches[2] + (int) $matches[3], $timestamp);
+
+			return;
+		}
+
+		// POP3
+		if (preg_match('/dovecot.*[:\]] pop3\(.*@([a-z0-9.\-]+)\)(?:<\d+><[a-z0-9+\/=]+>)?:.*in=(\d+).*out=(\d+)/i', $line, $matches)) {
+			$this->addDomainTraffic($matches[1], (int) $matches[2] + (int) $matches[3], $timestamp);
+		}
+	}
+}

--- a/lib/Froxlor/Cron/Traffic/Mail/Exim4LogHandler.php
+++ b/lib/Froxlor/Cron/Traffic/Mail/Exim4LogHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Froxlor\Cron\Traffic\Mail;
+
+use DateTimeInterface;
+
+/**
+ * Parses exim 4 smtp log file lines.
+ */
+final class Exim4LogHandler extends AbstractLogHandler
+{
+	public function handle(DateTimeInterface $timestamp, string $line)
+	{
+		// Outgoing traffic
+		if (preg_match('/<= .*@([a-z0-9.\-]+) .*S=(\d+)/i', $line, $matches)) {
+			$this->addDomainTraffic($matches[1], $matches[2], $timestamp);
+			return;
+		}
+		// Incoming traffic
+		if (preg_match('/=> .*<?.*@([a-z0-9.\-]+)>? .*S=(\d+)/i', $line, $matches)) {
+			$this->addDomainTraffic($matches[1], $matches[2], $timestamp);
+		}
+	}
+}

--- a/lib/Froxlor/Cron/Traffic/Mail/PostfixLogHandler.php
+++ b/lib/Froxlor/Cron/Traffic/Mail/PostfixLogHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Froxlor\Cron\Traffic\Mail;
+
+use DateTimeInterface;
+
+/**
+ * Parses postfix log file lines.
+ *
+ * This implementation counts incoming traffic and outgoing traffic and adds them to the traffic sink.
+ * The domain filtering is performed within the sink.
+ */
+final class PostfixLogHandler extends AbstractLogHandler
+{
+	/**
+	 * @var string[][]
+	 */
+	private $mails = [];
+
+	public function handle(DateTimeInterface $timestamp, string $line)
+	{
+		if (preg_match('/postfix\/qmgr.*[:\]]\s([A-Z\d]+).*from=<?(?:.*@([a-zA-Z\d.\-]+))?>?, size=(\d+),/', $line, $matches)) {
+			// from
+			$this->mails[$matches[1]] = array(
+				'domainFrom' => strtolower($matches[2]),
+				'size' => $matches[3]
+			);
+
+			return;
+		}
+
+		if (preg_match('/postfix\/(?:pipe|smtp).*[:\]]\s([A-Z\d]+).*to=<?(?:.*@([a-zA-Z\d.\-]+))?>?,/', $line, $matches)) {
+			// to
+			if (array_key_exists($matches[1], $this->mails)) {
+				$this->mails[$matches[1]]['domainTo'] = strtolower($matches[2]);
+
+				// Only mails from/to outside the system should be added
+				$mail = $this->mails[$matches[1]];
+				// Outgoing traffic
+				$this->addDomainTraffic($mail['domainFrom'], $mail['size'], $timestamp);
+				// Incoming traffic
+				$this->addDomainTraffic($mail['domainTo'], $mail['size'], $timestamp);
+
+				unset($mail);
+			}
+		}
+	}
+}

--- a/lib/Froxlor/Cron/Traffic/Mail/TrafficSink.php
+++ b/lib/Froxlor/Cron/Traffic/Mail/TrafficSink.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Froxlor\Cron\Traffic\Mail;
+
+use DateTimeInterface;
+
+class TrafficSink
+{
+	/**
+	 * List of domains.
+	 *
+	 * @var string[]
+	 */
+	private $myDomains;
+
+	/**
+	 * @var int[][]
+	 */
+	private $domainTraffic = [];
+
+	/**
+	 * @var DateTimeInterface
+	 */
+	private $lastRun;
+
+	/**
+	 * Create a new instance.
+	 *
+	 * @param string[]          $myDomains The known domains.
+	 * @param DateTimeInterface $lastRun   The time stamp of the last run - any date older than this is ignored.
+	 */
+	public function __construct(array $myDomains, DateTimeInterface $lastRun)
+	{
+		$this->myDomains = $myDomains;
+		$this->lastRun   = $lastRun;
+	}
+
+	public function acceptsTime(DateTimeInterface $timestamp): bool
+	{
+		return $timestamp >= $this->lastRun;
+	}
+
+	/**
+	 * Adds the traffic to the domain array if we own the domain.
+	 */
+	public function addDomainTraffic(string $domain, int $traffic, DateTimeInterface $timestamp)
+	{
+		if (!$this->acceptsTime($timestamp) || !in_array($domain, $this->myDomains)) {
+			return;
+		}
+
+		if (!array_key_exists($domain, $this->domainTraffic)) {
+			$this->domainTraffic[$domain] = [];
+		}
+		$date = $timestamp->format('Y-m-d');
+		if (!array_key_exists($date, $this->domainTraffic[$domain])) {
+			$this->domainTraffic[$domain][$date] = 0;
+		}
+
+		$this->domainTraffic[$domain][$date] += $traffic;
+	}
+
+	/**
+	 * Returns an array containing the traffic of a given domain indexed by date or empty array if the domain has no traffic.
+	 *
+	 * @return int[]
+	 */
+	public function getDomainTraffic(string $domain): array
+	{
+		if (array_key_exists($domain, $this->domainTraffic)) {
+			return $this->domainTraffic[$domain];
+		}
+
+		return [];
+	}
+}

--- a/lib/Froxlor/MailLogParser.php
+++ b/lib/Froxlor/MailLogParser.php
@@ -1,35 +1,29 @@
 <?php
 namespace Froxlor;
 
+use DateTimeImmutable;
+use Froxlor\Cron\Traffic\Mail\AbstractLogHandler;
+use Froxlor\Cron\Traffic\Mail\CourierLogHandler;
+use Froxlor\Cron\Traffic\Mail\DovecotLogHandler;
+use Froxlor\Cron\Traffic\Mail\Exim4LogHandler;
+use Froxlor\Cron\Traffic\Mail\PostfixLogHandler;
+use Froxlor\Cron\Traffic\Mail\TrafficSink;
 use Froxlor\Database\Database;
+use InvalidArgumentException;
 
-/**
- * This file is part of the Froxlor project.
- * Copyright (c) 2010 the Froxlor Team (see authors).
- *
- * For the full copyright and license information, please view the COPYING
- * file that was distributed with this source code. You can also view the
- * COPYING file online at http://files.froxlor.org/misc/COPYING.txt
- *
- * @copyright (c) the authors
- * @author Roman Schmerold <bnoize@froxlor.org>
- * @author Froxlor team <team@froxlor.org> (2010-)
- * @license GPLv2 http://files.froxlor.org/misc/COPYING.txt
- * @package Cron
- *         
- * @since 0.9.32
- *       
- */
 class MailLogParser
 {
+	/**
+	 * @var TrafficSink
+	 */
+	private $sink;
+
+	/**
+	 * @var DateTimeImmutable
+	 */
+	private $tomorrow;
 
 	private $startTime;
-
-	private $domainTraffic = array();
-
-	private $myDomains = array();
-
-	private $mails = array();
 
 	/**
 	 * constructor
@@ -45,268 +39,20 @@ class MailLogParser
 	{
 		$this->startTime = $startTime;
 
-		// Get all domains from Database
-		$stmt = Database::prepare("SELECT domain FROM `" . TABLE_PANEL_DOMAINS . "`");
-		Database::pexecute($stmt, array());
-		while ($domain_row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
-			$this->myDomains[] = $domain_row["domain"];
-		}
+		$this->sink = new TrafficSink($this->getMyDomains(), new DateTimeImmutable('@' . $startTime));
+		$this->tomorrow = new DateTimeImmutable('tomorrow');
 
 		// Parse MTA traffic
-		if (Settings::Get("system.mtaserver") == "postfix") {
-			$this->parsePostfixLog(Settings::Get("system.mtalog"));
-			$this->parsePostfixLog(Settings::Get("system.mtalog") . ".1");
-		} elseif (Settings::Get("system.mtaserver") == "exim4") {
-			$this->parseExim4Log(Settings::Get("system.mtalog"));
-		}
+		$mtaLogFile    = Settings::Get('system.mtalog');
+		$mtaLogHandler = $this->getMtaHandler(Settings::Get('system.mtaserver'));
+		$mtaLogHandler->handleFile($mtaLogFile);
+		$mtaLogHandler->handleFile($mtaLogFile . '.1');
 
 		// Parse MDA traffic
-		if (Settings::Get("system.mdaserver") == "dovecot") {
-			$this->parseDovecotLog(Settings::Get("system.mdalog"));
-			$this->parsePostfixLog(Settings::Get("system.mdalog") . ".1");
-		} elseif (Settings::Get("system.mdaserver") == "courier") {
-			$this->parseCourierLog(Settings::Get("system.mdalog"));
-			$this->parsePostfixLog(Settings::Get("system.mdalog") . ".1");
-		}
-	}
-
-	/**
-	 * parsePostfixLog
-	 * parses the traffic from a postfix logfile
-	 *
-	 * @param string $logFile
-	 *        	logFile
-	 */
-	private function parsePostfixLog($logFile)
-	{
-		// Check if file exists
-		if (! file_exists($logFile)) {
-			return false;
-		}
-
-		// Open the log file
-		try {
-			$file_handle = fopen($logFile, "r");
-			if (! $file_handle) {
-				throw new \Exception("Could not open the file!");
-			}
-		} catch (\Exception $e) {
-			echo "Error (File: " . $e->getFile() . ", line " . $e->getLine() . "): " . $e->getMessage();
-			return false;
-		}
-
-		while (! feof($file_handle)) {
-			unset($matches);
-			$line = fgets($file_handle);
-
-			$timestamp = $this->getLogTimestamp($line);
-			if ($this->startTime < $timestamp) {
-				if (preg_match("/postfix\/qmgr.*(?::|\])\s([A-Z\d]+).*from=<?(?:.*\@([a-zA-Z\d\.\-]+))?>?, size=(\d+),/", $line, $matches)) {
-					// Postfix from
-					$this->mails[$matches[1]] = array(
-						"domainFrom" => strtolower($matches[2]),
-						"size" => $matches[3]
-					);
-				} elseif (preg_match("/postfix\/(?:pipe|smtp).*(?::|\])\s([A-Z\d]+).*to=<?(?:.*\@([a-zA-Z\d\.\-]+))?>?,/", $line, $matches)) {
-					// Postfix to
-					if (array_key_exists($matches[1], $this->mails)) {
-						$this->mails[$matches[1]]["domainTo"] = strtolower($matches[2]);
-
-						// Only mails from/to outside the system should be added
-						$mail = $this->mails[$matches[1]];
-						if (in_array($mail["domainFrom"], $this->myDomains) || in_array($mail["domainTo"], $this->myDomains)) {
-							// Outgoing traffic
-							if (array_key_exists("domainFrom", $mail)) {
-								$this->addDomainTraffic($mail["domainFrom"], $mail["size"], $timestamp);
-							}
-
-							// Incoming traffic
-							if (array_key_exists("domainTo", $mail) && in_array($mail["domainTo"], $this->myDomains)) {
-								$this->addDomainTraffic($mail["domainTo"], $mail["size"], $timestamp);
-							}
-						}
-						unset($mail);
-					}
-				}
-			}
-		}
-		fclose($file_handle);
-		return true;
-	}
-
-	/**
-	 * parseExim4Log
-	 * parses the smtp traffic from a exim4 logfile
-	 *
-	 * @param string $logFile
-	 *        	logFile
-	 */
-	private function parseExim4Log($logFile)
-	{
-		// Check if file exists
-		if (! file_exists($logFile)) {
-			return false;
-		}
-
-		// Open the log file
-		try {
-			$file_handle = fopen($logFile, "r");
-			if (! $file_handle) {
-				throw new \Exception("Could not open the file!");
-			}
-		} catch (\Exception $e) {
-			echo "Error (File: " . $e->getFile() . ", line " . $e->getLine() . "): " . $e->getMessage();
-			return false;
-		}
-
-		while (! feof($file_handle)) {
-			unset($matches);
-			$line = fgets($file_handle);
-
-			$timestamp = $this->getLogTimestamp($line);
-			if ($this->startTime < $timestamp) {
-				if (preg_match("/<= .*@([a-z0-9.\-]+) .*S=(\d+)/i", $line, $matches)) {
-					// Outgoing traffic
-					$this->addDomainTraffic($matches[1], $matches[2], $timestamp);
-				} elseif (preg_match("/=> .*<?.*@([a-z0-9.\-]+)>? .*S=(\d+)/i", $line, $matches)) {
-					// Incoming traffic
-					$this->addDomainTraffic($matches[1], $matches[2], $timestamp);
-				}
-			}
-		}
-		fclose($file_handle);
-		return true;
-	}
-
-	/**
-	 * parseDovecotLog
-	 * parses the dovecot imap/pop3 traffic from logfile
-	 *
-	 * @param string $logFile
-	 *        	logFile
-	 */
-	private function parseDovecotLog($logFile)
-	{
-		// Check if file exists
-		if (! file_exists($logFile)) {
-			return false;
-		}
-
-		// Open the log file
-		try {
-			$file_handle = fopen($logFile, "r");
-			if (! $file_handle) {
-				throw new \Exception("Could not open the file!");
-			}
-		} catch (\Exception $e) {
-			echo "Error (File: " . $e->getFile() . ", line " . $e->getLine() . "): " . $e->getMessage();
-			return false;
-		}
-
-		while (! feof($file_handle)) {
-			unset($matches);
-			$line = fgets($file_handle);
-
-			$timestamp = $this->getLogTimestamp($line);
-			if ($this->startTime < $timestamp) {
-				if (preg_match("/dovecot.*(?::|\]) imap\(.*@([a-z0-9\.\-]+)\)(<\d+><[a-z0-9+\/=]+>)?:.*(?:in=(\d+) out=(\d+)|bytes=(\d+)\/(\d+))/i", $line, $matches)) {
-					// Dovecot IMAP
-					$this->addDomainTraffic($matches[1], (int) $matches[3] + (int) $matches[4], $timestamp);
-				} elseif (preg_match("/dovecot.*(?::|\]) pop3\(.*@([a-z0-9\.\-]+)\)(<\d+><[a-z0-9+\/=]+>)?:.*in=(\d+).*out=(\d+)/i", $line, $matches)) {
-					// Dovecot POP3
-					$this->addDomainTraffic($matches[1], (int) $matches[3] + (int) $matches[4], $timestamp);
-				}
-			}
-		}
-		fclose($file_handle);
-		return true;
-	}
-
-	/**
-	 * parseCourierLog
-	 * parses the dovecot imap/pop3 traffic from logfile
-	 *
-	 * @param string $logFile
-	 *        	logFile
-	 */
-	private function parseCourierLog($logFile)
-	{
-		// Check if file exists
-		if (! file_exists($logFile)) {
-			return false;
-		}
-
-		// Open the log file
-		try {
-			$file_handle = fopen($logFile, "r");
-			if (! $file_handle) {
-				throw new \Exception("Could not open the file!");
-			}
-		} catch (\Exception $e) {
-			echo "Error (File: " . $e->getFile() . ", line " . $e->getLine() . "): " . $e->getMessage();
-			return false;
-		}
-
-		while (! feof($file_handle)) {
-			unset($matches);
-			$line = fgets($file_handle);
-
-			$timestamp = $this->getLogTimestamp($line);
-			if ($this->startTime < $timestamp) {
-				if (preg_match("/(?:imapd|pop3d)(?:-ssl)?.*(?::|\]).*user=.*@([a-z0-9\.\-]+),.*rcvd=(\d+), sent=(\d+),/i", $line, $matches)) {
-					// Courier IMAP & POP3
-					$this->addDomainTraffic($matches[1], (int) $matches[2] + (int) $matches[3], $timestamp);
-				}
-			}
-		}
-		fclose($file_handle);
-		return true;
-	}
-
-	/**
-	 * _addDomainTraffic
-	 * adds the traffic to the domain array if we own the domain
-	 *
-	 * @param
-	 *        	string domain
-	 * @param
-	 *        	int traffic
-	 */
-	private function addDomainTraffic($domain, $traffic, $timestamp)
-	{
-		$date = date("Y-m-d", $timestamp);
-		if (in_array($domain, $this->myDomains)) {
-			if (array_key_exists($domain, $this->domainTraffic) && array_key_exists($date, $this->domainTraffic[$domain])) {
-				$this->domainTraffic[$domain][$date] += (int) $traffic;
-			} else {
-				if (! array_key_exists($domain, $this->domainTraffic)) {
-					$this->domainTraffic[$domain] = array();
-				}
-				$this->domainTraffic[$domain][$date] = (int) $traffic;
-			}
-		}
-	}
-
-	/**
-	 * getLogTimestamp
-	 *
-	 * @param
-	 *        	string line
-	 *        	return int
-	 */
-	private function getLogTimestamp($line)
-	{
-		$matches = null;
-		if (preg_match("/((?:[A-Z]{3}\s{1,2}\d{1,2}|\d{4}-\d{2}-\d{2}) \d{2}:\d{2}:\d{2})/i", $line, $matches)) {
-			$timestamp = strtotime($matches[1]);
-			if ($timestamp > ($this->startTime + 60 * 60 * 24)) {
-				return strtotime($matches[1] . " -1 year");
-			} else {
-				return strtotime($matches[1]);
-			}
-		} else {
-			return 0;
-		}
+		$mdaLogFile    = Settings::Get('system.mdalog');
+		$mdaLogHandler = $this->getMdaHandler(Settings::Get('system.mdaserver'));
+		$mdaLogHandler->handleFile($mdaLogFile);
+		$mdaLogHandler->handleFile($mdaLogFile . '.1');
 	}
 
 	/**
@@ -319,10 +65,43 @@ class MailLogParser
 	 */
 	public function getDomainTraffic($domain)
 	{
-		if (array_key_exists($domain, $this->domainTraffic)) {
-			return $this->domainTraffic[$domain];
-		} else {
-			return 0;
+		return $this->sink->getDomainTraffic($domain);
+	}
+
+	private function getMyDomains(): array
+	{
+		// Get all domains from Database
+		$stmt = Database::prepare('SELECT domain FROM `' . TABLE_PANEL_DOMAINS . '`');
+		Database::pexecute($stmt, []);
+		$myDomains = [];
+		while ($domain_row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+			$myDomains[] = $domain_row['domain'];
 		}
+
+		return $myDomains;
+	}
+
+	private function getMtaHandler(string $handlerName): AbstractLogHandler
+	{
+		switch ($handlerName) {
+			case 'postfix':
+				return new PostfixLogHandler($this->sink, $this->tomorrow);
+			case 'exim4':
+				return new Exim4LogHandler($this->sink, $this->tomorrow);
+			default:
+		}
+		throw new InvalidArgumentException('Unknown implementation: ' . $handlerName);
+	}
+
+	private function getMdaHandler(string $handlerName): AbstractLogHandler
+	{
+		switch ($handlerName) {
+			case 'dovecot':
+				return new DovecotLogHandler($this->sink, $this->tomorrow);
+			case 'courier':
+				return new CourierLogHandler($this->sink, $this->tomorrow);
+			default:
+		}
+		throw new InvalidArgumentException('Unknown implementation: ' . $handlerName);
 	}
 }

--- a/tests/Unit/Froxlor/Cron/Traffic/Mail/DovecotLogHandlerTest.php
+++ b/tests/Unit/Froxlor/Cron/Traffic/Mail/DovecotLogHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Froxlor\Test\Froxlor\Cron\Traffic\Mail;
+
+use DateTimeImmutable;
+use Froxlor\Cron\Traffic\Mail\DovecotLogHandler;
+use Froxlor\Cron\Traffic\Mail\TrafficSink;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Froxlor\Cron\Traffic\Mail\AbstractLogHandler
+ * @covers \Froxlor\Cron\Traffic\Mail\DovecotLogHandler
+ */
+class DovecotLogHandlerTest extends TestCase
+{
+	public function testParsesLogLines()
+	{
+		$yesterday = new DateTimeImmutable('yesterday');
+
+		$sink = new TrafficSink(['example.org'], $yesterday);
+
+		$tomorrow = new DateTimeImmutable('tomorrow');
+
+		$parser = new DovecotLogHandler($sink, $tomorrow);
+
+		$parser->handle(
+			$yesterday->modify('12:36:29'),
+			'server dovecot: imap(test-imap@example.org)<12345><sessionid>: Logged out in=512 out=512 deleted=0 expunged=0 trashed=0 hdr_count=0 hdr_bytes=0 body_count=0 body_bytes=0'
+		);
+		$parser->handle(
+			$yesterday->modify('12:36:30'),
+			'server dovecot: pop3(test-pop@example.org)<23456><sessionid2>: Disconnected: Logged out in=512 out=512 top=0/0, retr=1/21618, del=1/1, size=21583'
+		);
+
+		self::assertSame(
+			[
+				$yesterday->format('Y-m-d') => 2048
+			],
+			$sink->getDomainTraffic('example.org')
+		);
+	}
+
+	public function testParsesLogLinesWhenYearChanged()
+	{
+		$sink = new TrafficSink(['example.org'], $newYearEve = new DateTimeImmutable('last day of December last year'));
+
+		$tomorrow = new DateTimeImmutable('tomorrow');
+
+		$parser = new DovecotLogHandler($sink, $tomorrow);
+
+		$parser->handle(
+			$newYearEve->modify('12:36:29'),
+			'server dovecot: imap(test-imap@example.org)<12345><sessionid>: Logged out in=512 out=512 deleted=0 expunged=0 trashed=0 hdr_count=0 hdr_bytes=0 body_count=0 body_bytes=0'
+		);
+		$parser->handle(
+			$newYearEve->modify('12:36:30'),
+			'server dovecot: pop3(test-pop@example.org)<23456><sessionid2>: Disconnected: Logged out in=512 out=512 top=0/0, retr=1/21618, del=1/1, size=21583'
+		);
+
+		self::assertSame(
+			[
+				($tomorrow->modify('-1 years')->format('Y')) . '-12-31' => 2048
+			],
+			$sink->getDomainTraffic('example.org')
+		);
+	}
+}

--- a/tests/Unit/Froxlor/Cron/Traffic/Mail/PostfixLogHandlerTest.php
+++ b/tests/Unit/Froxlor/Cron/Traffic/Mail/PostfixLogHandlerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Froxlor\Test\Froxlor\Cron\Traffic\Mail;
+
+use DateTimeImmutable;
+use Froxlor\Cron\Traffic\Mail\PostfixLogHandler;
+use Froxlor\Cron\Traffic\Mail\TrafficSink;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Froxlor\Cron\Traffic\Mail\AbstractLogHandler
+ * @covers \Froxlor\Cron\Traffic\Mail\PostfixLogHandler
+ */
+class PostfixLogHandlerTest extends TestCase
+{
+	public function testParsesLogLines()
+	{
+		$yesterday = new DateTimeImmutable('yesterday');
+
+		$sink = new TrafficSink(['example.org'], $yesterday);
+
+		$tomorrow = new DateTimeImmutable('tomorrow');
+
+		$parser = new PostfixLogHandler($sink, $tomorrow);
+
+		$parser->handle(
+			$yesterday->modify('12:36:29'),
+			'server postfix/qmgr[2345]: A01234567890: from=<test@example.com>, size=12345, nrcpt=1 (queue active)'
+		);
+		$parser->handle(
+			$yesterday->modify('12:36:30'),
+			'server postfix/smtp[1234]: A01234567890: to=<test@example.org>, relay=127.0.0.1[127.0.0.1]:10024, delay=0, delays=0/0/0/0, dsn=2.0.0, status=sent (250 2.0.0 from MTA(smtp:[127.0.0.1]:10025): 250 2.0.0 Ok: queued as B01234567890)'
+		);
+
+		self::assertSame(
+			[
+				$yesterday->format('Y-m-d') => 12345
+			],
+			$sink->getDomainTraffic('example.org')
+		);
+	}
+
+	public function testParsesLogLinesWhenYearChanged()
+	{
+		$sink = new TrafficSink(['example.org'], $newYearEve = new DateTimeImmutable('last day of December last year'));
+
+		$tomorrow = new DateTimeImmutable('tomorrow');
+
+		$parser = new PostfixLogHandler($sink, $tomorrow);
+
+		$parser->handle(
+			$newYearEve->modify('12:36:29'),
+			'server postfix/qmgr[2345]: A01234567890: from=<test@example.com>, size=12345, nrcpt=1 (queue active)'
+		);
+		$parser->handle(
+			$newYearEve->modify('12:36:30'),
+			'server postfix/smtp[1234]: A01234567890: to=<test@example.org>, relay=127.0.0.1[127.0.0.1]:10024, delay=0, delays=0/0/0/0, dsn=2.0.0, status=sent (250 2.0.0 from MTA(smtp:[127.0.0.1]:10025): 250 2.0.0 Ok: queued as B01234567890)'
+		);
+
+		self::assertSame(
+			[
+				($tomorrow->modify('-1 years')->format('Y')) . '-12-31' => 12345
+			],
+			$sink->getDomainTraffic('example.org')
+		);
+	}
+}

--- a/tests/Unit/Froxlor/Cron/Traffic/Mail/TrafficSinkTest.php
+++ b/tests/Unit/Froxlor/Cron/Traffic/Mail/TrafficSinkTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Froxlor\Test\Cron\Traffic;
+
+use DateTimeImmutable;
+use Froxlor\Cron\Traffic\Mail\TrafficSink;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Froxlor\Cron\Traffic\Mail\TrafficSink
+ */
+class TrafficTest extends TestCase
+{
+	public function testReturnsEmptyArrayWhenNoLogExists()
+	{
+		$sink = new TrafficSink(['example.org'], new DateTimeImmutable('1999-01-01T00:00:00'));
+
+		self::assertSame([], $sink->getDomainTraffic('example.org'));
+	}
+
+	public function testReturnsAllEntriesAsDayArrayForDomain()
+	{
+		$sink = new TrafficSink(['example.org'], new DateTimeImmutable('1999-01-01T00:00:00'));
+
+		$sink->addDomainTraffic('example.org', 20000101, new DateTimeImmutable('2000-01-01T00:00:00'));
+		$sink->addDomainTraffic('example.org', 20000102, new DateTimeImmutable('2000-01-02T00:00:00'));
+
+		self::assertSame(
+			[
+				'2000-01-01' => 20000101,
+				'2000-01-02' => 20000102,
+			],
+			$sink->getDomainTraffic('example.org')
+		);
+	}
+
+	public function testIgnoresUnknownDomain()
+	{
+		$sink = new TrafficSink([], new DateTimeImmutable('1999-01-01T00:00:00'));
+
+		$sink->addDomainTraffic('example.org', 20000101, new DateTimeImmutable('2000-01-01T00:00:00'));
+
+		self::assertSame([], $sink->getDomainTraffic('example.org'));
+	}
+
+	public function testIgnoresTooOldTimestamp()
+	{
+		$sink = new TrafficSink(['example.org'], new DateTimeImmutable('2000-01-01T10:00:00'));
+
+		$sink->addDomainTraffic('example.org', 20000101, new DateTimeImmutable('2000-01-01T00:00:00'));
+		$sink->addDomainTraffic('example.org', 20000102, new DateTimeImmutable('2000-01-02T00:00:00'));
+
+		self::assertSame(
+			[
+				'2000-01-02' => 20000102,
+			],
+			$sink->getDomainTraffic('example.org')
+		);
+	}
+}


### PR DESCRIPTION
# Description

This cleans up the traffic parser classes.

This PR is currently just a preview (hence marked as WIP and none of the boxes below checked despite having added unit tests).

The TrafficCron is a big bunch of code and the mail log parser etc. are as well. As discussed on IRC, I started restructuring them into smaller classes that are more easy to track.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Includes unit tests for:
- [X] postfix log parsing
- [X] dovecot log parsing

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

