### PR TITLE
Set RC 1 if an exception occured

### DIFF
--- a/install/scripts/config-services.php
+++ b/install/scripts/config-services.php
@@ -28,4 +28,5 @@ try {
 	\Froxlor\Cli\ConfigServicesCmd::processParameters($argc, $argv);
 } catch (Exception $e) {
 	\Froxlor\Cli\ConfigServicesCmd::printerr($e->getMessage());
+	exit 1;
 }

--- a/install/scripts/switch-server-ip.php
+++ b/install/scripts/switch-server-ip.php
@@ -28,4 +28,5 @@ try {
 	\Froxlor\Cli\SwitchServerIpCmd::processParameters($argc, $argv);
 } catch (Exception $e) {
 	\Froxlor\Cli\SwitchServerIpCmd::printerr($e->getMessage());
+	exit 1;
 }


### PR DESCRIPTION
If the script is executed unattended a proper return code is useful to abort if there was an error.