### PR TITLE
Escape password in Dovecot config

### DIFF
--- a/lib/configfiles/trixie.xml
+++ b/lib/configfiles/trixie.xml
@@ -1807,7 +1807,7 @@ auth_mechanisms = plain login
 sql_driver = mysql
 mysql <SQL_HOST> {
   user = <SQL_UNPRIVILEGED_USER>
-  password = <SQL_UNPRIVILEGED_PASSWORD>
+  password = '<SQL_UNPRIVILEGED_PASSWORD>'
   dbname = <SQL_DB>
 }
 


### PR DESCRIPTION
Ran into an issue having special characters in the SQL_UNPRIVILEGED_PASSWORD when using Dovecot on Trixie.

In this case we had a "#" in the password:

```
doveconf: Warning: Configuration file /etc/dovecot/conf.d/99-froxlor.conf line 7: Ambiguous '#' character in line, treating it as comment. Add a space before it to remove this warning.
```

Which essentially removed the whole config line - great! :-)

Added single quotes to properly escape the password here.