### PR TITLE
Update Extrausers.php

### DIFF
--- a/lib/Froxlor/Cron/System/Extrausers.php
+++ b/lib/Froxlor/Cron/System/Extrausers.php
@@ -24,7 +24,7 @@ class Extrausers
 	{
 		// passwd
 		$passwd = '/var/lib/extrausers/passwd';
-		$sql = "SELECT customerid,username,'x' as password,uid,gid,'Froxlor User' as comment,homedir,shell, login_enabled FROM ftp_users ORDER BY uid ASC";
+		$sql = "SELECT customerid,username,'x' as password,uid,gid,'Froxlor User' as comment,homedir,shell, login_enabled FROM ftp_users ORDER BY id ASC";
 		self::generateFile($passwd, $sql, $cronlog);
 
 		// group


### PR DESCRIPTION
Migrating from mysql 5.7 to mysql 8 something in the default sorting order has probably changed, default ownership of the customer web folders have switched to ftp users instead of the default username, for example running the query:
SELECT customerid,username,'x' as password,uid,gid,'Froxlor User' as comment,homedir,shell, login_enabled FROM ftp_users ORDER BY uid ASC;
results in userftp1 userftp2 userftp3 being listed before the user
SELECT customerid,username,'x' as password,uid,gid,'Froxlor User' as comment,homedir,shell, login_enabled FROM ftp_users ORDER BY id ASC;
results in user listed before userftp1, userftp2, userftp3.
This fixes the problem with the ownership.

# Description

Please include a summary of the change and which issue is fixed if any. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Distribution:
* Webserver:
* PHP:
* etc.etc.:

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

