### PR TITLE
dns: check NS entry to be used as primary NS

### DIFF
--- a/lib/Froxlor/Dns/Dns.php
+++ b/lib/Froxlor/Dns/Dns.php
@@ -181,8 +181,8 @@ class Dns
 				// unset special spf required-entry
 				unset($required_entries[$entry['type']][md5("@SPF@")]);
 			}
-			if (empty($primary_ns) && $entry['type'] == 'NS') {
-				// use the first NS entry as primary ns
+			if (empty($primary_ns) && $entry['record'] == '@' && $entry['type'] == 'NS') {
+				// use the first NS entry pertaining to the current domain as primary ns
 				$primary_ns = $entry['content'];
 			}
 			// check for CNAME on @, www- or wildcard-Alias and remove A/AAAA record accordingly


### PR DESCRIPTION
Quoting the default regex delimiter is required for the password
complexity check to work if '/' had been specified as special character
in Froxlor's account settings.