### PR TITLE
Call PHP-FPM only when file exists

### DIFF
--- a/lib/Froxlor/Cron/Http/ApacheFcgi.php
+++ b/lib/Froxlor/Cron/Http/ApacheFcgi.php
@@ -56,7 +56,9 @@ class ApacheFcgi extends Apache
 					// start block, cut off last pipe and close block
 					$filesmatch = '(' . str_replace(".", "\.", substr($filesmatch, 0, - 1)) . ')';
 					$php_options_text .= '  <FilesMatch \.' . $filesmatch . '$>' . "\n";
-					$php_options_text .= '  SetHandler proxy:unix:' . $domain['fpm_socket'] . '|fcgi://localhost' . "\n";
+					$php_options_text .= '    <If "-f %{SCRIPT_FILENAME}">' . "\n";
+					$php_options_text .= '      SetHandler proxy:unix:' . $domain['fpm_socket'] . '|fcgi://localhost' . "\n";
+					$php_options_text .= '    </If>' . "\n";
 					$php_options_text .= '  </FilesMatch>' . "\n";
 
 					$mypath_dir = new \Froxlor\Http\Directory($domain['documentroot']);


### PR DESCRIPTION
# Description

Added `<If "-f %{SCRIPT_FILENAME}">` to load only PHP files that exists. This is to prevent `File not found` error from PHP-FPM and let Apache handle the error output. It removes also unnecessary PHP-FPM calls and `AH01071: Got error ‘Primary script unknown` in PHP error log.

Usually you can find the error whenever someone goes fishing for paths like wp-login.php.

The `<If>` directive is only available in Apache 2.4+ and not 2.2 or earlier.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Modified file and recreated all PHP configurations. Accessed path to a non existing *.php file. Now the Apache error page is shown and not the PHP-FPM error page.

**Test Configuration**:

* Distribution: Debian 11
* Webserver: Apache 2.4
* PHP-FPM: 7.4, 8.0, 8.1
* Apache module mpm_event used

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation --> no changes needed
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

