### PR TITLE
fix: improve DNS LE test and MySQL test cleanup

### DIFF
--- a/lib/Froxlor/Api/Response.php
+++ b/lib/Froxlor/Api/Response.php
@@ -35,7 +35,10 @@ class Response
 	public static function jsonResponse($data = null, int $response_code = 200)
 	{
 		if (!defined('TRAVIS_CI') || TRAVIS_CI == 0) {
-			http_response_code($response_code);
+			// Only set HTTP headers if not in CLI mode (e.g., PHPUnit tests)
+			if (php_sapi_name() !== 'cli') {
+				http_response_code($response_code);
+			}
 		}
 
 		return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);

--- a/lib/Froxlor/Database/Manager/DbManagerMySQL.php
+++ b/lib/Froxlor/Database/Manager/DbManagerMySQL.php
@@ -167,7 +167,11 @@ class DbManagerMySQL
 		} else {
 			$drop_stmt = Database::prepare("DROP USER IF EXISTS :dbname@:host");
 		}
-		$rev_stmt = Database::prepare("REVOKE ALL PRIVILEGES ON `" . $dbname . "`.* FROM :guser@:host;");
+		// Database names in GRANT/REVOKE patterns treat '_' as a wildcard, so use the
+		// same escaped form as grantPrivilegesTo()/grantCreateToDb() to match grants
+		// for the literal database name (e.g. test1\_abc123 instead of test1_abc123).
+		$escaped_dbname = str_replace('_', '\\_', $dbname);
+		$rev_stmt = Database::prepare("REVOKE ALL PRIVILEGES ON `" . $escaped_dbname . "`.* FROM :guser@:host;");
 		while ($host = $host_res_stmt->fetch(PDO::FETCH_ASSOC)) {
 			Database::pexecute($drop_stmt, [
 				'dbname' => $dbname,

--- a/lib/Froxlor/PhpHelper.php
+++ b/lib/Froxlor/PhpHelper.php
@@ -203,11 +203,14 @@ class PhpHelper
 	{
 		$ips = [];
 
+		// Limit CNAME traversal so misconfigured DNS loops cannot block callers.
+		$max_depth = 10;
+
 		try {
 			// set the default nameservers to use, use the system default if none are provided
 			$resolver = new Net_DNS2_Resolver($nameserver ? ['nameservers' => [$nameserver]] : []);
 
-			// get all ip addresses from the A record and normalize them
+			// 1. Query direct A records on the input hostname
 			if ($try_a) {
 				try {
 					$answer = $resolver->query($host, 'A')->answer;
@@ -217,11 +220,11 @@ class PhpHelper
 						}
 					}
 				} catch (Net_DNS2_Exception $e) {
-					// we can't do anything here, just continue
+					// no A record or query failed; continue to AAAA
 				}
 			}
 
-			// get all ip addresses from the AAAA record and normalize them
+			// 2. Query direct AAAA records on the input hostname
 			try {
 				$answer = $resolver->query($host, 'AAAA')->answer;
 				foreach ($answer as $rr) {
@@ -230,25 +233,114 @@ class PhpHelper
 					}
 				}
 			} catch (Net_DNS2_Exception $e) {
-				// we can't do anything here, just continue
+				// no AAAA record or query failed; continue to CNAME
+			}
+
+			// Follow CNAME chains explicitly; Net_DNS2 does not always include the
+			// target A/AAAA records when querying the original hostname.
+			$depth = 0;
+			$seen = [$host];
+			$current = $host;
+			while ($depth < $max_depth) {
+				$depth++;
+				try {
+					$answer = $resolver->query($current, 'CNAME')->answer;
+				} catch (Net_DNS2_Exception $e) {
+					break; // no CNAME found; stop following the chain
+				}
+				if (empty($answer)) {
+					break; // no CNAME record; stop following the chain
+				}
+				$cname_target = null;
+				foreach ($answer as $rr) {
+					if ($rr instanceof \Net_DNS2_RR_CNAME) {
+						$cname_target = $rr->cname;
+						break;
+					}
+				}
+				if ($cname_target === null) {
+					break; // no valid CNAME record found; stop
+				}
+				if (in_array($cname_target, $seen, true)) {
+					break; // loop detected; stop
+				}
+				$seen[] = $cname_target;
+
+				// 3a. Resolve A records from the CNAME target
+				if ($try_a) {
+					try {
+						$answer = $resolver->query($cname_target, 'A')->answer;
+						foreach ($answer as $rr) {
+							if ($rr instanceof \Net_DNS2_RR_A) {
+								$ips[] = inet_ntop(inet_pton($rr->address));
+							}
+						}
+					} catch (Net_DNS2_Exception $e) {
+						// continue following the chain even if A fails
+					}
+				}
+
+				// 3b. Resolve AAAA records from the CNAME target
+				try {
+					$answer = $resolver->query($cname_target, 'AAAA')->answer;
+					foreach ($answer as $rr) {
+						if ($rr instanceof \Net_DNS2_RR_AAAA) {
+							$ips[] = inet_ntop(inet_pton($rr->address));
+						}
+					}
+				} catch (Net_DNS2_Exception $e) {
+					// continue following the chain even if AAAA fails
+				}
+
+				$current = $cname_target;
 			}
 		} catch (Net_DNS2_Exception $e) {
 			// fallback to php's dns_get_record if Net_DNS2 has no resolver available, but this may cause
 			// problems if the system's dns is not configured correctly; for example, the acme pre-check
 			// will fail because some providers put a local ip in /etc/hosts
-
-			// get all ip addresses from the A record and normalize them
-			if ($try_a) {
-				$answer = @dns_get_record($host, DNS_A);
-				foreach ($answer as $rr) {
-					$ips[] = inet_ntop(inet_pton($rr['ip']));
+			$current = $host;
+			$depth = 0;
+			$seen = [$host];
+			while ($depth < $max_depth) {
+				$depth++;
+				// 1. Query direct A records on the current name
+				if ($try_a) {
+					$answer = @dns_get_record($current, DNS_A);
+					foreach ($answer as $rr) {
+						if (isset($rr['ip'])) {
+							$ips[] = inet_ntop(inet_pton($rr['ip']));
+						}
+					}
 				}
-			}
 
-			// get all ip addresses from the AAAA record and normalize them
-			$answer = @dns_get_record($host, DNS_AAAA);
-			foreach ($answer as $rr) {
-				$ips[] = inet_ntop(inet_pton($rr['ipv6']));
+				// 2. Query direct AAAA records on the current name
+				$answer = @dns_get_record($current, DNS_AAAA);
+				foreach ($answer as $rr) {
+					if (isset($rr['ipv6'])) {
+						$ips[] = inet_ntop(inet_pton($rr['ipv6']));
+					}
+				}
+
+				// 3. Follow CNAME chain
+				$answer = @dns_get_record($current, DNS_CNAME);
+				if (empty($answer)) {
+					break; // no CNAME found; stop following the chain
+				}
+				$cname_target = null;
+				foreach ($answer as $rr) {
+					if (isset($rr['cname'])) {
+						$cname_target = $rr['cname'];
+						break;
+					}
+				}
+				if ($cname_target === null) {
+					break; // no valid CNAME record found; stop
+				}
+				if (in_array($cname_target, $seen, true)) {
+					break; // loop detected; stop
+				}
+				$seen[] = $cname_target;
+				$current = $cname_target;
 			}
 		}
 

--- a/tests/Mysqls/MysqlsTest.php
+++ b/tests/Mysqls/MysqlsTest.php
@@ -342,23 +342,29 @@ class MysqlsTest extends TestCase
 			'password' => $testdata['hosts']['localhost']['password'],
 			'plugin' => $testdata['hosts']['localhost']['plugin']
 		];
-		$dbm->getManager()->grantPrivilegesTo('froxlor010', $password, '10.0.0.10', true);
+		try {
+			$dbm->getManager()->grantPrivilegesTo('froxlor010', $password, '10.0.0.10', true);
 
-		// select all entries from mysql.user for froxlor010 to compare password-hashes
-		$sel_stmt = Database::prepare("SELECT * FROM mysql.user WHERE `User` = :usr");
-		Database::pexecute($sel_stmt, [
-			'usr' => 'froxlor010'
-		]);
-		$results = $sel_stmt->fetchAll(\PDO::FETCH_ASSOC);
-		foreach ($results as $user) {
-			if ($user['Host'] == '10.0.0.10') {
-				// user 'froxlor010'@'10.0.0.10' has been added after we ran
-				// $dbm->getManager()->getAllSqlUsers(false) so it cannot be part of the array
-				$this->assertArrayNotHasKey($user['Host'], $testdata['hosts']);
-			} else {
-				$passwd = $user['Password'] ?? $user['authentication_string'];
-				$this->assertEquals($testdata['hosts'][$user['Host']]['password'], $passwd, "Wrong authentication_string for user '" . $user['User'] . "'@'" . $user['Host'] . "'");
+			// select all entries from mysql.user for froxlor010 to compare password-hashes
+			$sel_stmt = Database::prepare("SELECT * FROM mysql.user WHERE `User` = :usr");
+			Database::pexecute($sel_stmt, [
+				'usr' => 'froxlor010'
+			]);
+			$results = $sel_stmt->fetchAll(\PDO::FETCH_ASSOC);
+			foreach ($results as $user) {
+				if ($user['Host'] == '10.0.0.10') {
+					// user 'froxlor010'@'10.0.0.10' has been added after we ran
+					// $dbm->getManager()->getAllSqlUsers(false) so it cannot be part of the array
+					$this->assertArrayNotHasKey($user['Host'], $testdata['hosts']);
+				} else {
+					$passwd = $user['Password'] ?? $user['authentication_string'];
+					$this->assertEquals($testdata['hosts'][$user['Host']]['password'], $passwd, "Wrong authentication_string for user '" . $user['User'] . "'@'" . $user['Host'] . "'");
+				}
 			}
+		} finally {
+			// This test creates a temporary remote-host grant; remove it so later
+			// runs do not see stale froxlor010@10.0.0.10 entries in mysql.user/db.
+			Database::query("DROP USER IF EXISTS froxlor010@10.0.0.10;");
 		}
 	}
 }

--- a/tests/PhpHelper/CnameResolutionTest.php
+++ b/tests/PhpHelper/CnameResolutionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Froxlor\PhpHelper;
+
+use PHPUnit\Framework\TestCase;
+use Froxlor\PhpHelper;
+
+/**
+ * Tests for CNAME chain resolution in PhpHelper::gethostbynamel6().
+ * These assertions use public DNS, so they verify result shape instead of fixed IPs.
+ *
+ * @group dns
+ */
+class CnameResolutionTest extends TestCase
+{
+    /**
+     * Test that the function exists and is callable
+     */
+    public function testFunctionExists(): void
+    {
+        $this->assertTrue(is_callable([PhpHelper::class, 'gethostbynamel6']));
+    }
+
+    /**
+     * Test non-existent domains return false
+     */
+    public function testNonExistentDomainReturnsFalse(): void
+    {
+        $result = PhpHelper::gethostbynamel6('this-domain-definitely-does-not-exist-12345.invalid', true);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test single CNAME resolution
+     * github.github.io -> CNAME -> lb-2.github.com -> A records
+     */
+    public function testSingleCnameResolution(): void
+    {
+        $result = PhpHelper::gethostbynamel6('github.github.io', true);
+        $this->assertNotFalse($result);
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+
+        foreach ($result as $ip) {
+            $this->assertNotFalse(filter_var($ip, FILTER_VALIDATE_IP));
+        }
+    }
+
+    /**
+     * Test that AAAA-only resolution works with CNAME
+     */
+    public function testCnameResolutionWithAaaaOnly(): void
+    {
+        $result = PhpHelper::gethostbynamel6('github.github.io', false); // AAAA only
+        // If it resolves, verify IPs are valid
+        if ($result !== false) {
+            $this->assertIsArray($result);
+            $this->assertNotEmpty($result);
+            foreach ($result as $ip) {
+                $this->assertNotFalse(filter_var($ip, FILTER_VALIDATE_IP));
+            }
+        }
+        // If it returns false, that's also acceptable (no AAAA records)
+    }
+
+    /**
+     * Test direct A/AAAA resolution (no CNAME)
+     */
+    public function testDirectARecordResolution(): void
+    {
+        $result = PhpHelper::gethostbynamel6('google.com', true);
+        $this->assertNotFalse($result);
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+
+        foreach ($result as $ip) {
+            $this->assertNotFalse(filter_var($ip, FILTER_VALIDATE_IP));
+        }
+    }
+
+    /**
+     * Test that the function handles CNAME chains gracefully without crashing
+     */
+    public function testCnameDoesNotCrash(): void
+    {
+        // Should not throw any exception
+        $result = PhpHelper::gethostbynamel6('github.github.io', true);
+        $this->assertIsArray($result); // or false, but not throw
+    }
+
+    /**
+     * Test that the function doesn't infinite-loop on CNAME chains
+     * (max depth guard should prevent this)
+     */
+    public function testCnameChainDoesNotInfiniteLoop(): void
+    {
+        $start = microtime(true);
+        PhpHelper::gethostbynamel6('github.github.io', true);
+        $elapsed = microtime(true) - $start;
+
+        // Should complete in reasonable time (< 5 seconds)
+        $this->assertLessThan(5.0, $elapsed, 'CNAME resolution took too long, possible infinite loop');
+    }
+
+    /**
+     * Test mixed A/AAAA resolution
+     */
+    public function testMixedAAndAaaaResolution(): void
+    {
+        $result = PhpHelper::gethostbynamel6('google.com', true);
+        $this->assertNotFalse($result);
+        $this->assertIsArray($result);
+
+        // Verify all IPs are valid (either IPv4 or IPv6)
+        foreach ($result as $ip) {
+            $this->assertNotFalse(filter_var($ip, FILTER_VALIDATE_IP));
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,12 +48,20 @@ use Froxlor\Database\Database;
 use Froxlor\Settings;
 
 if (TRAVIS_CI == 0) {
-	Database::needRoot(true);
+	// Use a root connection without selecting froxlor010 first. This lets the
+	// bootstrap create the test database from scratch instead of requiring an
+	// empty froxlor010 database to exist before the test run starts.
+	Database::needRoot(true, 0, false);
 	Database::query("DROP DATABASE IF EXISTS `froxlor010`;");
 	Database::query("CREATE DATABASE `froxlor010`;");
+	$testuser_stmt = Database::prepare("CREATE USER IF NOT EXISTS 'froxlor010'@'localhost' IDENTIFIED BY :pwd");
+	Database::pexecute($testuser_stmt, ['pwd' => $pwd]);
+	$testuser_stmt = Database::prepare("ALTER USER 'froxlor010'@'localhost' IDENTIFIED BY :pwd");
+	Database::pexecute($testuser_stmt, ['pwd' => $pwd]);
+	Database::query("GRANT ALL PRIVILEGES ON `froxlor010`.* TO 'froxlor010'@'localhost';");
 	$sql = include(dirname(__DIR__) . "/install/froxlor.sql.php");
 	file_put_contents("/tmp/froxlor.sql", $sql);
-	exec("mysql -u root -p" . $rpwd . " froxlor010 < /tmp/froxlor.sql");
+	exec("mysql -u root -p" . escapeshellarg($rpwd) . " froxlor010 < /tmp/froxlor.sql");
 	Database::query("DROP USER IF EXISTS 'test1sql1'@'localhost';");
 	Database::query("DROP USER IF EXISTS 'test1sql1'@'127.0.0.1';");
 	Database::query("DROP USER IF EXISTS 'test1sql1'@'172.17.0.1';");
@@ -64,6 +72,14 @@ if (TRAVIS_CI == 0) {
 	Database::query("DROP USER IF EXISTS 'test1_abc123'@'172.17.0.1';");
 	Database::query("DROP USER IF EXISTS 'test1_abc123'@'82.149.225.46';");
 	Database::query("DROP USER IF EXISTS 'test1_abc123'@'2a01:440:1:12:82:149:225:46';");
+	// Drop test1 and test1hp users that may have been left behind from previous test runs.
+	// The Customers API test creates these users via the API, but they are not cleaned up
+	// if the test fails (e.g., due to CREATE USER failing with error 1396 if the user already exists).
+	foreach (['test1', 'test1hp'] as $username) {
+		foreach (['localhost', '127.0.0.1', '172.17.0.1', '82.149.225.46', '2a01:440:1:12:82:149:225:46', '::1'] as $host) {
+			Database::query("DROP USER IF EXISTS '{$username}'@'{$host}';");
+		}
+	}
 	Database::query("DROP DATABASE IF EXISTS `test1sql1`;");
 	Database::query("DROP DATABASE IF EXISTS `test1_abc123`;");
 	Database::needRoot(false);


### PR DESCRIPTION
Resolve CNAME chains in gethostbynamel6 with loop protection and add DNS regression coverage.

Match escaped database privilege patterns when revoking grants and make local test bootstrap recreate MySQL state from scratch while cleaning transient test grants.

# Description

This patch enables CNAME records (that in the end resolve to A or AAAA records) to be accepted for LetsEncrypt with domain verification active. Also fixed small escape issue for mysql and related tests.

Fixes # 1089

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested the full phpunit (including test updates)
also tested on a fresh froxlor webhost (v2.3.7) with domains that have CNAMEs and active letsencrypt dns-verification.

**Test Configuration**:

* Distribution: Ubuntu 24.04 LTS
* Webserver: apache2.4.67
* PHP: 8.5
* MariaDB: 10.11.14

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
