### PR TITLE
Fix missing proftpd-mod-wrap installation

### DIFF
--- a/lib/configfiles/noble.xml
+++ b/lib/configfiles/noble.xml
@@ -2121,7 +2121,7 @@ action = "no action";
 			<service type="ftp" title="{{lng.admin.configfiles.ftp}}">
 				<!-- Proftpd -->
 				<daemon name="proftpd" title="ProFTPd" default="true">
-					<install><![CDATA[apt-get install proftpd-basic proftpd-mod-mysql proftpd-mod-crypto]]></install>
+					<install><![CDATA[apt-get install proftpd-basic proftpd-mod-mysql proftpd-mod-crypto proftpd-mod-wrap]]></install>
 					<file name="/etc/proftpd/create-cert.sh" chown="root:0"
 						chmod="0700">
 						<content><![CDATA[#!/bin/bash


### PR DESCRIPTION
Missing Package Installation on Ubuntu Noble 24.04 - proftpd-mod-wrap (Froxlor 2.20) #1271

# Description

Change installation script to
apt-get install proftpd-basic proftpd-mod-mysql proftpd-mod-crypto proftpd-mod-wrap

Fixes #1271 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

* Distribution:
* Webserver:
* PHP:
* etc.etc.:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
