### PR TITLE
Enhance session path validation in PhpSessionclean

### DIFF
--- a/lib/Froxlor/Cli/PhpSessionclean.php
+++ b/lib/Froxlor/Cli/PhpSessionclean.php
@@ -79,6 +79,13 @@ final class PhpSessionclean extends CliCommand
 				$pattern = preg_quote('session.save_path', '/');
 				$pattern = "/" . $pattern . ".+?\=(.*)/";
 				if (preg_match_all($pattern, $contents, $matches)) {
+					$session_path = trim($matches[1][0]);
+					// Skip non-file-based session storage (Redis, Memcached, etc.)
+					// These typically contain protocol indicators like :// or are not valid directories
+					if (strpos($session_path, '://') !== false) {
+						// Skip paths with protocol indicators (tcp://, redis://, memcached://, etc.)
+						continue;
+					}
 					$paths_to_clean[] = FileDir::makeCorrectDir(trim($matches[1][0]));
 				}
 			}


### PR DESCRIPTION
Add checks to skip non-file-based session storage.

# Description

The `froxlor:php-sessionclean` command was failing with "No such file or directory" errors when PHP sessions were configured to use non-file-based storage such as Redis, Memcached, or other session handlers that use protocol-based paths (e.g., `tcp://127.0.0.1:6379`).

The script was attempting to run `find` on these protocol-based paths, which are not valid filesystem directories. This change adds a check to skip any session paths containing protocol indicators (`://`) before processing them, preventing the error and allowing the script to continue processing valid file-based session storage paths.

Fixes the issue where Redis session storage caused errors when running the session cleanup cron job.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

1. **Test A**: Configured PHP-FPM pool with Redis session storage (`session.save_path = tcp://127.0.0.1:6379`)
   - Ran `froxlor:php-sessionclean` command
   - Verified that the command completes without errors
   - Confirmed that Redis session paths are skipped (no "No such file or directory" error)

2. **Test B**: Configured PHP-FPM pool with file-based session storage (`session.save_path = /tmp`)
   - Ran `froxlor:php-sessionclean` command
   - Verified that file-based session paths are still processed correctly
   - Confirmed that old session files are cleaned up as expected


**Test Configuration**:

* Distribution: Gentoo
* Webserver: Apache
* PHP: 8.2 with PHP-FPM
* Session Storage: Redis (tcp://127.0.0.1:6379) and file-based (/var/lib/php/sessions)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
