### PR TITLE
replace deprecated function utf8_encode

### DIFF
--- a/lib/Froxlor/Idna/IdnaWrapper.php
+++ b/lib/Froxlor/Idna/IdnaWrapper.php
@@ -64,7 +64,7 @@ class IdnaWrapper
 	 */
 	public function encode(string $to_encode): string
 	{
-		$to_encode = $this->isUtf8($to_encode) ? $to_encode : utf8_encode($to_encode);
+		$to_encode = $this->isUtf8($to_encode) ? $to_encode : mb_convert_encoding($to_encode, 'UTF-8');
 		try {
 			return $this->idna_converter->encode($to_encode);
 		} catch (InvalidArgumentException $iae) {


### PR DESCRIPTION
utf8_encode is deprecated since PHP 8.2.0

# Description

See [PHP documentation](https://www.php.net/manual/en/function.utf8-encode.php).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* Distribution:
* Webserver:
* PHP:
* etc.etc.:

# Checklist:

- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
