### PR TITLE
pdns: default zone type should be master

### DIFF
--- a/lib/Froxlor/Cron/Dns/PowerDNS.php
+++ b/lib/Froxlor/Cron/Dns/PowerDNS.php
@@ -112,7 +112,7 @@ class PowerDNS extends DnsBase
 	private function insertZone($domainname, $serial = 0)
 	{
 		$ins_stmt = \Froxlor\Dns\PowerDNS::getDB()->prepare("
-			INSERT INTO domains set `name` = :domainname, `notified_serial` = :serial, `type` = 'NATIVE'
+			INSERT INTO domains set `name` = :domainname, `notified_serial` = :serial, `type` = 'MASTER'
 		");
 		$ins_stmt->execute(array(
 			'domainname' => $domainname,


### PR DESCRIPTION
# Description

By default, pdns.conf is created with "master = yes" and pre-sets for XFR enabled. For it to properly work, the zone type of new domains should be MASTER, not NATIVE.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update