### PR TITLE
Relax dkim_entry visibilty for admins in domain editor like it is for customers

### DIFF
--- a/lib/formfields/admin/domains/formfield.domains_edit.php
+++ b/lib/formfields/admin/domains/formfield.domains_edit.php
@@ -437,7 +437,7 @@ return [
 			'section_d' => [
 				'title' => lng('admin.nameserversettings'),
 				'image' => 'icons/domain_edit.png',
-				'visible' => ($userinfo['change_serversettings'] == '1' && Settings::Get('system.bind_enable') == '1') || ($result['isemaildomain'] == '1' && (Settings::Get('spf.use_spf') == '1' || Settings::Get('dmarc.use_dmarc') == '1' || (Settings::Get('antispam.activated') == '1' && $result['dkim'] == '1' && $result['dkim_pubkey'] != ''))),
+				'visible' => ($userinfo['change_serversettings'] == '1' && Settings::Get('system.bind_enable') == '1') || ($result['isemaildomain'] == '1' && (Settings::Get('spf.use_spf') == '1' || Settings::Get('dmarc.use_dmarc') == '1') || Settings::Get('antispam.activated') == '1' && $result['dkim'] == '1' && $result['dkim_pubkey'] != ''),
 				'fields' => [
 					'isbinddomain' => [
 						'visible' => $userinfo['change_serversettings'] == '1' && Settings::Get('system.bind_enable') == '1',
@@ -466,7 +466,7 @@ return [
 						'value' => (string)(new \Froxlor\Dns\DnsEntry('_dmarc', 'TXT', \Froxlor\Dns\Dns::encloseTXTContent(Settings::Get('dmarc.dmarc_entry'))))
 					],
 					'dkim_entry' => [
-						'visible' => (Settings::Get('antispam.activated') == '1' && $result['dkim'] == '1' && $result['dkim_pubkey'] != '' && $result['isemaildomain'] == '1'),
+						'visible' => (Settings::Get('antispam.activated') == '1' && $result['dkim'] == '1' && $result['dkim_pubkey'] != ''),
 						'label' => lng('antispam.required_dkim_dns'),
 						'type' => 'longtext',
 						'value' => (string)(new \Froxlor\Dns\DnsEntry('dkim' . $result['dkim_id'] . '._domainkey', 'TXT', \Froxlor\Dns\Dns::encloseTXTContent('v=DKIM1; k=rsa; p='.trim($result['dkim_pubkey']))))


### PR DESCRIPTION
# Description

Relax dkim_entry visibility for admins to be less strict like it is already for customers (e.g. when nameserver is off and not is email domain).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I tested it on our server by deploying the patched file and checked if it worked as intended.

**Test Configuration**:

* Distribution: Debian
* Webserver: Apache2
* PHP: 7.4
* Nameserver: Bind9 (turned off in settings and on when testing both ways)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes