### PR TITLE
Protect only private keys and leave certificates world readable.

### DIFF
--- a/lib/Froxlor/Cron/Http/DomainSSL.php
+++ b/lib/Froxlor/Cron/Http/DomainSSL.php
@@ -105,7 +105,9 @@ class DomainSSL
 					$_fh = fopen($filename, 'w');
 					fwrite($_fh, $dom_certs[$type]);
 					fclose($_fh);
-					chmod($filename, 0600);
+					if ($type == 'ssl_key_file') {
+						chmod($filename, 0600);
+					}
 				}
 			}
 			// override corresponding array values

--- a/lib/Froxlor/Cron/Http/DomainSSL.php
+++ b/lib/Froxlor/Cron/Http/DomainSSL.php
@@ -107,6 +107,8 @@ class DomainSSL
 					fclose($_fh);
 					if ($type == 'ssl_key_file') {
 						chmod($filename, 0600);
+					} else {
+						chmod($filename, 0644);
 					}
 				}
 			}


### PR DESCRIPTION
# Description

Until now all files in Froxlor's SSL directory are only readable by root. While this is required for the .key files which contain the private keys it isn't necessary for the certificates (and chains) which only contain public keys.
Having the certificates world readable allows external programs executed by non-privileged users to scan the certificates. So it would be possible for a monitoring system to check whether there are expired certificates.
As the certificates are presented to all website visitors there is no reason to protect them.

This change executes chmod 600 only for ssl_key_files and leaves all other files mode 644 (or whatever is requested by umask on global level).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Applied the change, requested config rebuild and checked the content of SSL directory and website functionality.

**Test Configuration**:

* Distribution: Debian 10
* Webserver: Apache 2.4.38
* PHP: 7.3

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings