### PR TITLE
fixed duplicated column heading in /admin_phpsettings.php?page=fpmdaemons

### DIFF
--- a/lib/tablelisting/admin/tablelisting.fpmconfigs.php
+++ b/lib/tablelisting/admin/tablelisting.fpmconfigs.php
@@ -56,7 +56,7 @@ return [
 				'field' => 'config_dir'
 			],
 			'pm' => [
-				'label' => lng('serversettings.phpfpm_settings.configdir'),
+				'label' => lng('serversettings.phpfpm_settings.pm'),
 				'field' => 'pm',
 			],
 		],


### PR DESCRIPTION
# Description

Very small UI fix that corrects a table header label

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Made change. Reloaded UI. Check if heading now correct.

**Test Configuration**:

* Distribution: Ubuntu jammy
* Webserver: nginx
* PHP: 7.4 fpm

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
