### PR TITLE
Fix `pop3_logout_format` for Dovecot 2.4

### DIFF
--- a/lib/configfiles/trixie.xml
+++ b/lib/configfiles/trixie.xml
@@ -1864,7 +1864,7 @@ protocol imap {
   }
 }
 
-pop3_logout_format = in=%i out=%o top=%t/%p, retr=%r/%b, del=%d/%m, size=%s
+pop3_logout_format = "in=%{input} out=%{output} top=%{top_count}/%{top_bytes}, retr=%{retr_count}/%{retr_bytes}, del=%{deleted_count}/%{deleted_bytes}, size=%{message_bytes}"
 
 protocol lda {
 	mail_plugins {


### PR DESCRIPTION
Dovecot 2.4 changed the variables to be used in `pop3_logout_format` (removed the short-hand versions basically):

https://doc.dovecot.org/2.4.2/core/summaries/settings.html#pop3_logout_format

Currently, the logs look like this:
```
Dec 17 06:19:12 xxxx dovecot: pop3(xx@xxx)<84247><J2CX0h9GyKdNdjUV>: Disconnected: Logged out in=%i out=%o top=%t/%p, retr=%r/%b, del=%d/%m, size=%s
```