### PR TITLE
Automatic assigment of "worker_processes" in nginx

### DIFF
--- a/lib/configfiles/bookworm.xml
+++ b/lib/configfiles/bookworm.xml
@@ -168,8 +168,9 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 					<file name="/etc/nginx/nginx.conf" backup="true">
 						<content><![CDATA[
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /var/run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
 	worker_connections 768;

--- a/lib/configfiles/bullseye.xml
+++ b/lib/configfiles/bullseye.xml
@@ -168,8 +168,9 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 					<file name="/etc/nginx/nginx.conf" backup="true">
 						<content><![CDATA[
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /var/run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
 	worker_connections 768;

--- a/lib/configfiles/focal.xml
+++ b/lib/configfiles/focal.xml
@@ -167,8 +167,9 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 					<file name="/etc/nginx/nginx.conf" backup="true">
 						<content><![CDATA[
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /var/run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
 	worker_connections 768;

--- a/lib/configfiles/jammy.xml
+++ b/lib/configfiles/jammy.xml
@@ -167,8 +167,9 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 					<file name="/etc/nginx/nginx.conf" backup="true">
 						<content><![CDATA[
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /var/run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
 	worker_connections 768;

--- a/lib/configfiles/noble.xml
+++ b/lib/configfiles/noble.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <froxlor>
-	<distribution name="Ubuntu" codename="noble"
+	<distribution name="Ubuntu" codename="Noble"
 		version="24.04" defaulteditor="/bin/nano">
 		<!-- OS defaults to be loaded on installation -->
 		<defaults>
@@ -167,8 +167,9 @@ include_shell "/usr/share/lighttpd/include-conf-enabled.pl"
 					<file name="/etc/nginx/nginx.conf" backup="true">
 						<content><![CDATA[
 user www-data;
-worker_processes 4;
+worker_processes auto;
 pid /var/run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
 events {
 	worker_connections 768;


### PR DESCRIPTION
It seems that "worker_processes" auto feature is currently supported by all distributions supported by froxlor. This feautre seems older than i thought, so even old version should support it.

Automatic assignment should more optimize the nginx enviroment for more than 4 cpu cores or maybe even less cores.

This change was taken from default config of each distro, i have downloaded every version from WSL and tested the nginx.

Sources of the versions for each distro:
Ubuntu: https://packages.ubuntu.com/search?keywords=nginx
Debian bullseye: https://packages.debian.org/bullseye/nginx
Debian bookworm: https://packages.debian.org/bookworm/nginx

Nginx docs reference:
https://nginx.org/en/docs/ngx_core_module.html#worker_processes