### PR TITLE
fix froxlor (an probably many others) on http3: populate [HTTP_HOST]

### DIFF
--- a/lib/configfiles/bookworm.xml
+++ b/lib/configfiles/bookworm.xml
@@ -225,6 +225,9 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Fix for HTTP/3 ($http_host is not populated automatically)
+fastcgi_param  HTTP_HOST          $host;
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/bullseye.xml
+++ b/lib/configfiles/bullseye.xml
@@ -225,6 +225,9 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Fix for HTTP/3 ($http_host is not populated automatically)
+fastcgi_param  HTTP_HOST          $host;
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/focal.xml
+++ b/lib/configfiles/focal.xml
@@ -224,6 +224,9 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Fix for HTTP/3 ($http_host is not populated automatically)
+fastcgi_param  HTTP_HOST          $host;
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/jammy.xml
+++ b/lib/configfiles/jammy.xml
@@ -224,6 +224,9 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Fix for HTTP/3 ($http_host is not populated automatically)
+fastcgi_param  HTTP_HOST          $host;
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/noble.xml
+++ b/lib/configfiles/noble.xml
@@ -224,6 +224,9 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Fix for HTTP/3 ($http_host is not populated automatically)
+fastcgi_param  HTTP_HOST          $host;
 ]]>
 						</content>
 					</file>

--- a/lib/configfiles/trixie.xml
+++ b/lib/configfiles/trixie.xml
@@ -225,6 +225,9 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Fix for HTTP/3 ($http_host is not populated automatically)
+fastcgi_param  HTTP_HOST          $host;
 ]]>
 						</content>
 					</file>


### PR DESCRIPTION
# Description

On http3, $http_host is not populated consistently (depends on if client sends this header, which it will not in most cases). Since froxlor (and I can only guess, countless other apps) rely on `$_SERVER['HTTP_HOST']` being available (and correct), we should give PHP the `$host` as content for `HTTP_HOST´. Unbreaking froxlor.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When migrating to nginx, I had to set this option. When updating to Trixie, thus reconfiguring services, I had to set it again. So it is battle-tested.

**Test Configuration**:

* Distribution: Debian Bookworm/Trixie
* Webserver: nginx with h3 enabled
* PHP: 8.3
* etc.etc.: nginx from Sury.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
