### PR TITLE
Add 'always' to add_header for HSTS and h3

### DIFF
--- a/lib/Froxlor/Cron/Http/Nginx.php
+++ b/lib/Froxlor/Cron/Http/Nginx.php
@@ -443,7 +443,7 @@ class Nginx extends HttpConfigBase
 					if ($domain_or_ip['hsts_preload'] == 1) {
 						$sslsettings .= '; preload';
 					}
-					$sslsettings .= '"always;' . "\n";
+					$sslsettings .= '" always;' . "\n";
 				}
 
 				if ((isset($domain_or_ip['ocsp_stapling']) && $domain_or_ip['ocsp_stapling'] == "1")) {


### PR DESCRIPTION
# Description

Add `always` to froxlor's default headers (HSTS and h3 upgrade advertisement) so it'll also show on non-200-pages, such as 4xx and 5xx.

We've talked about that on the discords.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas (wasnt necessary)
- [X] I have made corresponding changes to the documentation (want necessary)
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
