### PR TITLE
Fix "expires" option cannot have a year greater than 9999

### DIFF
--- a/actions/admin/settings/110.accounts.php
+++ b/actions/admin/settings/110.accounts.php
@@ -35,6 +35,7 @@ return [
 					'varname' => 'sessiontimeout',
 					'type' => 'number',
 					'min' => 60,
+					'max' => 31536000,
 					'default' => 600,
 					'save_method' => 'storeSettingField'
 				],

--- a/lib/init.php
+++ b/lib/init.php
@@ -369,7 +369,7 @@ if (CurrentUser::hasSession()) {
 	}
 	// update cookie lifetime
 	$cookie_params = [
-		'expires' => time() + Settings::Get('session.sessiontimeout'),
+		'expires' => time() + min(Settings::Get('session.sessiontimeout'), 31536000),
 		'path' => '/',
 		'domain' => UI::getCookieHost(),
 		'secure' => UI::requestIsHttps(),


### PR DESCRIPTION
This fixes the exception: '"expires" option cannot have a year greater than 9999', which happens on upgrade from Debian 11 to 12. The session timeout in the DB is 9999999999999, so we constrain the value.