### PR TITLE
Fix implicitly marked variables as null

### DIFF
--- a/lib/Froxlor/Cron/Http/DomainSSL.php
+++ b/lib/Froxlor/Cron/Http/DomainSSL.php
@@ -45,7 +45,7 @@ class DomainSSL
 	 * @return null
 	 * @throws \Exception
 	 */
-	public function setDomainSSLFilesArray(array &$domain = null)
+	public function setDomainSSLFilesArray(?array &$domain = null)
 	{
 		// check if the domain itself has a certificate defined
 		$dom_certs_stmt = Database::prepare("

--- a/lib/Froxlor/Http/Directory.php
+++ b/lib/Froxlor/Http/Directory.php
@@ -47,7 +47,7 @@ class Directory
 	 *
 	 * @param string $dir
 	 */
-	public function __construct(string $dir = null)
+	public function __construct(?string $dir = null)
 	{
 		$this->dir = $dir;
 	}


### PR DESCRIPTION
Fixes:

```
PHP Deprecated:  Froxlor\Cron\Http\DomainSSL::setDomainSSLFilesArray(): Implicitly marking parameter $domain as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/froxlor/lib/Froxlor/Cron/Http/DomainSSL.php on line 48
PHP Deprecated:  Froxlor\Http\Directory::__construct(): Implicitly marking parameter $dir as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/froxlor/lib/Froxlor/Http/Directory.php on line 50
```