### PR TITLE
Fix APCu memory usage percent

### DIFF
--- a/admin_apcuinfo.php
+++ b/admin_apcuinfo.php
@@ -118,7 +118,7 @@ if ($page == 'showinfo' && $userinfo['change_serversettings'] == '1') {
 		'uptime' => duration($cache['start_time'])
 	];
 
-	$overview['mem_used_percentage'] = number_format(($overview['mem_used'] / $overview['mem_avail']) * 100, 1);
+	$overview['mem_used_percentage'] = number_format(($overview['mem_used'] / $overview['mem_size']) * 100, 1);
 	$overview['num_hits_percentage'] = number_format(($overview['num_hits'] / $overview['num_hits_and_misses']) * 100,
 		1);
 	$overview['num_misses_percentage'] = number_format(($overview['num_misses'] / $overview['num_hits_and_misses']) * 100,


### PR DESCRIPTION
# Description
The APCu memory usage percent is not correct, because it is calculated with mem_avail, not with the mem_size.
This can lead to values above 100%, which obviously does not make sense.

Before: 
<img width="377" alt="Bildschirmfoto 2024-10-07 um 14 32 45" src="https://github.com/user-attachments/assets/38e09748-87a2-48ec-8b23-71f090666158">

After:
<img width="381" alt="Bildschirmfoto 2024-10-07 um 14 31 57" src="https://github.com/user-attachments/assets/37000d6f-2312-4b90-8ca5-60a2ef9f4db5">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Make change, see correct percentage :)

**Test Configuration**:

* Distribution: Debian 12
* Webserver: Nginx
* PHP: 8.3 FPM
* etc.etc.:
