### PR TITLE
Permissions on the parent directory of the configdir are too strict

### DIFF
--- a/lib/Froxlor/Cron/Http/Php/Fcgid.php
+++ b/lib/Froxlor/Cron/Http/Php/Fcgid.php
@@ -129,7 +129,7 @@ class Fcgid
 
 		if (!is_dir($configdir) && $createifnotexists) {
 			FileDir::safe_exec('mkdir -p ' . escapeshellarg($configdir));
-			FileDir::safe_exec('chmod 0750 ' . escapeshellarg(dirname($configdir)));
+			FileDir::safe_exec('chmod 0755 ' . escapeshellarg(dirname($configdir)));
 			FileDir::safe_exec('chmod 0750 ' . escapeshellarg($configdir));
 			FileDir::safe_exec('chown ' . $this->domain['guid'] . ':' . $this->domain['guid'] . ' ' . escapeshellarg($configdir));
 		}


### PR DESCRIPTION
# Description

The parent directory of the configuration directory (/var/www/php-fcgi-scripts/[user]/) is created as root:root. If you set the permissions to 0750, Apache will no longer be able to access the subdirectory. An alternative would be to set the permissions to 0750 with the GID of the domain user.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

When I run PHP as FastCGI with stricter permissions, PHP cannot be executed and Apache returns a 500 Internal Server Error. When I manually set the permissions to 0755, everything works. Alternatively, I tested whether it also works when I leave the permissions at 0750 but set the group to the GID of the domain user. That also worked.

**Test Configuration**:

* Distribution: Debian 12 / Bookworm
* Webserver: Apache
* PHP: 8.2

# Checklist:

- [X] I have performed a self-review of my own code
- [X ] My changes generate no new warnings

