### PR TITLE
Allow admins to edit openbasedir_path for domains

### DIFF
--- a/admin_domains.php
+++ b/admin_domains.php
@@ -282,6 +282,12 @@ if ($page == 'domains' || $page == 'overview') {
 				}
 			}
 
+			$openbasedir = [
+				0 => lng('domain.docroot'),
+				1 => lng('domain.homedir'),
+				2 => lng('domain.docparent')
+			];
+			
 			// create serveralias options
 			$serveraliasoptions = [
 				0 => lng('domains.serveraliasoption_wildcard'),
@@ -545,6 +551,12 @@ if ($page == 'domains' || $page == 'overview') {
 				$result['temporary_ssl_redirect'] = $result['ssl_redirect'];
 				$result['ssl_redirect'] = ($result['ssl_redirect'] == 0 ? 0 : 1);
 
+				$openbasedir = [
+					0 => lng('domain.docroot'),
+					1 => lng('domain.homedir'),
+					2 => lng('domain.docparent')
+				];
+				
 				$serveraliasoptions = [
 					0 => lng('domains.serveraliasoption_wildcard'),
 					1 => lng('domains.serveraliasoption_www'),

--- a/lib/Froxlor/Api/Commands/Domains.php
+++ b/lib/Froxlor/Api/Commands/Domains.php
@@ -225,6 +225,8 @@ class Domains extends ApiCommand implements ResourceEntity
 	 *            optional, whether php is enabled for this domain, default 0 (false)
 	 * @param bool $openbasedir
 	 *            optional, whether to activate openbasedir restriction for this domain, default 0 (false)
+	 * @param int $openbasedir_path
+	 *            optional, either 0 for domains-docroot, 1 for customers-homedir or 2 for parent-directory of domains-docroot
 	 * @param int $phpsettingid
 	 *            optional, specify php-configuration that is being used by id, default 1 (system-default)
 	 * @param int $mod_fcgid_starter
@@ -312,6 +314,7 @@ class Domains extends ApiCommand implements ResourceEntity
 				$documentroot = $this->getParam('documentroot', true, '');
 				$phpenabled = $this->getBoolParam('phpenabled', true, 0);
 				$openbasedir = $this->getBoolParam('openbasedir', true, 0);
+				$openbasedir_path = $this->getBoolParam('openbasedir_path', true, 0);
 				$phpsettingid = $this->getParam('phpsettingid', true, 1);
 				$mod_fcgid_starter = $this->getParam('mod_fcgid_starter', true, -1);
 				$mod_fcgid_maxrequests = $this->getParam('mod_fcgid_maxrequests', true, -1);
@@ -529,7 +532,11 @@ class Domains extends ApiCommand implements ResourceEntity
 					$mod_fcgid_starter = '-1';
 					$mod_fcgid_maxrequests = '-1';
 				}
-
+				
+				if ($openbasedir_path > 2 && $openbasedir_path < 0) {
+					$openbasedir_path = 0;
+				}
+				
 				// check non-ssl IP
 				$ipandports = $this->validateIpAddresses($p_ipandports);
 				// check ssl IP
@@ -701,6 +708,7 @@ class Domains extends ApiCommand implements ResourceEntity
 						'caneditdomain' => $caneditdomain,
 						'phpenabled' => $phpenabled,
 						'openbasedir' => $openbasedir,
+						'openbasedir_path' => $openbasedir_path,
 						'speciallogfile' => $speciallogfile,
 						'specialsettings' => $specialsettings,
 						'ssl_specialsettings' => $ssl_specialsettings,
@@ -754,6 +762,7 @@ class Domains extends ApiCommand implements ResourceEntity
 						`caneditdomain` = :caneditdomain,
 						`phpenabled` = :phpenabled,
 						`openbasedir` = :openbasedir,
+						`openbasedir_path` = :openbasedir_path,
 						`speciallogfile` = :speciallogfile,
 						`specialsettings` = :specialsettings,
 						`ssl_specialsettings` = :ssl_specialsettings,
@@ -1101,6 +1110,8 @@ class Domains extends ApiCommand implements ResourceEntity
 	 *            from setting system.apply_phpconfigs_default
 	 * @param bool $openbasedir
 	 *            optional, whether to activate openbasedir restriction for this domain, default 0 (false)
+	 * @param int $openbasedir_path
+	 *            optional, either 0 for domains-docroot, 1 for customers-homedir or 2 for parent-directory of domains-docroot
 	 * @param int $phpsettingid
 	 *            optional, specify php-configuration that is being used by id, default 1 (system-default)
 	 * @param int $mod_fcgid_starter
@@ -1198,6 +1209,7 @@ class Domains extends ApiCommand implements ResourceEntity
 			$phpenabled = $this->getBoolParam('phpenabled', true, $result['phpenabled']);
 			$phpfs = $this->getBoolParam('phpsettingsforsubdomains', true, Settings::Get('system.apply_phpconfigs_default'));
 			$openbasedir = $this->getBoolParam('openbasedir', true, $result['openbasedir']);
+			$openbasedir_path = $this->getParam('openbasedir_path', true, $result['openbasedir_path']);
 			$phpsettingid = $this->getParam('phpsettingid', true, $result['phpsettingid']);
 			$mod_fcgid_starter = $this->getParam('mod_fcgid_starter', true, $result['mod_fcgid_starter']);
 			$mod_fcgid_maxrequests = $this->getParam('mod_fcgid_maxrequests', true, $result['mod_fcgid_maxrequests']);
@@ -1487,6 +1499,11 @@ class Domains extends ApiCommand implements ResourceEntity
 				$phpfs = 1;
 				$mod_fcgid_starter = $result['mod_fcgid_starter'];
 				$mod_fcgid_maxrequests = $result['mod_fcgid_maxrequests'];
+			}
+			
+			// check changes of openbasedir-path variable
+			if ($openbasedir_path > 2 && $openbasedir_path < 0) {
+				$openbasedir_path = 0;
 			}
 
 			// check non-ssl IP
@@ -1782,7 +1799,8 @@ class Domains extends ApiCommand implements ResourceEntity
 			$update_data['wwwserveralias'] = $wwwserveralias;
 			$update_data['iswildcarddomain'] = $iswildcarddomain;
 			$update_data['phpenabled'] = $phpenabled;
-			$update_data['openbasedir'] = $openbasedir;
+			$update_data['openbasedir'] = $openbasedir;;
+			$update_data['openbasedir_path'] = $openbasedir_path;
 			$update_data['speciallogfile'] = $speciallogfile;
 			$update_data['phpsettingid'] = $phpsettingid;
 			$update_data['mod_fcgid_starter'] = $mod_fcgid_starter;
@@ -1830,6 +1848,7 @@ class Domains extends ApiCommand implements ResourceEntity
 				`iswildcarddomain` = :iswildcarddomain,
 				`phpenabled` = :phpenabled,
 				`openbasedir` = :openbasedir,
+				`openbasedir_path` = :openbasedir_path,
 				`speciallogfile` = :speciallogfile,
 				`phpsettingid` = :phpsettingid,
 				`mod_fcgid_starter` = :mod_fcgid_starter,
@@ -1865,6 +1884,7 @@ class Domains extends ApiCommand implements ResourceEntity
 			$_update_data['adminid'] = $adminid;
 			$_update_data['phpenabled'] = $phpenabled;
 			$_update_data['openbasedir'] = $openbasedir;
+			$_update_data['openbasedir_path'] = $openbasedir_path;
 			$_update_data['mod_fcgid_starter'] = $mod_fcgid_starter;
 			$_update_data['mod_fcgid_maxrequests'] = $mod_fcgid_maxrequests;
 			$_update_data['notryfiles'] = $notryfiles;
@@ -1898,6 +1918,7 @@ class Domains extends ApiCommand implements ResourceEntity
 				`adminid` = :adminid,
 				`phpenabled` = :phpenabled,
 				`openbasedir` = :openbasedir,
+				`openbasedir_path` = :openbasedir_path,
 				`mod_fcgid_starter` = :mod_fcgid_starter,
 				`mod_fcgid_maxrequests` = :mod_fcgid_maxrequests,
 				`notryfiles` = :notryfiles,

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -364,6 +364,13 @@ return [
 						'value' => '1',
 						'checked' => true
 					],
+					'openbasedir_path' => [
+						'visible' => $result['openbasedir'] == '1',
+						'label' => lng('domain.openbasedirpath'),
+						'type' => 'select',
+						'select_var' => $openbasedir,
+						'selected' => $result['openbasedir_path']
+					],
 					'phpenabled' => [
 						'label' => lng('admin.phpenabled'),
 						'type' => 'checkbox',

--- a/lib/formfields/admin/domains/formfield.domains_add.php
+++ b/lib/formfields/admin/domains/formfield.domains_add.php
@@ -365,11 +365,10 @@ return [
 						'checked' => true
 					],
 					'openbasedir_path' => [
-						'visible' => $result['openbasedir'] == '1',
 						'label' => lng('domain.openbasedirpath'),
 						'type' => 'select',
 						'select_var' => $openbasedir,
-						'selected' => $result['openbasedir_path']
+						'selected' => 0
 					],
 					'phpenabled' => [
 						'label' => lng('admin.phpenabled'),

--- a/lib/formfields/admin/domains/formfield.domains_edit.php
+++ b/lib/formfields/admin/domains/formfield.domains_edit.php
@@ -390,6 +390,13 @@ return [
 						'value' => '1',
 						'checked' => $result['openbasedir']
 					],
+					'openbasedir_path' => [
+						'visible' => $result['openbasedir'] == '1',
+						'label' => lng('domain.openbasedirpath'),
+						'type' => 'select',
+						'select_var' => $openbasedir,
+						'selected' => $result['openbasedir_path']
+					],
 					'phpenabled' => [
 						'label' => lng('admin.phpenabled'),
 						'type' => 'checkbox',


### PR DESCRIPTION
# Description
Admins should be able to modify the OpenBasedir path for domains, just like customers can.

Fixes #1086

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have not added unit tests for this, as there are no tests for the openbasedir field or the openbasedir_path field for Subdomains either, but I have tested it manually by adding and updating domains while changing this field.

**Test Configuration**:

* Distribution: Debian 11
* Webserver: nginx 
* PHP: 8.2.5 FPM
* etc.etc.:

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
