### PR TITLE
Fix Minimum and Expired SOA-Records

### DIFF
--- a/lib/Froxlor/Dns/Dns.php
+++ b/lib/Froxlor/Dns/Dns.php
@@ -386,7 +386,7 @@ class Dns
 			$soa_content = $primary_ns . " " . self::escapeSoaAdminMail($soa_email) . " ";
 			$soa_content .= $domain['bindserial'] . " ";
 			// TODO for now, dummy time-periods
-			$soa_content .= "3600 900 604800 " . (int) Settings::Get('system.defaultttl');
+			$soa_content .= "3600 900 1209600 1200";
 
 			$soa_record = new DnsEntry('@', 'SOA', $soa_content);
 			array_unshift($zonerecords, $soa_record);


### PR DESCRIPTION
Currently in $soa_content the "Minimun SOA record" is obtained from the system configuration -> TTL and thus may be incorrect. (TTL and Minimum SOA-Records are not the same?! looks like a bug)

In addition, I also fixed the "Expired" entry, according to current [RFC](https://www.ietf.org/rfc/rfc1912.txt) this must be 2 or 4 weeks.

Thanks for merging.