### PR TITLE
Fix IPv6 address in cookie domain

### DIFF
--- a/lib/Froxlor/UI/Panel/UI.php
+++ b/lib/Froxlor/UI/Panel/UI.php
@@ -87,6 +87,29 @@ class UI
 
 		return $isHttps && (strcasecmp('on', $isHttps) == 0 || strcasecmp('https', $isHttps) == 0);
 	}
+
+	/**
+	 * Extract the cookie host from HTTP_HOST, stripping the port.
+	 */
+	public static function getCookieHost(): ?string
+	{
+		if (empty($_SERVER['HTTP_HOST']))
+			return null;
+
+		$colonPosition = strrpos($_SERVER['HTTP_HOST'], ':');
+		// There's no port in the host
+		if ($colonPosition === false)
+			return $_SERVER['HTTP_HOST'];
+
+		$closingSquareBracketPosition = strrpos($_SERVER['HTTP_HOST'], ']');
+		// The host is an IPv4 address or hostname with port
+		if ($closingSquareBracketPosition === false)
+			return substr($_SERVER['HTTP_HOST'], 0, $colonPosition);
+
+		// The host is an IPv6 address with port
+		return substr($_SERVER['HTTP_HOST'], 0, $closingSquareBracketPosition + 1);
+	}
+
 	/**
 	 * send various security related headers
 	 */

--- a/lib/Froxlor/UI/Panel/UI.php
+++ b/lib/Froxlor/UI/Panel/UI.php
@@ -115,11 +115,10 @@ class UI
 	 */
 	public static function sendHeaders()
 	{
-		$cookie_host = empty($_SERVER['HTTP_HOST']) ? null : explode (':', $_SERVER['HTTP_HOST'])[0];
 		session_set_cookie_params([
 			'lifetime' => self::$install_mode ? 7200 : 600, // will be renewed based on settings in lib/init.php
 			'path' => '/',
-			'domain' => $cookie_host,
+			'domain' => self::getCookieHost(),
 			'secure' => self::requestIsHttps(),
 			'httponly' => true,
 			'samesite' => 'Strict'

--- a/lib/init.php
+++ b/lib/init.php
@@ -331,11 +331,10 @@ if (CurrentUser::hasSession()) {
 		}
 	}
 	// update cookie lifetime
-	$cookie_host = empty($_SERVER['HTTP_HOST']) ? null : explode (':', $_SERVER['HTTP_HOST'])[0];
 	$cookie_params = [
 		'expires' => time() + Settings::Get('session.sessiontimeout'),
 		'path' => '/',
-		'domain' => $cookie_host,
+		'domain' => UI::getCookieHost(),
 		'secure' => UI::requestIsHttps(),
 		'httponly' => true,
 		'samesite' => 'Strict'


### PR DESCRIPTION
# Description
This PR fixes the incorrect handling of literal IPv6 addresses in the cookie domain.

Currently, the cookie domain is broken, when using a literal IPv6 address to access Froxlor:
```
➜  ~ curl -sI "http://froxlor.home/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=gd76r4bln50mqim4i310304ckn; expires=Tue, 09-May-2023 23:51:16 GMT; Max-Age=7200; path=/; domain=froxlor.home; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://froxlor.home:8080/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=nvtgr79p4d1b0ibu75e4l36ktp; expires=Tue, 09-May-2023 23:51:24 GMT; Max-Age=7200; path=/; domain=froxlor.home; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://192.168.4.4/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=2j0dn1c97cod7i5v62vaej0rma; expires=Tue, 09-May-2023 23:51:40 GMT; Max-Age=7200; path=/; domain=192.168.4.4; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://192.168.4.4:8080/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=sf8dml6okuc9vpev3kgtm05mph; expires=Tue, 09-May-2023 23:51:44 GMT; Max-Age=7200; path=/; domain=192.168.4.4; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://[2001:9e8:5cf0:1201:fc32:88ff:fe1c:d9cd]/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=shru3irs4d9sq008433nf4guct; expires=Tue, 09-May-2023 23:51:52 GMT; Max-Age=7200; path=/; domain=[2001; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://[2001:9e8:5cf0:1201:fc32:88ff:fe1c:d9cd]:8080/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=c4klojb2bv3fiul5s7nripomrp; expires=Tue, 09-May-2023 23:51:56 GMT; Max-Age=7200; path=/; domain=[2001; HttpOnly; SameSite=Strict
```
Note `domain=[2001;` in the last two examples. This broken domain causes the cookie to not be used by the browser, so it's e.g. impossible to finish initial setup of Froxlor. I expect e.g. the login to be broken as well in.

With this patch applied, the handling of literal IPv6 is fixed, so that the cookie domain is correctly set:
```
➜  ~ curl -sI "http://froxlor.home/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=4ecqhfeop9n4ou5tgrlrjp7n7d; expires=Tue, 09-May-2023 23:54:42 GMT; Max-Age=7200; path=/; domain=froxlor.home; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://froxlor.home:8080/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=6365e4r81qo0cisi6jlaej52ga; expires=Tue, 09-May-2023 23:54:45 GMT; Max-Age=7200; path=/; domain=froxlor.home; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://192.168.4.4/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=dmfh00eh079jv500u41t41u83r; expires=Tue, 09-May-2023 23:54:48 GMT; Max-Age=7200; path=/; domain=192.168.4.4; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://192.168.4.4:8080/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=pi8n2ogd5n8qsnahp6vk7gpbil; expires=Tue, 09-May-2023 23:54:50 GMT; Max-Age=7200; path=/; domain=192.168.4.4; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://[2001:9e8:5cf0:1201:fc32:88ff:fe1c:d9cd]/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=ffuno7q225jirco1arjrhr1egl; expires=Tue, 09-May-2023 23:54:54 GMT; Max-Age=7200; path=/; domain=[2001:9e8:5cf0:1201:fc32:88ff:fe1c:d9cd]; HttpOnly; SameSite=Strict
➜  ~ curl -sI "http://[2001:9e8:5cf0:1201:fc32:88ff:fe1c:d9cd]:8080/froxlor/install/install.php" | grep Set-Cookie
Set-Cookie: PHPSESSID=i64d76rrv9ususl57lra6l1dcb; expires=Tue, 09-May-2023 23:54:57 GMT; Max-Age=7200; path=/; domain=[2001:9e8:5cf0:1201:fc32:88ff:fe1c:d9cd]; HttpOnly; SameSite=Strict
```
Note the `domain` in the last two exampled being correct now. With this I am now able to finish the setup and log in.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I've tested running Apache and making it listen both port 80 and 8080 for IPv4 and IPv6. I then access Froxlor via hostname, hostname + port 8080, IPv4 address, IPv4 address + port 8080, IPv6 address, IPv6 address + port 8080 (see the curl commands above).

**Test Configuration**:

* Distribution: Debian Bullseye
* Webserver: Apache 2.4.56-1~deb11u2
* PHP: 7.4
* Followed the install guide from the website and accessed the installer via the literal IPv6 address

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
