### PR TITLE
Fix empty PATH_INFO fastcgi_param in nginx

### DIFF
--- a/lib/Froxlor/Cron/Http/Nginx.php
+++ b/lib/Froxlor/Cron/Http/Nginx.php
@@ -284,8 +284,10 @@ class Nginx extends HttpConfigBase
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_split_path_info ^(.+?\.php)(/.*)$;\n";
 					$this->nginx_data[$vhost_filename] .= "\t\tinclude " . Settings::Get('nginx.fastcgiparams') . ";\n";
 					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param SCRIPT_FILENAME \$request_filename;\n";
-					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param PATH_INFO \$fastcgi_path_info;\n";
 					$this->nginx_data[$vhost_filename] .= "\t\ttry_files \$fastcgi_script_name =404;\n";
+					$this->nginx_data[$vhost_filename] .= "\t\tset \$path_info \$fastcgi_path_info;\n";
+					$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param PATH_INFO \$path_info;\n";
+
 
 					if ($row_ipsandports['ssl'] == '1') {
 						$this->nginx_data[$vhost_filename] .= "\t\tfastcgi_param HTTPS on;\n";
@@ -1184,7 +1186,8 @@ class Nginx extends HttpConfigBase
 			$phpopts .= "\t\tfastcgi_split_path_info ^(.+?\.php)(/.*)$;\n";
 			$phpopts .= "\t\tinclude " . Settings::Get('nginx.fastcgiparams') . ";\n";
 			$phpopts .= "\t\tfastcgi_param SCRIPT_FILENAME \$request_filename;\n";
-			$phpopts .= "\t\tfastcgi_param PATH_INFO \$fastcgi_path_info;\n";
+			$phpopts .= "\t\tset \$path_info \$fastcgi_path_info;\n";
+			$phpopts .= "\t\tfastcgi_param PATH_INFO \$path_info;\n";
 			$phpopts .= "\t\tfastcgi_pass " . Settings::Get('system.nginx_php_backend') . ";\n";
 			$phpopts .= "\t\tfastcgi_index index.php;\n";
 			if ($domain['ssl'] == '1' && $ssl_vhost) {

--- a/lib/Froxlor/Cron/Http/NginxFcgi.php
+++ b/lib/Froxlor/Cron/Http/NginxFcgi.php
@@ -110,7 +110,8 @@ class NginxFcgi extends Nginx
 			$php_options_text .= "\t\t" . 'include ' . Settings::Get('nginx.fastcgiparams') . ";\n";
 			$php_options_text .= "\t\t" . 'fastcgi_split_path_info ^(.+?\.php)(/.*)$;' . "\n";
 			$php_options_text .= "\t\t" . 'fastcgi_param SCRIPT_FILENAME $request_filename;' . "\n";
-			$php_options_text .= "\t\t" . 'fastcgi_param PATH_INFO $2;' . "\n";
+			$php_options_text .= "\t\t" . 'set $path_info $fastcgi_path_info;' . "\n";
+			$php_options_text .= "\t\t" . 'fastcgi_param PATH_INFO $path_info;' . "\n";
 			if ($domain['ssl'] == '1' && $ssl_vhost) {
 				$php_options_text .= "\t\t" . 'fastcgi_param HTTPS on;' . "\n";
 			}


### PR DESCRIPTION
Up until now, PATH_INFO was always empty when using PHP with nginx.

We haven't had any customers or projects using PATH_INFO, so it never came up as an issue. However, Roundcube decided to use and rely on that with their upcoming 1.7 update (where they use a separate public_html folder as root and including static assets via abominations like "/assets.php/css/somefile.css" - which won't work with an empty PATH_INFO (which would include the "css/somefile.css" in this example to work with).

After some digging, this seems to be a long-standing nginx bug (10 years or so) when using try_files and using the $fastcgi_path_info variable after, which try_files seems to override and set to empty!?

This can be fixed with a temporary variable and using this in fastcgi_param.

References:
https://github.com/nginx/nginx/issues/879
https://serverfault.com/questions/502790/security-issue-on-nginx-php-fastcgi-split-path-info/800078#800078

This shouldn't be a breaking change for anyone, since it didn't work before and now it does.