### PR TITLE
Ensure XPath for ConfigDaemon matches exactly one element

### DIFF
--- a/lib/Froxlor/Config/ConfigDaemon.php
+++ b/lib/Froxlor/Config/ConfigDaemon.php
@@ -91,6 +91,9 @@ class ConfigDaemon
 		$this->fullxml = $xml;
 		$this->xpath = $xpath;
 		$this->daemon = $this->fullxml->xpath($this->xpath);
+		if (count($this->daemon) !== 1) {
+			throw new Exception('XPath "' . $this->xpath . '" didn\'t return exactly one element');
+		}
 		$attributes = $this->daemon[0]->attributes();
 		if ($attributes['title'] != '') {
 			$this->title = $this->parseContent((string)$attributes['title']);

--- a/lib/configfiles/gentoo.xml
+++ b/lib/configfiles/gentoo.xml
@@ -1702,7 +1702,7 @@ dovecot	  unix	-	n	n	-	-	pipe
 					</include>
 				</daemon>
 				<!-- postfix with dovecot -->
-				<daemon name="postfix_dovecot"
+				<daemon name="postfix_dovecot" version="3"
 					title="Postfix 3 with dovecot" default="true">
 					<include>//service[@type='smtp']/general/commands[@index=1]
 					</include>


### PR DESCRIPTION
# Description

ConfigDaemon always uses the first matched element from specified XPath https://github.com/Froxlor/Froxlor/blob/87409473231f7f928ae36bff02362a7e034b9e4f/lib/Froxlor/Config/ConfigDaemon.php#L94 but didn't check if specified XPath matched exactly one element.

The Gentoo config XML has two different versions for the daemon `postfix_dovecot` specified:
- https://github.com/Froxlor/Froxlor/blob/87409473231f7f928ae36bff02362a7e034b9e4f/lib/configfiles/gentoo.xml#L1557
- https://github.com/Froxlor/Froxlor/blob/87409473231f7f928ae36bff02362a7e034b9e4f/lib/configfiles/gentoo.xml#L1705

The second version in line 1705 is missing the `version` attribute. This causes the XPath (based only on the `name` attribute) to match both elements and results in a broken output for service configuration (version from line 1557 is displayed twice).

![g_1](https://github.com/Froxlor/Froxlor/assets/35873310/5cf4bae4-81ca-42b2-baef-27ca42b01a22)

# Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- dc220b7a8e5f2237effe2f496a35d68a248030fc causes exception when using Gentoo as expected because of non unique XPath
- dc220b7a8e5f2237effe2f496a35d68a248030fc + b55071aeac4cd82ffe4e435cdf7fb409e2291255 fixes the problem when using Gentoo 
  ![g_2](https://github.com/Froxlor/Froxlor/assets/35873310/22d2f211-6a21-4184-8de2-2600a8cc9c4e)
- manually checked other distro XMLs for duplicated `name` attributes for daemons -> none found -> only Gentoo affected

