### PR TITLE
Disable autocomplete on 2FA input element

### DIFF
--- a/templates/Froxlor/login/enter2fa.html.twig
+++ b/templates/Froxlor/login/enter2fa.html.twig
@@ -12,7 +12,7 @@
 
 						<div class="mb-3">
 							<label for="2fa_code" class="col-form-label">{{ lng('login.2facode') }}</label>
-							<input class="form-control" type="text" name="2fa_code" id="2fa_code" value="" autofocus required/>
+							<input class="form-control" type="text" name="2fa_code" id="2fa_code" value="" autocomplete="off" autofocus required/>
 						</div>
 
 					</div>


### PR DESCRIPTION
# Description
2FA codes change every login. So there is no need to save entered values in browser and suggest them again during future logins.

According to https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete there also exists the value `one-time-code` for `autocomplete`, but e.g. Chrome doesn't support it. That's why the value `off` was chosen.

## Type of change

- [x] Improvement

# How Has This Been Tested?

Tested with browsers:

- [x] Firefox 111.0.1
- [x] Chrome 112.0.5615.49

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
