### PR TITLE
[configfiles] Add command to remove debians prerotate script

### DIFF
--- a/lib/configfiles/bionic.xml
+++ b/lib/configfiles/bionic.xml
@@ -4599,6 +4599,7 @@ UPLOADGID=
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/logrotate.d/httpd-prerotate/awstats]]></command>
 				</daemon>
 				<!-- libnss-extrausers -->
 				<daemon name="libnssextrausers"

--- a/lib/configfiles/bookworm.xml
+++ b/lib/configfiles/bookworm.xml
@@ -3241,6 +3241,7 @@ UPLOADGID=
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/logrotate.d/httpd-prerotate/awstats]]></command>
 				</daemon>
 				<!-- libnss-extrausers -->
 				<daemon name="libnssextrausers"

--- a/lib/configfiles/bullseye.xml
+++ b/lib/configfiles/bullseye.xml
@@ -4811,6 +4811,7 @@ UPLOADGID=
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/logrotate.d/httpd-prerotate/awstats]]></command>
 				</daemon>
 				<!-- libnss-extrausers -->
 				<daemon name="libnssextrausers"

--- a/lib/configfiles/buster.xml
+++ b/lib/configfiles/buster.xml
@@ -4802,6 +4802,7 @@ UPLOADGID=
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/logrotate.d/httpd-prerotate/awstats]]></command>
 				</daemon>
 				<!-- libnss-extrausers -->
 				<daemon name="libnssextrausers"

--- a/lib/configfiles/focal.xml
+++ b/lib/configfiles/focal.xml
@@ -4030,6 +4030,7 @@ UPLOADGID=
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/logrotate.d/httpd-prerotate/awstats]]></command>
 				</daemon>
 				<!-- libnss-extrausers -->
 				<daemon name="libnssextrausers"

--- a/lib/configfiles/jammy.xml
+++ b/lib/configfiles/jammy.xml
@@ -4022,6 +4022,7 @@ UPLOADGID=
 					<command><![CDATA[sed -i.bak 's/^DirData/# DirData/' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[sed -i.bak 's|^\\(DirIcons=\\).*$|\\1\\"/awstats-icon\\"|' {{settings.system.awstats_conf}}/awstats.model.conf]]></command>
 					<command><![CDATA[rm /etc/cron.d/awstats]]></command>
+					<command><![CDATA[rm /etc/logrotate.d/httpd-prerotate/awstats]]></command>
 				</daemon>
 				<!-- libnss-extrausers -->
 				<daemon name="libnssextrausers"


### PR DESCRIPTION
# Description

This extends the configfiles for debian based distros with an additional command to remove a prerotate script included in their pacakges.

The removed script is obsolete with Froxlor because it has it's own cron task for traffic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Not tested :-P

* Distribution: debian bullseye
* Webserver: apache2
* PHP: 8.2
* etc.etc.: etc.

# Checklist:

- [x] I have performed a self-review of my own code