### PR TITLE
Add manual_config install var to cli

### DIFF
--- a/lib/Froxlor/Cli/InstallCommand.php
+++ b/lib/Froxlor/Cli/InstallCommand.php
@@ -273,7 +273,7 @@ final class InstallCommand extends Command
 					$cmdfield['label'],
 					$cmdfield['value']
 				]);
-				if (!empty($decoded_input) || $this->io->confirm('Execute command now?', false)) {
+				if (!empty($decoded_input) ? (!isset($decoded_input['manual_config']) || !filter_var($decoded_input['manual_config'], FILTER_VALIDATE_BOOLEAN)) : $this->io->confirm('Execute command now?', false)) {
 					passthru($cmdfield['value']);
 				}
 				break;
@@ -305,7 +305,7 @@ final class InstallCommand extends Command
 		$json_output = [];
 		foreach ($fields['install']['sections'] as $section => $section_fields) {
 			foreach ($section_fields['fields'] as $name => $field) {
-				if ($name == 'system' || $name == 'manual_config' || $name == 'target_servername') {
+				if ($name == 'system' || $name == 'target_servername') {
 					continue;
 				}
 				if ($field['type'] == 'text' || $field['type'] == 'email') {

--- a/lib/Froxlor/Cli/InstallCommand.php
+++ b/lib/Froxlor/Cli/InstallCommand.php
@@ -273,8 +273,10 @@ final class InstallCommand extends Command
 					$cmdfield['label'],
 					$cmdfield['value']
 				]);
-				if (!empty($decoded_input) ? (!isset($decoded_input['manual_config']) || !filter_var($decoded_input['manual_config'], FILTER_VALIDATE_BOOLEAN)) : $this->io->confirm('Execute command now?', false)) {
-					passthru($cmdfield['value']);
+				if (!isset($decoded_input['manual_config']) || (bool)$decoded_input['manual_config'] === false) {
+					if (!empty($decoded_input) || $this->io->confirm('Execute command now?', false)) {
+						passthru($cmdfield['value']);
+					}
 				}
 				break;
 		}


### PR DESCRIPTION
Make the manual_config var, which is available to the web installer, usuable for the cli installer too. If manual_config is set to true skip else (not set or false) proceed with auto config.

Maybe example in docs needs to be updated, too.