### PR TITLE
Remove `curl_close()` calls, has been not doing anything since 8.0 and is now officiall deprecated

### DIFF
--- a/lib/Froxlor/Cli/ConfigServices.php
+++ b/lib/Froxlor/Cli/ConfigServices.php
@@ -153,7 +153,6 @@ final class ConfigServices extends CliCommand
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 		// get curl response
 		curl_exec($ch);
-		curl_close($ch);
 		fclose($fp);
 	}
 

--- a/lib/Froxlor/Cli/InstallCommand.php
+++ b/lib/Froxlor/Cli/InstallCommand.php
@@ -358,7 +358,6 @@ final class InstallCommand extends Command
 		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 		// get curl response
 		curl_exec($ch);
-		curl_close($ch);
 		fclose($fp);
 	}
 

--- a/lib/Froxlor/Http/HttpClient.php
+++ b/lib/Froxlor/Http/HttpClient.php
@@ -53,10 +53,8 @@ class HttpClient
 		$output = curl_exec($ch);
 		if ($output === false) {
 			$e = curl_error($ch);
-			curl_close($ch);
 			throw new Exception("Curl error: " . $e);
 		}
-		curl_close($ch);
 		return $output;
 	}
 
@@ -83,10 +81,8 @@ class HttpClient
 		$output = curl_exec($ch);
 		if ($output === false) {
 			$e = curl_error($ch);
-			curl_close($ch);
 			throw new Exception("Curl error: " . $e);
 		}
-		curl_close($ch);
 		return $output;
 	}
 }


### PR DESCRIPTION
Fixes (as example):

```
PHP Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in /var/www/froxlor/lib/Froxlor/Http/HttpClient.php on line 59
```