### PR TITLE
Adjust dovecot LDA options to allow SMTP relaying

### DIFF
--- a/lib/configfiles/bookworm.xml
+++ b/lib/configfiles/bookworm.xml
@@ -2455,7 +2455,7 @@ mailman   unix  -       n       n       -       -       pipe
   ${nexthop} ${user}
 # Dovecot LDA
 dovecot	  unix	-	n	n	-	-	pipe
-	flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+	flags=DORhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${recipient}
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/bullseye.xml
+++ b/lib/configfiles/bullseye.xml
@@ -2455,7 +2455,7 @@ mailman   unix  -       n       n       -       -       pipe
   ${nexthop} ${user}
 # Dovecot LDA
 dovecot	  unix	-	n	n	-	-	pipe
-	flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+	flags=DORhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${recipient}
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/focal.xml
+++ b/lib/configfiles/focal.xml
@@ -1912,7 +1912,7 @@ postlog   unix-dgram n  -       n       -       1       postlogd
 #
 # Dovecot LDA
 dovecot	  unix	-	n	n	-	-	pipe
-	flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+	flags=DORhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${recipient}
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/jammy.xml
+++ b/lib/configfiles/jammy.xml
@@ -1912,7 +1912,7 @@ postlog   unix-dgram n  -       n       -       1       postlogd
 #
 # Dovecot LDA
 dovecot	  unix	-	n	n	-	-	pipe
-	flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+	flags=DORhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${recipient}
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/noble.xml
+++ b/lib/configfiles/noble.xml
@@ -1912,7 +1912,7 @@ postlog   unix-dgram n  -       n       -       1       postlogd
 #
 # Dovecot LDA
 dovecot	  unix	-	n	n	-	-	pipe
-	flags=DRhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -d ${recipient}
+	flags=DORhu user=vmail:vmail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${recipient}
 ]]>
 						</content>
 					</file>


### PR DESCRIPTION
# Description

When postfix is configured with a SMTP relay, forwarded mail is rejected.  This is because the sender envelope address is not rewritten.  Change the postfix dovecot LDA configuration to rewrite the sender envelope address.  This allows the SMTP relay service to validate that the mail is coming from an accepted domain.  The From: header is left unchanged.

Fixes #1278

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I am using this in production.  Logs uploaded to the issue indicate that it works.

**Test Configuration**:

* Distribution: Ubuntu 22.04
* POP/IMAP server: Dovecot
* SMTP server: postfix

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
