### PR TITLE
Fix incorrect width of APCu Hit/Miss bar

### DIFF
--- a/templates/Froxlor/settings/apcuinfo.html.twig
+++ b/templates/Froxlor/settings/apcuinfo.html.twig
@@ -55,7 +55,7 @@
 							<div class="progress-bar bg-success"></div>
 						</div>
 						<div class="progress" role="progressbar"
-							 style="width: {{ 100 - apcuinfo.num_misses_percentage }}%"
+							 style="width: {{ apcuinfo.num_misses_percentage }}%"
 							 aria-valuenow="{{ apcuinfo.num_misses }}" aria-valuemin="0"
 							 aria-valuemax="{{ apcuinfo.num_hits_and_misses }}">
 							<div class="progress-bar bg-danger"></div>


### PR DESCRIPTION
# Description
The width of the APCu Miss bar in the Hit/Miss graph on the APCu info page is calculated incorrectly, resulting in both bars always being the same width. This PR fixes that issue.

Before:
<img width="398" alt="image" src="https://github.com/user-attachments/assets/9091a975-bd1b-4eb5-a82b-8353e098bbf6">

After:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/a7e8d8ab-96c0-4eda-907e-5d1b865d35b9">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Make change
2. See bars with correct width

**Test Configuration**:

* Distribution: Debian 12
* Webserver: Nginx
* PHP: 8.3 FPM
* etc.etc.:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
