### PR TITLE
Add login header image max-width

### DIFF
--- a/templates/Sparkle/assets/css/main.css
+++ b/templates/Sparkle/assets/css/main.css
@@ -82,6 +82,7 @@ header img {
 .login header img {
 	margin: 0 auto;
 	display: block;
+	max-width: calc(100% - 20px);
 }
 
 img.small {


### PR DESCRIPTION
# Description

Currently, if you upload a custom login header image (logo) there is no size limitation, so if its wider than the login box it'll just break the layout. This PR introduces a max-width of 100% (minus the 20px x-axis padding of the parent) for this image to not break the layout.

## Type of change

[x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Yup! :-)