### PR TITLE
Installer throws a 500 error in version 2.3.1 but works with version 2.3.0

### DIFF
--- a/lib/Froxlor/System/Cronjob.php
+++ b/lib/Froxlor/System/Cronjob.php
@@ -121,7 +121,11 @@ class Cronjob
 	public static function checkCurrentDistro(bool $is_install = false): string
 	{
 		// set default os.
-		$distro = Settings::Get('system.distribution');
+		if ($is_install) {
+			$distro = "bookworm";
+		} else {
+			$distro = Settings::Get('system.distribution');
+		}
 
 		// read os-release
 		if (@file_exists('/etc/os-release') && is_readable('/etc/os-release')) {


### PR DESCRIPTION
# Description

Settings::Get('system.distribution') depends on userdata.inc.php; however, this file is missing in pre-installation environments

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I attempted to install Froxlor on a fresh machine, but version 2.3.1 consistently threw a 500 error when accessing 'froxlor/installer/installer.php'. Since version 2.3.0 had 'bookworm' hardcoded, I added a condition to check whether the installer is the one calling the Froxlor\System\Cronjob::checkCurrentDistro function.

**Test Configuration**:

* Distribution: Debian Bookworm
* Webserver: Apache2
* PHP: 8.2

# Checklist:

- [X] I have performed a self-review of my own code
