### PR TITLE
remove nested dirname and use level parameter for better readability

### DIFF
--- a/install/lib/class.FroxlorInstall.php
+++ b/install/lib/class.FroxlorInstall.php
@@ -28,7 +28,7 @@ use Froxlor\UI\Panel\UI;
  * @author Froxlor team <team@froxlor.org> (2010-)
  * @license GPLv2 http://files.froxlor.org/misc/COPYING.txt
  * @package Install
- *         
+ *
  */
 class FroxlorInstall
 {
@@ -83,7 +83,7 @@ class FroxlorInstall
 	 */
 	public function __construct()
 	{
-		$this->_basepath = dirname(dirname(dirname(__FILE__)));
+		$this->_basepath = dirname(__FILE__, 3);
 		$this->_data = array();
 	}
 
@@ -362,9 +362,9 @@ class FroxlorInstall
 
 	/**
 	 * Create userdata.inc.php file
-	 * 
+	 *
 	 * @param array $content
-	 * 
+	 *
 	 * @return void
 	 */
 	private function _createUserdataConf(&$content)
@@ -394,7 +394,7 @@ class FroxlorInstall
 
 		// test if we can store the userdata.inc.php in ../lib
 		$umask = @umask(077);
-		$userdata_file = dirname(dirname(dirname(__FILE__))) . '/lib/userdata.inc.php';
+		$userdata_file = dirname(__FILE__, 3) . '/lib/userdata.inc.php';
 		if (@touch($userdata_file) && @is_writable($userdata_file)) {
 			$fp = @fopen($userdata_file, 'w');
 			@fputs($fp, $userdata, strlen($userdata));
@@ -609,7 +609,7 @@ class FroxlorInstall
 		}
 
 		$this->_updateSetting($upd_stmt, $this->_data['activate_newsfeed'], 'admin', 'show_news_feed');
-		$this->_updateSetting($upd_stmt, dirname(dirname(dirname(__FILE__))), 'system', 'letsencryptchallengepath');
+		$this->_updateSetting($upd_stmt, dirname(__FILE__, 3), 'system', 'letsencryptchallengepath');
 
 		// insert the lastcronrun to be the installation date
 		$this->_updateSetting($upd_stmt, time(), 'system', 'lastcronrun');
@@ -687,7 +687,7 @@ class FroxlorInstall
 				'title' => $this->_lng['install']['importing_data'],
 				'result' => 0
 			];
-			$db_schema = dirname(dirname(__FILE__)) . '/froxlor.sql';
+			$db_schema = dirname(__FILE__, 2) . '/froxlor.sql';
 			$sql_query = @file_get_contents($db_schema);
 			$sql_query = $this->_remove_remarks($sql_query);
 			$sql_query = $this->_split_sql_file($sql_query, ';');
@@ -1034,7 +1034,7 @@ class FroxlorInstall
 	 *        	optional css
 	 * @param string $type
 	 *        	optional type of input-box (default: text)
-	 *        	
+	 *
 	 * @return array
 	 */
 	private function _getSectionItemString($fieldname = null, $required = false, $style = "", $type = 'text')

--- a/install/lng/english.lng.php
+++ b/install/lng/english.lng.php
@@ -93,8 +93,8 @@ $lng['install']['changing_data'] = 'Adjusting settings...';
 $lng['install']['creating_entries'] = 'Inserting new values...';
 $lng['install']['adding_admin_user'] = 'Creating admin-account...';
 $lng['install']['creating_configfile'] = 'Creating configfile...';
-$lng['install']['creating_configfile_temp'] = 'File was saved in %s, please move to ' . dirname(dirname(__DIR__)) . '/lib/userdata.inc.php';
-$lng['install']['creating_configfile_failed'] = 'Could not create ' . dirname(dirname(__DIR__)) . '/lib/userdata.inc.php, please create it manually with the following content:';
+$lng['install']['creating_configfile_temp'] = 'File was saved in %s, please move to ' . dirname(__DIR__, 2) . '/lib/userdata.inc.php';
+$lng['install']['creating_configfile_failed'] = 'Could not create ' . dirname(__DIR__, 2) . '/lib/userdata.inc.php, please create it manually with the following content:';
 $lng['install']['froxlor_succ_installed'] = 'Froxlor was installed successfully.';
 $lng['install']['failed'] = 'failed';
 

--- a/install/lng/french.lng.php
+++ b/install/lng/french.lng.php
@@ -78,8 +78,8 @@ $lng['install']['changing_data'] = 'Ajustement des paramètres...';
 $lng['install']['creating_entries'] = 'Insertion des nouvelles valeurs...';
 $lng['install']['adding_admin_user'] = 'Création du compte administrateur...';
 $lng['install']['creating_configfile'] = 'Création du fichier de configuration...';
