### PR TITLE
dns: make mail address of SOA records configurable

### DIFF
--- a/actions/admin/settings/160.nameserver.php
+++ b/actions/admin/settings/160.nameserver.php
@@ -132,6 +132,16 @@ return array(
 					'int_min' => 3600, /* 1 hour */
 					'int_max' => 2147483647, /* integer max */
 					'save_method' => 'storeSettingField'
+				),
+				'system_soaemail' => array(
+					'label' => $lng['serversettings']['soaemail'],
+					'settinggroup' => 'system',
+					'varname' => 'soaemail',
+					'type' => 'string',
+					'string_type' => 'mail',
+					'string_emptyallowed' => true,
+					'default' => '',
+					'save_method' => 'storeSettingField'
 				)
 			)
 		)

--- a/install/froxlor.sql
+++ b/install/froxlor.sql
@@ -674,6 +674,7 @@ opcache.interned_strings_buffer'),
 	('system', 'apply_phpconfigs_default', '1'),
 	('system', 'hide_incompatible_settings', '0'),
 	('system', 'include_default_vhostconf', '0'),
+	('system', 'soaemail', ''),
 	('api', 'enabled', '0'),
 	('2fa', 'enabled', '1'),
 	('panel', 'decimal_places', '4'),
@@ -709,7 +710,7 @@ opcache.interned_strings_buffer'),
 	('panel', 'customer_hide_options', ''),
 	('panel', 'is_configured', '0'),
 	('panel', 'version', '0.10.24'),
-	('panel', 'db_version', '202101200');
+	('panel', 'db_version', '202102200');
 
 
 DROP TABLE IF EXISTS `panel_tasks`;

--- a/install/updates/froxlor/0.10/update_0.10.inc.php
+++ b/install/updates/froxlor/0.10/update_0.10.inc.php
@@ -725,3 +725,12 @@ if (\Froxlor\Froxlor::isFroxlorVersion('0.10.23.1')) {
 	showUpdateStep("Updating from 0.10.23.1 to 0.10.24", false);
 	\Froxlor\Froxlor::updateToVersion('0.10.24');
 }
+
+if (\Froxlor\Froxlor::isDatabaseVersion('202101200')) {
+
+	showUpdateStep("Adding setting for mail address used in SOA records", true);
+	Settings::AddNew("system.soaemail", '');
+	lastStepStatus(0);
+
+	\Froxlor\Froxlor::updateToDbVersion('202102200');
+}

--- a/lib/Froxlor/Dns/Dns.php
+++ b/lib/Froxlor/Dns/Dns.php
@@ -365,7 +365,11 @@ class Dns
 			}
 
 			// PowerDNS does not like multi-line-format
-			$soa_content = $primary_ns . " " . self::escapeSoaAdminMail(Settings::Get('panel.adminmail')) . " ";
+			$soa_email = Settings::Get('system.soaemail');
+			if ($soa_email == "") {
+				$soa_email = Settings::Get('panel.adminmail');
+			}
+			$soa_content = $primary_ns . " " . self::escapeSoaAdminMail($soa_email) . " ";
 			$soa_content .= $domain['bindserial'] . " ";
 			// TODO for now, dummy time-periods
 			$soa_content .= "3600 900 604800 " . (int) Settings::Get('system.defaultttl');

--- a/lib/Froxlor/Froxlor.php
+++ b/lib/Froxlor/Froxlor.php
@@ -10,7 +10,7 @@ final class Froxlor
 	const VERSION = '0.10.24';
 
 	// Database version (YYYYMMDDC where C is a daily counter)
-	const DBVERSION = '202101200';
+	const DBVERSION = '202102200';
 
 	// Distribution branding-tag (used for Debian etc.)
 	const BRANDING = '';

--- a/lng/english.lng.php
+++ b/lng/english.lng.php
@@ -2104,3 +2104,5 @@ $lng['serversettings']['awstats']['logformat']['description'] = 'If you use cust
 $lng['error']['cannotdeletesuperadmin'] = 'The first admin cannot be deleted.';
 $lng['error']['no_wwwcnamae_ifwwwalias'] = 'Cannot set CNAME record for "www" as domain is set to generate a www-alias. Please change settings to either "No alias" or "Wildcard alias"';
 $lng['serversettings']['hide_incompatible_settings'] = 'Hide incompatible settings';
+
+$lng['serversettings']['soaemail'] = 'Mail address to use in SOA records (defaults to sender address from panel settings if empty)';

--- a/lng/german.lng.php
+++ b/lng/german.lng.php
@@ -1750,3 +1750,5 @@ $lng['serversettings']['awstats']['logformat']['description'] = 'Wenn ein benutz
 $lng['error']['cannotdeletesuperadmin'] = 'Der erste Administrator kann nicht gelöscht werden.';
 $lng['error']['no_wwwcnamae_ifwwwalias'] = 'Es kann kein CNAME Eintrag für "www" angelegt werden, da die Domain einen www-Alias aktiviert hat. Ändere diese Einstellung auf "Kein Alias" oder "Wildcard Alias"';
 $lng['serversettings']['hide_incompatible_settings'] = 'Inkompatible Einstellungen ausblenden';
+
+$lng['serversettings']['soaemail'] = 'Mail-Adresse für SOA-Einträge (verwendet Panel-Absender-Name der Panel-Einstellungen falls leer)';


### PR DESCRIPTION
Quoting the default regex delimiter is required for the password
complexity check to work if '/' had been specified as special character
in Froxlor's account settings.