### PR TITLE
Fix auto config cmd display on manual_config

### DIFF
--- a/lib/Froxlor/Cli/InstallCommand.php
+++ b/lib/Froxlor/Cli/InstallCommand.php
@@ -265,15 +265,15 @@ final class InstallCommand extends Command
 				return $this->showStep(++$step, $extended, $decoded_input);
 				break;
 			case 4:
-				$section = $inst->formfield['install']['sections']['step' . $step] ?? [];
-				$this->io->section($section['title']);
-				$this->io->note($this->cliTextFormat($section['description']));
-				$cmdfield = $section['fields']['system'];
-				$this->io->success([
-					$cmdfield['label'],
-					$cmdfield['value']
-				]);
 				if (!isset($decoded_input['manual_config']) || (bool)$decoded_input['manual_config'] === false) {
+					$section = $inst->formfield['install']['sections']['step' . $step] ?? [];
+					$this->io->section($section['title']);
+					$this->io->note($this->cliTextFormat($section['description']));
+					$cmdfield = $section['fields']['system'];
+					$this->io->success([
+						$cmdfield['label'],
+						$cmdfield['value']
+					]);
 					if (!empty($decoded_input) || $this->io->confirm('Execute command now?', false)) {
 						passthru($cmdfield['value']);
 					}


### PR DESCRIPTION
Only display command for automatic install if no manual_config was specified.

_TODO: It would be good to only display the auto cmd if the "Execute command now?" confirmation request pops up._