### PR TITLE
Add missing label for REBUILD_NSSUSERS task

### DIFF
--- a/lng/de.lng.php
+++ b/lng/de.lng.php
@@ -2261,6 +2261,7 @@ Vielen Dank, Ihr Administrator',
 		'DELETE_DOMAIN_PDNS' => 'Lösche Domain %s von PowerDNS Datenbank',
 		'DELETE_DOMAIN_SSL' => 'Lösche SSL Dateien von Domain %s',
 		'UPDATE_LE_SERVICES' => 'Aktualisiere Systemdienste für Let\'s Encrypt',
+		'REBUILD_NSSUSERS' => 'Neuerstellung der libnss-extrausers Dateien',
 	],
 	'terms' => 'AGB',
 	'traffic' => [

--- a/lng/en.lng.php
+++ b/lng/en.lng.php
@@ -2388,6 +2388,7 @@ Yours sincerely, your administrator',
 		'DELETE_DOMAIN_PDNS' => 'Delete domain %s from PowerDNS database',
 		'DELETE_DOMAIN_SSL' => 'Delete ssl files of domain %s',
 		'UPDATE_LE_SERVICES' => 'Updating system services for Let\'s Encrypt',
+		'REBUILD_NSSUSERS' => 'Rebuilding libnss-extrausers files',
 	],
 	'terms' => 'Terms of use',
 	'traffic' => [


### PR DESCRIPTION
# Description

Currently there is no translation label for the `REBUILD_NSSUSERS` task, this PR adds those in English and German. :)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Add translation, run `froxlor-cli froxlor:cron -f`, view pending cron-tasks in froxlor dashboard

Before 
<img width="314" height="32" alt="image" src="https://github.com/user-attachments/assets/184fe26c-1cfa-48fc-a321-47f7b8b5bc88" />

After
<img width="333" height="27" alt="image" src="https://github.com/user-attachments/assets/5da50683-5b42-40b4-9ec5-2fccf73b8302" />


**Test Configuration**:

* Distribution: Debian 13
* Webserver: Apache 2.4.66
* PHP: PHP 8.5.5
* etc.etc.:

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
