### PR TITLE
Fix escaped html in description on Froxlor update screen

### DIFF
--- a/templates/Froxlor/form/formfields.html.twig
+++ b/templates/Froxlor/form/formfields.html.twig
@@ -3,7 +3,7 @@
 		{% if norow == false and (field.type != 'hidden' or (field.type == 'hidden' and field.display is defined and field.display is not empty)) %}
 			<div class="row g-0 formfield d-flex align-items-center">
 				{% if field.prior_infotext is defined and field.prior_infotext|length > 0 %}
-					<h5>{{ field.prior_infotext }}</h5>
+					<h5>{{ field.prior_infotext|raw }}</h5>
 				{% endif %}
 				{% if field.label is iterable %}
 					<label for="{{ id }}" class="col-sm-6 col-form-label pe-3">


### PR DESCRIPTION
# Description

Add |raw to the h5 in the template to fix the escaped HTML output for example on admin_updates.php with the 2.2 update.

Before: 
![image](https://github.com/user-attachments/assets/a12d8510-7724-4209-b5e9-10fb4b1a6497)

After:
![image](https://github.com/user-attachments/assets/8675bc62-2a9a-47a3-ad17-a24fe962e3d0)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

 - Make change
 - See correctly formatted output

**Test Configuration**:

* Distribution: Debian 12
* Webserver: Nginx
* PHP: 8.3 FPM
* etc.etc.:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
