### PR TITLE
Check for Argon2 support before using constant PASSWORD_ARGON2X

### DIFF
--- a/lib/Froxlor/Api/Commands/EmailAccounts.php
+++ b/lib/Froxlor/Api/Commands/EmailAccounts.php
@@ -157,10 +157,10 @@ class EmailAccounts extends ApiCommand implements ResourceEntity
 
 			// prefix hash-algo
 			switch (Settings::Get('system.passwordcryptfunc')) {
-				case PASSWORD_ARGON2I:
+				case defined('PASSWORD_ARGON2I') && PASSWORD_ARGON2I:
 					$cpPrefix = '{ARGON2I}';
 					break;
-				case PASSWORD_ARGON2ID:
+				case defined('PASSWORD_ARGON2ID') && PASSWORD_ARGON2ID:
 					$cpPrefix = '{ARGON2ID}';
 					break;
 				default:
@@ -404,10 +404,10 @@ class EmailAccounts extends ApiCommand implements ResourceEntity
 			$password = Crypt::validatePassword($password, true);
 			// prefix hash-algo
 			switch (Settings::Get('system.passwordcryptfunc')) {
-				case PASSWORD_ARGON2I:
+				case defined('PASSWORD_ARGON2I') && PASSWORD_ARGON2I:
 					$cpPrefix = '{ARGON2I}';
 					break;
-				case PASSWORD_ARGON2ID:
+				case defined('PASSWORD_ARGON2ID') && PASSWORD_ARGON2ID:
 					$cpPrefix = '{ARGON2ID}';
 					break;
 				default:

--- a/tests/Emails/EmailsTest.php
+++ b/tests/Emails/EmailsTest.php
@@ -426,10 +426,10 @@ class MailsTest extends TestCase
 		$this->assertEquals(1, $result['popaccountid']);
 
 		switch (Settings::Get('system.passwordcryptfunc')) {
-			case PASSWORD_ARGON2I:
+			case defined('PASSWORD_ARGON2I') && PASSWORD_ARGON2I:
 				$cpPrefix = '{ARGON2I}';
 				break;
-			case PASSWORD_ARGON2ID:
+			case defined('PASSWORD_ARGON2ID') && PASSWORD_ARGON2ID:
 				$cpPrefix = '{ARGON2ID}';
 				break;
 			default:


### PR DESCRIPTION
# Description

Adding a new mail account on a system without PHP Argon2X support an exception will be triggered.

![e1](https://github.com/Froxlor/Froxlor/assets/35873310/379cca12-c902-429a-bea9-037c4d3e84ea)

-> Check if Argon2X is supported in PHP (==constant is defined) before using it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Adding a mail account on a system without PHP Argon2X support was possible after patch