-$lng['install']['creating_configfile_temp'] = 'Le fichier a été enregistré dans %s, merci de le déplacer dans ' . dirname(dirname(__DIR__)) . '/lib/userdata.inc.php';
-$lng['install']['creating_configfile_failed'] = 'Impossible de créer ' . dirname(dirname(__DIR__)) . '/lib/userdata.inc.php, merci de le créer manuellement avec le contenu suivant:';
+$lng['install']['creating_configfile_temp'] = 'Le fichier a été enregistré dans %s, merci de le déplacer dans ' . dirname(__DIR__, 2) . '/lib/userdata.inc.php';
+$lng['install']['creating_configfile_failed'] = 'Impossible de créer ' . dirname(__DIR__, 2) . '/lib/userdata.inc.php, merci de le créer manuellement avec le contenu suivant:';
 $lng['install']['froxlor_succ_installed'] = 'Froxlor a été installé avec succès.';
 
 $lng['click_here_to_refresh'] = 'Cliquez ici pour vérifier à nouveau';

--- a/install/lng/german.lng.php
+++ b/install/lng/german.lng.php
@@ -93,8 +93,8 @@ $lng['install']['changing_data'] = 'Einstellungen anpassen...';
 $lng['install']['creating_entries'] = 'Trage neue Werte ein...';
 $lng['install']['adding_admin_user'] = 'Erstelle Admin-Benutzer...';
 $lng['install']['creating_configfile'] = 'Erstelle Konfigurationsdatei...';
-$lng['install']['creating_configfile_temp'] = 'Datei wurde in %s gespeichert, bitte nach ' . dirname(dirname(__DIR__)) . '/lib/userdata.inc.php verschieben.';
-$lng['install']['creating_configfile_failed'] = 'Konnte ' . dirname(dirname(__DIR__)) . '/lib/userdata.inc.php nicht erstellen, bitte manuell mit folgendem Inhalt anlegen:';
+$lng['install']['creating_configfile_temp'] = 'Datei wurde in %s gespeichert, bitte nach ' . dirname(__DIR__, 2) . '/lib/userdata.inc.php verschieben.';
+$lng['install']['creating_configfile_failed'] = 'Konnte ' . dirname(__DIR__, 2) . '/lib/userdata.inc.php nicht erstellen, bitte manuell mit folgendem Inhalt anlegen:';
 $lng['install']['froxlor_succ_installed'] = 'Froxlor wurde erfolgreich installiert.';
 $lng['install']['failed'] = 'fehlgeschlagen';
 

--- a/lib/Froxlor/Cron/Http/LighttpdFcgi.php
+++ b/lib/Froxlor/Cron/Http/LighttpdFcgi.php
@@ -17,7 +17,7 @@ use Froxlor\Cron\Http\Php\PhpInterface;
  * @author Froxlor team <team@froxlor.org> (2010-)
  * @license GPLv2 http://files.froxlor.org/misc/COPYING.txt
  * @package Cron
- *         
+ *
  */
 class LighttpdFcgi extends Lighttpd
 {
@@ -95,7 +95,7 @@ class LighttpdFcgi extends Lighttpd
 	public function createOwnVhostStarter()
 	{
 		if (Settings::Get('phpfpm.enabled') == '1' && Settings::Get('phpfpm.enabled_ownvhost') == '1') {
-			$mypath = \Froxlor\FileDir::makeCorrectDir(dirname(dirname(dirname(__FILE__)))); // /var/www/froxlor, needed for chown
+			$mypath = \Froxlor\FileDir::makeCorrectDir(dirname(__FILE__, 3)); // /var/www/froxlor, needed for chown
 
 			$user = Settings::Get('phpfpm.vhost_httpuser');
 			$group = Settings::Get('phpfpm.vhost_httpgroup');

--- a/lib/Froxlor/Cron/Http/NginxFcgi.php
+++ b/lib/Froxlor/Cron/Http/NginxFcgi.php
@@ -17,7 +17,7 @@ use Froxlor\Cron\Http\Php\PhpInterface;
  * @author Froxlor team <team@froxlor.org> (2010-)
  * @license GPLv2 http://files.froxlor.org/misc/COPYING.txt
  * @package Cron
- *         
+ *
  */
 class NginxFcgi extends Nginx
 {
@@ -64,7 +64,7 @@ class NginxFcgi extends Nginx
 	public function createOwnVhostStarter()
 	{
 		if (Settings::Get('phpfpm.enabled') == '1' && Settings::Get('phpfpm.enabled_ownvhost') == '1') {
-			$mypath = \Froxlor\FileDir::makeCorrectDir(dirname(dirname(dirname(__FILE__)))); // /var/www/froxlor, needed for chown
+			$mypath = \Froxlor\FileDir::makeCorrectDir(dirname(__FILE__, 3)); // /var/www/froxlor, needed for chown
 
 			$user = Settings::Get('phpfpm.vhost_httpuser');
 			$group = Settings::Get('phpfpm.vhost_httpgroup');

--- a/lib/Froxlor/Froxlor.php
+++ b/lib/Froxlor/Froxlor.php
@@ -23,7 +23,7 @@ final class Froxlor
 	 */
 	public static function getInstallDir()
 	{
-		return dirname(dirname(__DIR__)) . '/';
+		return dirname(__DIR__, 2) . '/';
 	}
 
 	/**


### PR DESCRIPTION
remove nested dirname and use level parameter for better readability

```dirname(dirname(dirname(__FILE__)))```
can be replaced with
```dirname(__FILE__, 3)```