### PR TITLE
Update Fcgid.php because PHP warning

### DIFF
--- a/lib/Froxlor/Cron/Http/Php/Fcgid.php
+++ b/lib/Froxlor/Cron/Http/Php/Fcgid.php
@@ -185,22 +185,26 @@ class Fcgid
 			$openbasedirc = ';';
 		}
 
-		$admin = $this->getAdminData($this->domain['adminid']);
-		$php_ini_variables = [
-			'SAFE_MODE' => 'Off', // keep this for compatibility, just in case
-			'PEAR_DIR' => Settings::Get('system.mod_fcgid_peardir'),
-			'TMP_DIR' => $this->getTempDir(),
-			'CUSTOMER_EMAIL' => $this->domain['email'],
-			'ADMIN_EMAIL' => $admin['email'],
-			'DOMAIN' => $this->domain['domain'],
-			'CUSTOMER' => $this->domain['loginname'],
-			'ADMIN' => $admin['loginname'],
-			'OPEN_BASEDIR' => $openbasedir,
-			'OPEN_BASEDIR_C' => $openbasedirc,
-			'OPEN_BASEDIR_GLOBAL' => Settings::Get('system.phpappendopenbasedir'),
-			'DOCUMENT_ROOT' => FileDir::makeCorrectDir($this->domain['documentroot']),
-			'CUSTOMER_HOMEDIR' => FileDir::makeCorrectDir($this->domain['customerroot'])
-		];
+$admin = $this->getAdminData($this->domain['adminid']);
+
+$admin_email = (is_array($admin) && isset($admin['email'])) ? $admin['email'] : '';
+$admin_loginname = (is_array($admin) && isset($admin['loginname'])) ? $admin['loginname'] : '';
+
+$php_ini_variables = [
+    'SAFE_MODE' => 'Off',
+    'PEAR_DIR' => Settings::Get('system.mod_fcgid_peardir'),
+    'TMP_DIR' => $this->getTempDir(),
+    'CUSTOMER_EMAIL' => $this->domain['email'],
+    'ADMIN_EMAIL' => $admin_email,
+    'DOMAIN' => $this->domain['domain'],
+    'CUSTOMER' => $this->domain['loginname'],
+    'ADMIN' => $admin_loginname,
+    'OPEN_BASEDIR' => $openbasedir,
+    'OPEN_BASEDIR_C' => $openbasedirc,
+    'OPEN_BASEDIR_GLOBAL' => Settings::Get('system.phpappendopenbasedir'),
+    'DOCUMENT_ROOT' => FileDir::makeCorrectDir($this->domain['documentroot']),
+    'CUSTOMER_HOMEDIR' => FileDir::makeCorrectDir($this->domain['customerroot'])
+];
 
 		// insert a small header for the file
 		$phpini_file = ";\n";


### PR DESCRIPTION
Fix PHP warnings in Fcgid.php for array access on boolean values Changes Made
Added safety checks: The code now uses is_array($admin) and isset() to verify that admin data was loaded correctly before accessing array elements

Defined fallback values: If no admin data is found, empty strings are used as fallback values to prevent the warnings

Separate variables: $admin_email and $admin_loginname are defined before being used in the array, ensuring proper type checking

Problem
The original code was trying to access array offsets on a boolean value (false) when getAdminData() couldn't find an admin with the given ID, causing PHP warnings on lines 194 and 197.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

* Distribution: Debian Bullseye
* Webserver: Apache/2.4.65
* PHP: 8.4.11

# Checklist:
- [x ] My changes generate no new warnings