### PR TITLE
Remove http3_hq from vhost

### DIFF
--- a/lib/Froxlor/Cron/Http/Nginx.php
+++ b/lib/Froxlor/Cron/Http/Nginx.php
@@ -181,7 +181,6 @@ class Nginx extends HttpConfigBase
 				if ($http3) {
 					$this->nginx_data[$vhost_filename] .= "\t" . 'listen    ' . $ip . ':' . $port . ' default_server quic reuseport;' . "\n";
 					$this->nginx_data[$vhost_filename] .= "\t" . 'http3 on;' . "\n";
-					$this->nginx_data[$vhost_filename] .= "\t" . 'http3_hq on;' . "\n";
 					$this->nginx_data[$vhost_filename] .= "\t" . 'quic_gso on;' . "\n";
 					$this->nginx_data[$vhost_filename] .= "\t" . 'quic_retry on;' . "\n";
 					$this->nginx_data[$vhost_filename] .= "\t" . 'add_header Alt-Svc \'h3=":' . $port . '"; ma=86400\';' . "\n";
@@ -570,7 +569,6 @@ class Nginx extends HttpConfigBase
 		if ($http3) {
 			$vhost_content .= "\t" . 'add_header Alt-Svc \'h3=":' . $domain['port'] . '"; ma=86400\';' . "\n";
 			$vhost_content .= "\t" . 'http3 on;' . "\n";
-			$vhost_content .= "\t" . 'http3_hq on;' . "\n";
 			$vhost_content .= "\t" . 'quic_gso on;' . "\n";
 			$vhost_content .= "\t" . 'quic_retry on;' . "\n";
 		}


### PR DESCRIPTION
# Description

http3_hq is an old implementation of http over quic; since http/3 is now properly standardized in RFC 9114, there is no need to include this. In fact, if you really want to test older implementations with that, you should add it yourself in your vhost.

We've talked about this on the discords.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Generated nginx vhosts and verified http3_hq is no longer emitted; http3 still works as expected.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas (not necessary)
- [X] I have made corresponding changes to the documentation (not necessary)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works (not necessary)
- [X] New and existing unit tests pass locally with my changes
