### PR TITLE
Fix CSRF token for table column AJAX requests

### DIFF
--- a/templates/Froxlor/assets/js/jquery/tablecolumns.js
+++ b/templates/Froxlor/assets/js/jquery/tablecolumns.js
@@ -8,6 +8,12 @@ export default function () {
 				url: 'lib/ajax.php?action=updatetablelisting&listing=' + $(this).data('listing') + '&theme=' + window.$theme,
 				type: 'POST',
 				dataType: 'json',
+				beforeSend: function(request) {
+					request.setRequestHeader(
+						'X-CSRF-TOKEN',
+						document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+					);
+				},
 				data: $(this).serialize(),
 				success: function () {
 					window.location.href = '';
@@ -25,6 +31,12 @@ export default function () {
 				url: 'lib/ajax.php?action=resettablelisting&listing=' + form.data('listing') + '&theme=' + window.$theme,
 				type: 'POST',
 				dataType: 'json',
+				beforeSend: function(request) {
+					request.setRequestHeader(
+						'X-CSRF-TOKEN',
+						document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+					);
+				},
 				data: {},
 				success: function () {
 					window.location.href = '';


### PR DESCRIPTION
The updatetablelisting and resettablelisting AJAX requests do not send the X-CSRF-TOKEN header, although lib/ajax.php validates AJAX requests against the current CSRF token.

This causes both actions to fail with:

CSRF validation failed

This patch adds the same X-CSRF-TOKEN header handling already used by other AJAX requests in Froxlor.

The issue is still present in 2.3.13.