### PR TITLE
Add Buypass to the list of ACME providers.

### DIFF
--- a/actions/admin/settings/131.ssl.php
+++ b/actions/admin/settings/131.ssl.php
@@ -168,6 +168,7 @@ return array(
 					'option_options' => array(
 						'letsencrypt_test' => 'Let\'s Encrypt (Test / Staging)',
 						'letsencrypt' => 'Let\'s Encrypt (Live)',
+						'buypass' => 'Buypass (Live)',
 					    'zerossl' => 'ZeroSSL (Live)'
 					),
 					'save_method' => 'storeSettingField'

--- a/lib/Froxlor/Cron/Http/LetsEncrypt/AcmeSh.php
+++ b/lib/Froxlor/Cron/Http/LetsEncrypt/AcmeSh.php
@@ -31,6 +31,7 @@ class AcmeSh extends \Froxlor\Cron\FroxlorCron
 	const ACME_PROVIDER = [
 		'letsencrypt' => "https://acme-v02.api.letsencrypt.org/directory",
 		'letsencrypt_test' => "https://acme-staging-v02.api.letsencrypt.org/directory",
+		'buypass' => "https://api.buypass.com/acme/directory",
 		'zerossl' => "https://acme.zerossl.com/v2/DV90"
 	];
 


### PR DESCRIPTION
# Description

Just added Buypass to the list of ACME providers. They provide certificates with a validity of 180 days via ACME. The API URL is documented [here](https://community.buypass.com/t/63d4ay/buypass-go-ssl-endpoints-updated-14-05-2020).